### PR TITLE
Add DB bootstrap on app startup

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -26,7 +26,7 @@ from fastapi.staticfiles import StaticFiles
 from api.metadata_writer import run_metadata_writer
 from api.errors import ErrorCode, http_error
 from api.utils.logger import get_logger
-from api.orm_bootstrap import SessionLocal
+from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
 from api.models import JobStatusEnum, TranscriptMetadata
 from api.utils.logger import get_system_logger
@@ -74,6 +74,7 @@ db_lock = threading.RLock()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     system_log.info("App startup — lifespan entering.")
+    validate_or_initialize_database()
     rehydrate_incomplete_jobs()
     yield
     system_log.info("App shutdown — lifespan exiting.")


### PR DESCRIPTION
## Summary
- import `validate_or_initialize_database`
- run database validation in lifespan startup

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.0)*
- `(cd frontend && npm install)` *(fails: 403 Forbidden - GET https://registry.npmjs.org/...)*
- `black .`
- `uvicorn api.main:app --port 8000 --timeout-keep-alive 2` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68599c2a53388325962e572ef6c87ef9