### PR TITLE
Handle missing access log

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -386,6 +386,10 @@ def delete_job(job_id: str):
 
 @app.get("/logs/access", response_class=PlainTextResponse)
 def get_access_log():
+    """Return the server access log or 404 if missing."""
+    if not ACCESS_LOG.exists():
+        backend_log.warning("Access log missing")
+        return PlainTextResponse("", status_code=404)
     return ACCESS_LOG.read_text()
 
 def rehydrate_incomplete_jobs():

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -30,7 +30,7 @@ Key environment files include `pyproject.toml`, `requirements.txt`, and the `Doc
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.
 - **Admin actions** under `/admin` allow listing and deleting files, downloading all artifacts, resetting the system, and retrieving basic stats.
-- **Logging endpoints** expose job logs and the access log. Static files under `/uploads`, `/transcripts`, and `/static` are served directly.
+- **Logging endpoints** expose job logs and the access log. If the access log does not exist, `/logs/access` returns a `404` with an empty body. Static files under `/uploads`, `/transcripts`, and `/static` are served directly.
 
 ## Migrations and Logging
 - Database schema migrations are managed with Alembic in `api/migrations/`. The `env.py` file loads `Base.metadata` so new models are detected automatically. Migration scripts live in `api/migrations/versions/`.


### PR DESCRIPTION
## Summary
- return 404 if the access log doesn't exist
- note new access log behavior in docs

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.0)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_6859b82c11d88325baf266c3dbd36f47