### PR TITLE
Remove console logging from admin page

### DIFF
--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -34,19 +34,18 @@ useEffect(() => {
       const res = await fetch(`${API_HOST}/admin/files`);
       if (!res.ok) throw new Error();
       const raw = await res.text();
-      console.log("Raw /admin/files response:", raw);
 
       try {
         const data = JSON.parse(raw);
         setLogs(data.logs || []);
         setUploads(data.uploads || []);
         setTranscripts(data.transcripts || []);
-        setError(null);  // ✅ clear error if successful
-      } catch (parseError) {
-        console.error("JSON parse failed:", parseError);
+        setError(null);
+        setFeedback("File lists refreshed.");
+      } catch {
         setError("Failed to parse server response.");
+        return;
       }
-      setError(null); // clear any old error
     } catch {
       setError("Failed to load file listings.");
     }


### PR DESCRIPTION
## Summary
- drop console statements in AdminPage
- show a small feedback message after refreshing the admin file lists

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536d112e108325a5c2ba301993f886