### PR TITLE
Update proxy for admin stats

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
       '/jobs': 'http://localhost:8000',
       '/audio': 'http://localhost:8000',
       '^/admin/(files|reset|download-all)$': 'http://localhost:8000',
+      '/admin/stats': 'http://localhost:8000',
       '/logs': 'http://localhost:8000',
       '/uploads': 'http://localhost:8000',
       '/transcripts': 'http://localhost:8000'


### PR DESCRIPTION
## Summary
- include `/admin/stats` in the Vite dev server proxy

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a920c1e48325919f0ff49de7fddc