### PR TITLE
Add metadata endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -438,6 +438,24 @@ def transcript_view(job_id: str, request: Request):
     """
     return HTMLResponse(content=html)
 
+# ── New: Transcript Metadata Endpoint ─────────────────────────────
+@app.get("/metadata/{job_id}")
+def get_metadata(job_id: str):
+    """Return metadata for a completed transcript."""
+    with SessionLocal() as db:
+        meta = db.query(TranscriptMetadata).filter_by(job_id=job_id).first()
+        if not meta:
+            raise http_error(ErrorCode.JOB_NOT_FOUND)
+
+        return {
+            "job_id": meta.job_id,
+            "tokens": meta.tokens,
+            "duration": meta.duration,
+            "abstract": meta.abstract,
+            "sample_rate": meta.sample_rate,
+            "generated_at": meta.generated_at.isoformat() if meta.generated_at else None,
+        }
+
 @app.post("/jobs/{job_id}/restart")
 def restart_job(job_id: str):
     with db_lock:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,7 +17,10 @@ def test_backend_job_lifecycle(client, submit_stub_job):
     assert resp.status_code == 200
     assert "stub transcript" in resp.text
 
-    # Metadata should exist
+    # Metadata should exist and come from DB
     resp = client.get(f"/metadata/{job_id}")
     assert resp.status_code == 200
-    assert resp.json()["tokens"] == 2
+    meta = resp.json()
+    assert meta["job_id"] == job_id
+    assert meta["tokens"] == 2
+    assert meta["duration"] == 30.0


### PR DESCRIPTION
## Summary
- implement `/metadata/{job_id}` for retrieving `TranscriptMetadata`
- verify returned structure in integration tests

## Testing
- `pytest -q tests/test_integration.py::test_backend_job_lifecycle -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685336c470408325a7e5b58bb3d74c60