### PR TITLE
Allow DB override via env

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -46,7 +46,7 @@ TRANSCRIPTS_DIR = ROOT.parent / "transcripts"
 MODEL_DIR = ROOT.parent / "models"
 LOG_DIR = ROOT.parent / "logs"
 ACCESS_LOG = LOG_DIR / "access.log"
-DB_PATH = ROOT / "jobs.db"
+DB_PATH = Path(os.getenv("DB", str(ROOT / "jobs.db")))
 
 
 # ─── Ensure Required Dirs Exist ───

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -7,19 +7,12 @@ from sqlalchemy.orm import sessionmaker
 from api.models import Base
 from api.utils.logger import get_logger
 
-DB_PATH = "api/jobs.db"
+DB_PATH = os.getenv("DB", "api/jobs.db")
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine)
 
 log = get_logger("orm")
-
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-DATABASE_URL = f"sqlite:///{DB_PATH}"
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
-SessionLocal = sessionmaker(bind=engine)
 
 def validate_or_initialize_database():
     log.info("Bootstrapping database...")


### PR DESCRIPTION
## Summary
- allow overriding DB path with `DB` environment variable in `api/main.py`
- use `DB` env var when creating SQLAlchemy engine in `api/orm_bootstrap.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68533bd14d0c8325a09f4ff0f288114d