### PR TITLE
Update API host configuration

### DIFF
--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -7,5 +7,5 @@ export const ROUTES = {
   TRANSCRIPT_VIEW: "/transcript/:jobId/view",
   STATUS: "/status/:jobId",
   PROGRESS: "/progress/:jobId",
-  API: "http://localhost:8000"
+  API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
 };


### PR DESCRIPTION
## Summary
- configure frontend API host using `import.meta.env.VITE_API_HOST`

## Testing
- `npm test --silent` *(fails: network access blocked)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536b21d5b48325b21dfa40add51816