### PR TITLE
Refactor API routes into submodules

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,8 @@
 import os
-import uuid
 import time
 import shutil
 import threading
 import subprocess
-import zipfile
-import io
 
 from datetime import datetime
 from subprocess import Popen, PIPE
@@ -13,26 +10,22 @@ from pathlib import Path
 from contextlib import asynccontextmanager
 
 from fastapi import HTTPException
-from fastapi import FastAPI, UploadFile, File, Form, Request, status
-from fastapi.responses import (
-    FileResponse,
-    PlainTextResponse,
-    HTMLResponse,
-    StreamingResponse
-)
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from api.routes import jobs, admin, logs
 
 from api.metadata_writer import run_metadata_writer
 from api.errors import ErrorCode, http_error
 from api.utils.logger import get_logger
 from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
-from api.models import JobStatusEnum, TranscriptMetadata
+from api.models import JobStatusEnum
 from api.utils.logger import get_system_logger
 from zoneinfo import ZoneInfo
+
 LOCAL_TZ = ZoneInfo("America/Chicago")
-import psutil
 
 # ─── Logging ───
 backend_log = get_logger("backend")
@@ -58,17 +51,17 @@ WHISPER_BIN = shutil.which("whisper")
 
 # ─── ENV SAFETY CHECK ───
 from dotenv import load_dotenv
+
 load_dotenv()
 
 # Read API host from environment with a default for local development.
 API_HOST = os.getenv("VITE_API_HOST", "http://localhost:8000")
 if os.getenv("VITE_API_HOST") is None:
-    system_log.warning(
-        "VITE_API_HOST not set, defaulting to http://localhost:8000"
-    )
+    system_log.warning("VITE_API_HOST not set, defaulting to http://localhost:8000")
 
 # ─── DB Lock ───
 db_lock = threading.RLock()
+
 
 # ─── Lifespan Hook ───
 @asynccontextmanager
@@ -78,6 +71,7 @@ async def lifespan(app: FastAPI):
     rehydrate_incomplete_jobs()
     yield
     system_log.info("App shutdown — lifespan exiting.")
+
 
 system_log.info("FastAPI app initialization starting.")
 
@@ -93,6 +87,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.middleware("http")
 async def access_logger(request: Request, call_next):
     start = time.time()
@@ -100,14 +95,21 @@ async def access_logger(request: Request, call_next):
     dur = time.time() - start
     host = getattr(request.client, "host", "localtest")
     with ACCESS_LOG.open("a", encoding="utf-8") as fh:
-        fh.write(f"[{datetime.now(LOCAL_TZ).isoformat()}] {host} "
-                 f"{request.method} {request.url.path} -> "
-                 f"{resp.status_code} in {dur:.2f}s\n")
+        fh.write(
+            f"[{datetime.now(LOCAL_TZ).isoformat()}] {host} "
+            f"{request.method} {request.url.path} -> "
+            f"{resp.status_code} in {dur:.2f}s\n"
+        )
     return resp
+
 
 # ─── Static File Routes ───
 app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
-app.mount("/transcripts", StaticFiles(directory=TRANSCRIPTS_DIR, html=True), name="transcripts")
+app.mount(
+    "/transcripts",
+    StaticFiles(directory=TRANSCRIPTS_DIR, html=True),
+    name="transcripts",
+)
 
 # ─── Debug Output ───
 backend_log.debug("\nSTATIC ROUTE CHECK:")
@@ -117,14 +119,24 @@ for route in app.routes:
     )
 
 from typing import Union
+
+
 def get_duration(path: Union[str, os.PathLike]) -> float:
     if shutil.which("ffprobe") is None:
         raise RuntimeError("ffprobe not found in PATH. Required to determine duration.")
 
     try:
         out = subprocess.run(
-            ["ffprobe", "-v", "error", "-show_entries", "format=duration",
-             "-of", "default=noprint_wrappers=1:nokey=1", str(path)],
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -132,6 +144,7 @@ def get_duration(path: Union[str, os.PathLike]) -> float:
         return float(out.stdout.strip())
     except Exception:
         return 0.0
+
 
 def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
     global WHISPER_BIN
@@ -158,25 +171,37 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
             output_filename = Path(upload).stem + ".srt"
 
             cmd = [
-                WHISPER_BIN, str(upload),
-                "--model", model,
-                "--model_dir", str(MODEL_DIR),
-                "--output_dir", str(job_dir),
-                "--output_format", "srt",
-                "--language", "en",
-                "--verbose", "True"
+                WHISPER_BIN,
+                str(upload),
+                "--model",
+                model,
+                "--model_dir",
+                str(MODEL_DIR),
+                "--output_dir",
+                str(job_dir),
+                "--output_format",
+                "srt",
+                "--language",
+                "en",
+                "--verbose",
+                "True",
             ]
             logger.info(f"Launching subprocess: {' '.join(cmd)}")
             logger.info(f"FINAL CMD: {' '.join(cmd)}")
 
             try:
                 with Popen(cmd, stdout=PIPE, stderr=PIPE, text=True, bufsize=1) as proc:
+
                     def stream_output(stream, label):
-                        for line in iter(stream.readline, ''):
+                        for line in iter(stream.readline, ""):
                             logger.info(f"{label}: {line.strip()}")
 
-                    stdout_thread = threading.Thread(target=stream_output, args=(proc.stdout, "STDOUT"))
-                    stderr_thread = threading.Thread(target=stream_output, args=(proc.stderr, "STDERR"))
+                    stdout_thread = threading.Thread(
+                        target=stream_output, args=(proc.stdout, "STDOUT")
+                    )
+                    stderr_thread = threading.Thread(
+                        target=stream_output, args=(proc.stderr, "STDERR")
+                    )
                     stdout_thread.start()
                     stderr_thread.start()
 
@@ -210,7 +235,9 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
 
             raw_txt_path = job_dir / (Path(upload).with_suffix(".srt").name)
             if not raw_txt_path.exists():
-                raise RuntimeError(f"[{job_id}] Expected .srt not found at {raw_txt_path}")
+                raise RuntimeError(
+                    f"[{job_id}] Expected .srt not found at {raw_txt_path}"
+                )
 
             with db_lock:
                 with SessionLocal() as db:
@@ -223,20 +250,22 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
                                 job.status = JobStatusEnum.ENRICHING
                                 db.commit()
                                 run_metadata_writer(
-                                    job_id, 
-                                    raw_txt_path, 
-                                    duration, 
-                                    16000, 
-                                    db_lock  # type: ignore[arg-type] 
+                                    job_id,
+                                    raw_txt_path,
+                                    duration,
+                                    16000,
+                                    db_lock,  # type: ignore[arg-type]
                                 )
                                 logger.info("metadata_writer complete.")
-                                with SessionLocal() as db2:                      # NEW clean session
+                                with SessionLocal() as db2:  # NEW clean session
                                     job2 = db2.query(Job).filter_by(id=job_id).first()
                                     if job2:
                                         job2.status = JobStatusEnum.COMPLETED
                                         job2.transcript_path = str(raw_txt_path)
                                         db2.commit()
-                                        logger.info("status -> COMPLETED committed")   # debug breadcrumb
+                                        logger.info(
+                                            "status -> COMPLETED committed"
+                                        )  # debug breadcrumb
                         except Exception as e:
                             job = db.query(Job).filter_by(id=job_id).first()
                             if job:
@@ -245,13 +274,17 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
                                 logger.error(f"Metadata writer failed: {e}")
                             db.commit()
                     elif proc.returncode < 0:
-                        logger.error(f"Whisper process terminated with signal {-proc.returncode}")
+                        logger.error(
+                            f"Whisper process terminated with signal {-proc.returncode}"
+                        )
                         job = db.query(Job).filter_by(id=job_id).first()
                         if job:
                             job.status = JobStatusEnum.FAILED_WHISPER_ERROR
                             job.log_path = str(log_path)
                             db.commit()
-                        logger.error(f"Whisper process terminated with signal {-proc.returncode}")
+                        logger.error(
+                            f"Whisper process terminated with signal {-proc.returncode}"
+                        )
                     else:
                         logger.error("Whisper process failed — not zero return code")
                         job = db.query(Job).filter_by(id=job_id).first()
@@ -268,137 +301,29 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
                         job.log_path = str(log_path)
                         db.commit()
 
-
-
     threading.Thread(target=_run, daemon=True).start()
 
-@app.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
-async def submit_job(file: UploadFile = File(...), model: str = Form("base")):
-    job_id = uuid.uuid4().hex
-    saved = f"{job_id}_{file.filename}"
-    upload_path = UPLOAD_DIR / saved
-    job_dir = TRANSCRIPTS_DIR / job_id
-
-    try:
-        with upload_path.open("wb") as dst:
-            shutil.copyfileobj(file.file, dst)
-    except Exception as e:
-        backend_log.error(f"File save failed for job {job_id}: {e}")
-        raise http_error(ErrorCode.FILE_SAVE_FAILED)
-
-    ts = datetime.now(LOCAL_TZ)
-    with db_lock:
-        with SessionLocal() as db:
-            job = Job(
-                id=job_id,
-                original_filename=file.filename,
-                saved_filename=saved,
-                model=model,
-                created_at=ts,
-                status=JobStatusEnum.QUEUED
-            )
-            db.add(job)
-            db.commit()
-    backend_log.info(f"Job {job_id} created.")
-    handle_whisper(job_id, upload_path, job_dir, model)
-    return {"job_id": job_id}
 
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
 
-@app.get("/jobs")
-def list_jobs():
-    with SessionLocal() as db:
-        jobs = db.query(Job).order_by(Job.created_at.desc()).all()
-        return [
-            {
-                "id": j.id,
-                "original_filename": j.original_filename,
-                "model": j.model,
-                "created_at": j.created_at.isoformat(),
-                "updated": j.updated_at.isoformat(),
-                "status": j.status.value,
-            }
-            for j in jobs
-        ]
-
-@app.get("/jobs/{job_id}")
-def get_job(job_id: str):
-    with SessionLocal() as db:
-        job = db.query(Job).filter_by(id=job_id).first()
-        if not job:
-            raise http_error(ErrorCode.JOB_NOT_FOUND)
-        return {
-            "id": job.id,
-            "original_filename": job.original_filename,
-            "model": job.model,
-            "created_at": job.created_at.isoformat(),
-            "updated": job.updated_at.isoformat(),
-            "status": job.status.value,
-        }
-
-@app.get("/metadata/{job_id}")
-def get_metadata(job_id: str):
-    with SessionLocal() as db:
-        metadata = db.query(TranscriptMetadata).filter_by(job_id=job_id).first()
-        if not metadata:
-            raise http_error(ErrorCode.JOB_NOT_FOUND)
-        return {
-            "tokens": metadata.tokens,
-            "duration": metadata.duration,
-            "abstract": metadata.abstract,
-            "sample_rate": metadata.sample_rate,
-            "generated_at": metadata.generated_at.isoformat(),
-        }
-
-@app.delete("/jobs/{job_id}")
-def delete_job(job_id: str):
-    with db_lock:
-        with SessionLocal() as db:
-            job = db.query(Job).filter_by(id=job_id).first()
-            if not job:
-                raise http_error(ErrorCode.JOB_NOT_FOUND)
-
-            saved_filename = job.saved_filename
-            transcript_dir = TRANSCRIPTS_DIR / job_id
-            upload_path = UPLOAD_DIR / saved_filename
-            log_path = LOG_DIR / f"{job_id}.log"
-
-            shutil.rmtree(transcript_dir, ignore_errors=True)
-
-            try:
-                upload_path.unlink()
-            except FileNotFoundError:
-                pass
-
-            try:
-                log_path.unlink()
-            except FileNotFoundError:
-                pass
-
-            db.delete(job)
-            db.commit()
-
-        backend_log.info(f"Deleted job {job_id} and associated files")
-        return {"status": "deleted"}
-
-
-@app.get("/logs/access", response_class=PlainTextResponse)
-def get_access_log():
-    """Return the server access log or 404 if missing."""
-    if not ACCESS_LOG.exists():
-        backend_log.warning("Access log missing")
-        return PlainTextResponse("", status_code=404)
-    return ACCESS_LOG.read_text()
 
 def rehydrate_incomplete_jobs():
     with SessionLocal() as db:
-        jobs = db.query(Job).filter(Job.status.in_([
-            JobStatusEnum.QUEUED,
-            JobStatusEnum.PROCESSING,
-            JobStatusEnum.ENRICHING
-        ])).all()
+        jobs = (
+            db.query(Job)
+            .filter(
+                Job.status.in_(
+                    [
+                        JobStatusEnum.QUEUED,
+                        JobStatusEnum.PROCESSING,
+                        JobStatusEnum.ENRICHING,
+                    ]
+                )
+            )
+            .all()
+        )
         for job in jobs:
             backend_log.info(f"Rehydrating job {job.id} with model '{job.model}'")
             try:
@@ -409,216 +334,41 @@ def rehydrate_incomplete_jobs():
                 backend_log.error(f"Failed to rehydrate job {job.id}: {e}")
 
 
-@app.get("/jobs/{job_id}/download")
-def download_transcript(job_id: str):
-    with SessionLocal() as db:
-        job = db.query(Job).filter_by(id=job_id).first()
-        if not job:
-            backend_log.warning(f"Download failed: job {job_id} not found")
-            raise http_error(ErrorCode.JOB_NOT_FOUND)
+# ─── Register Routers ─────────────────────────────────────
+app.include_router(jobs.router)
+app.include_router(admin.router)
+app.include_router(logs.router)
 
-        if not job.transcript_path:
-            backend_log.error(f"Transcript path is missing for job {job_id}")
-            raise http_error(ErrorCode.FILE_NOT_FOUND)
-
-        srt_path = Path(job.transcript_path)
-        if not srt_path.exists():
-            backend_log.error(f"Transcript file missing for job {job_id} at {srt_path}")
-            raise http_error(ErrorCode.FILE_NOT_FOUND)
-
-        original_name = Path(job.original_filename).stem + ".srt"
-        return FileResponse(
-            path=srt_path,
-            media_type="text/plain",
-            filename=original_name
-        )
-
-@app.get("/transcript/{job_id}/view", response_class=HTMLResponse)
-def transcript_view(job_id: str, request: Request):
-    with SessionLocal() as db:
-        job = db.query(Job).filter_by(id=job_id).first()
-        if not job:
-            return HTMLResponse(content=f"<h2>Job not found: {job_id}</h2>", status_code=404)
-
-        transcript_path = job.transcript_path
-
-    if not transcript_path:
-        return HTMLResponse(content=f"<h2>No transcript available for job {job_id}</h2>", status_code=404)
-
-    transcript_file = Path(transcript_path)
-    if not transcript_file.exists():
-        return HTMLResponse(content=f"<h2>Transcript file not found at {transcript_file}</h2>", status_code=404)
-
-    transcript_text = transcript_file.read_text(encoding="utf-8")
-    html = f"""
-    <html>
-      <head>
-        <title>Transcript for {job_id}</title>
-        <style>
-          body {{ background: #111; color: #eee; font-family: monospace; padding: 2rem; }}
-          pre {{ white-space: pre-wrap; word-wrap: break-word; }}
-        </style>
-      </head>
-      <body>
-        <h1>Transcript for Job ID: {job_id}</h1>
-        <pre>{transcript_text}</pre>
-      </body>
-    </html>
-    """
-    return HTMLResponse(content=html)
-
-@app.post("/jobs/{job_id}/restart")
-def restart_job(job_id: str):
-    with db_lock:
-        with SessionLocal() as db:
-            job = db.query(Job).filter_by(id=job_id).first()
-            if not job:
-                raise http_error(ErrorCode.JOB_NOT_FOUND)
-
-            saved_filename = job.saved_filename
-            model = job.model
-            upload_path = UPLOAD_DIR / saved_filename
-            job_dir = TRANSCRIPTS_DIR / job_id
-
-            if not upload_path.exists():
-                raise http_error(ErrorCode.FILE_NOT_FOUND)
-
-            shutil.rmtree(job_dir, ignore_errors=True)
-
-            job.status = JobStatusEnum.QUEUED
-            db.commit()
-
-    backend_log.info(f"Restarting job {job_id}")
-    handle_whisper(job_id, upload_path, job_dir, model)
-    return {"status": "restarted"}
-
-@app.get("/log/{job_id}", response_class=PlainTextResponse)
-def get_job_log(job_id: str):
-    log_path = LOG_DIR / f"{job_id}.log"
-    if not log_path.exists():
-        return PlainTextResponse("No log yet.", status_code=404)
-    return log_path.read_text(encoding="utf-8")
-
-@app.post("/log_event")
-async def log_event(request: Request):
-    try:
-        payload = await request.json()
-        event = payload.get("event", "unknown")
-        context = payload.get("context", {})
-        backend_log.info(f"Client Event: {event} | Context: {context}")
-        return {"status": "logged"}
-    except Exception as e:
-        backend_log.error(f"Failed to log client event: {e}")
-        return {"status": "error", "message": str(e)}
-
-@app.get("/admin/files")
-def list_admin_files():
-    logs = sorted(f.name for f in LOG_DIR.glob("*") if f.is_file())
-    uploads = sorted(f.name for f in UPLOAD_DIR.glob("*") if f.is_file())
-    transcripts = sorted(str(f.relative_to(TRANSCRIPTS_DIR)) for f in TRANSCRIPTS_DIR.rglob("*") if f.is_file())
-
-    backend_log.debug("LOG_DIR: %s", LOG_DIR.resolve())
-    backend_log.debug("UPLOAD_DIR: %s", UPLOAD_DIR.resolve())
-    backend_log.debug("TRANSCRIPTS_DIR: %s", TRANSCRIPTS_DIR.resolve())
-    backend_log.debug("Logs found: %s", logs)
-    backend_log.debug("Uploads found: %s", uploads)
-    backend_log.debug("Transcripts found: %s", transcripts)
-
-    return {
-        "logs": logs,
-        "uploads": uploads,
-        "transcripts": transcripts
-    }
-
-@app.delete("/admin/files")
-def delete_admin_file(payload: dict):
-    folder = payload.get("folder")
-    filename = payload.get("filename")
-
-    folder_map = {
-        "logs": LOG_DIR,
-        "uploads": UPLOAD_DIR,
-        "transcripts": TRANSCRIPTS_DIR
-    }
-
-    if folder not in folder_map or not filename:
-        raise http_error(ErrorCode.FILE_SAVE_FAILED)
-
-    target = folder_map[folder] / filename
-    if not target.exists() or not target.is_file():
-        raise http_error(ErrorCode.FILE_NOT_FOUND)
-
-    target.unlink()
-    return { "status": "deleted" }
-
-@app.post("/admin/reset")
-def reset_system():
-    with db_lock:
-        with SessionLocal() as db:
-            db.query(Job).delete()
-            db.commit()
-
-    for directory in [UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR]:
-        for file in directory.rglob("*"):
-            if file.is_file():
-                file.unlink()
-            elif file.is_dir():
-                shutil.rmtree(file, ignore_errors=True)
-
-    return { "status": "reset complete" }
-
-@app.get("/admin/download-all")
-def download_all():
-    mem_zip = io.BytesIO()
-
-    with zipfile.ZipFile(mem_zip, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
-        for dir_path, prefix in [(LOG_DIR, "logs"), (UPLOAD_DIR, "uploads"), (TRANSCRIPTS_DIR, "transcripts")]:
-            for file in dir_path.rglob("*"):
-                if file.is_file():
-                    arcname = f"{prefix}/{file.relative_to(dir_path)}"
-                    zf.write(file, arcname)
-
-    mem_zip.seek(0)
-    return StreamingResponse(mem_zip, media_type="application/zip", headers={
-        "Content-Disposition": "attachment; filename=all_data.zip"
-    })
-# ── NEW: /admin/stats ─────────────────────────────────────
-@app.get("/admin/stats")
-def admin_stats():
-    """Return simple CPU and memory metrics for the running container."""
-    cpu_percent = psutil.cpu_percent(interval=0.1)
-    mem = psutil.virtual_memory()
-    return {
-        "cpu_percent": cpu_percent,
-        "mem_used_mb": round(mem.used / (1024 * 1024), 1),
-        "mem_total_mb": round(mem.total / (1024 * 1024), 1)
-    }
-# ──────────────────────────────────────────────────────────
-
-@app.get("/logs/{filename}", response_class=PlainTextResponse)
-def get_log_file(filename: str):
-    path = LOG_DIR / filename
-    if not path.exists():
-        raise http_error(ErrorCode.FILE_NOT_FOUND)
-    return path.read_text()
 
 # ── Serve React SPA ───────────────────────────────────────
 static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir, html=True), name="static")
 
+
 @app.get("/", include_in_schema=False)
 def spa_index():
     return FileResponse(static_dir / "index.html")
+
+
 # ──────────────────────────────────────────────────────────
+
 
 # ── React-Router fallback ────────────────────────────────────────
 @app.get("/{full_path:path}", include_in_schema=False)
 def spa_fallback(full_path: str):
     # Let real API and asset paths keep their normal behaviour
     protected = (
-        "static", "uploads", "transcripts", "jobs",
-        "log", "admin/files", "admin/reset", "admin/download-all",
-        "health", "docs", "openapi.json"
+        "static",
+        "uploads",
+        "transcripts",
+        "jobs",
+        "log",
+        "admin/files",
+        "admin/reset",
+        "admin/download-all",
+        "health",
+        "docs",
+        "openapi.json",
     )
     if full_path.startswith(protected):
         raise HTTPException(status_code=404, detail="Not Found")

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,0 +1,92 @@
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+import io
+import shutil
+import zipfile
+from pathlib import Path
+
+import psutil
+
+from api.errors import ErrorCode, http_error
+from api.models import Job
+from api.orm_bootstrap import SessionLocal
+from api.main import UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR, db_lock
+
+router = APIRouter(prefix="/admin")
+
+
+@router.get("/files")
+def list_admin_files():
+    logs = sorted(f.name for f in LOG_DIR.glob("*") if f.is_file())
+    uploads = sorted(f.name for f in UPLOAD_DIR.glob("*") if f.is_file())
+    transcripts = sorted(
+        str(f.relative_to(TRANSCRIPTS_DIR))
+        for f in TRANSCRIPTS_DIR.rglob("*")
+        if f.is_file()
+    )
+    return {"logs": logs, "uploads": uploads, "transcripts": transcripts}
+
+
+@router.delete("/files")
+def delete_admin_file(payload: dict):
+    folder = payload.get("folder")
+    filename = payload.get("filename")
+    folder_map = {
+        "logs": LOG_DIR,
+        "uploads": UPLOAD_DIR,
+        "transcripts": TRANSCRIPTS_DIR,
+    }
+    if folder not in folder_map or not filename:
+        raise http_error(ErrorCode.FILE_SAVE_FAILED)
+    target = folder_map[folder] / filename
+    if not target.exists() or not target.is_file():
+        raise http_error(ErrorCode.FILE_NOT_FOUND)
+    target.unlink()
+    return {"status": "deleted"}
+
+
+@router.post("/reset")
+def reset_system():
+    with db_lock:
+        with SessionLocal() as db:
+            db.query(Job).delete()
+            db.commit()
+    for directory in [UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR]:
+        for file in directory.rglob("*"):
+            if file.is_file():
+                file.unlink()
+            elif file.is_dir():
+                shutil.rmtree(file, ignore_errors=True)
+    return {"status": "reset complete"}
+
+
+@router.get("/download-all")
+def download_all():
+    mem_zip = io.BytesIO()
+    with zipfile.ZipFile(mem_zip, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for dir_path, prefix in [
+            (LOG_DIR, "logs"),
+            (UPLOAD_DIR, "uploads"),
+            (TRANSCRIPTS_DIR, "transcripts"),
+        ]:
+            for file in dir_path.rglob("*"):
+                if file.is_file():
+                    arcname = f"{prefix}/{file.relative_to(dir_path)}"
+                    zf.write(file, arcname)
+    mem_zip.seek(0)
+    return StreamingResponse(
+        mem_zip,
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=all_data.zip"},
+    )
+
+
+@router.get("/stats")
+def admin_stats():
+    cpu_percent = psutil.cpu_percent(interval=0.1)
+    mem = psutil.virtual_memory()
+    return {
+        "cpu_percent": cpu_percent,
+        "mem_used_mb": round(mem.used / (1024 * 1024), 1),
+        "mem_total_mb": round(mem.total / (1024 * 1024), 1),
+    }

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -1,0 +1,218 @@
+from fastapi import APIRouter, UploadFile, File, Form, Request, status
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
+from datetime import datetime
+from pathlib import Path
+import shutil
+import uuid
+
+from api.errors import ErrorCode, http_error
+from api.models import Job, JobStatusEnum, TranscriptMetadata
+from api.orm_bootstrap import SessionLocal
+from api.main import (
+    LOCAL_TZ,
+    UPLOAD_DIR,
+    TRANSCRIPTS_DIR,
+    LOG_DIR,
+    db_lock,
+    handle_whisper,
+)
+
+router = APIRouter()
+
+
+@router.post("/jobs", status_code=status.HTTP_202_ACCEPTED)
+async def submit_job(file: UploadFile = File(...), model: str = Form("base")):
+    job_id = uuid.uuid4().hex
+    saved = f"{job_id}_{file.filename}"
+    upload_path = UPLOAD_DIR / saved
+    job_dir = TRANSCRIPTS_DIR / job_id
+
+    try:
+        with upload_path.open("wb") as dst:
+            shutil.copyfileobj(file.file, dst)
+    except Exception:
+        raise http_error(ErrorCode.FILE_SAVE_FAILED)
+
+    ts = datetime.now(LOCAL_TZ)
+    with db_lock:
+        with SessionLocal() as db:
+            job = Job(
+                id=job_id,
+                original_filename=file.filename,
+                saved_filename=saved,
+                model=model,
+                created_at=ts,
+                status=JobStatusEnum.QUEUED,
+            )
+            db.add(job)
+            db.commit()
+
+    handle_whisper(job_id, upload_path, job_dir, model)
+    return {"job_id": job_id}
+
+
+@router.get("/jobs")
+def list_jobs():
+    with SessionLocal() as db:
+        jobs = db.query(Job).order_by(Job.created_at.desc()).all()
+        return [
+            {
+                "id": j.id,
+                "original_filename": j.original_filename,
+                "model": j.model,
+                "created_at": j.created_at.isoformat(),
+                "updated": j.updated_at.isoformat(),
+                "status": j.status.value,
+            }
+            for j in jobs
+        ]
+
+
+@router.get("/jobs/{job_id}")
+def get_job(job_id: str):
+    with SessionLocal() as db:
+        job = db.query(Job).filter_by(id=job_id).first()
+        if not job:
+            raise http_error(ErrorCode.JOB_NOT_FOUND)
+        return {
+            "id": job.id,
+            "original_filename": job.original_filename,
+            "model": job.model,
+            "created_at": job.created_at.isoformat(),
+            "updated": job.updated_at.isoformat(),
+            "status": job.status.value,
+        }
+
+
+@router.get("/metadata/{job_id}")
+def get_metadata(job_id: str):
+    with SessionLocal() as db:
+        metadata = db.query(TranscriptMetadata).filter_by(job_id=job_id).first()
+        if not metadata:
+            raise http_error(ErrorCode.JOB_NOT_FOUND)
+        return {
+            "tokens": metadata.tokens,
+            "duration": metadata.duration,
+            "abstract": metadata.abstract,
+            "sample_rate": metadata.sample_rate,
+            "generated_at": metadata.generated_at.isoformat(),
+        }
+
+
+@router.delete("/jobs/{job_id}")
+def delete_job(job_id: str):
+    with db_lock:
+        with SessionLocal() as db:
+            job = db.query(Job).filter_by(id=job_id).first()
+            if not job:
+                raise http_error(ErrorCode.JOB_NOT_FOUND)
+
+            saved_filename = job.saved_filename
+            transcript_dir = TRANSCRIPTS_DIR / job_id
+            upload_path = UPLOAD_DIR / saved_filename
+            log_path = LOG_DIR / f"{job_id}.log"
+
+            shutil.rmtree(transcript_dir, ignore_errors=True)
+
+            try:
+                upload_path.unlink()
+            except FileNotFoundError:
+                pass
+
+            try:
+                log_path.unlink()
+            except FileNotFoundError:
+                pass
+
+            db.delete(job)
+            db.commit()
+
+        return {"status": "deleted"}
+
+
+@router.get("/jobs/{job_id}/download")
+def download_transcript(job_id: str):
+    with SessionLocal() as db:
+        job = db.query(Job).filter_by(id=job_id).first()
+        if not job:
+            raise http_error(ErrorCode.JOB_NOT_FOUND)
+
+        if not job.transcript_path:
+            raise http_error(ErrorCode.FILE_NOT_FOUND)
+
+        srt_path = Path(job.transcript_path)
+        if not srt_path.exists():
+            raise http_error(ErrorCode.FILE_NOT_FOUND)
+
+        original_name = Path(job.original_filename).stem + ".srt"
+        return FileResponse(
+            path=srt_path, media_type="text/plain", filename=original_name
+        )
+
+
+@router.get("/transcript/{job_id}/view", response_class=HTMLResponse)
+def transcript_view(job_id: str, request: Request):
+    with SessionLocal() as db:
+        job = db.query(Job).filter_by(id=job_id).first()
+        if not job:
+            return HTMLResponse(
+                content=f"<h2>Job not found: {job_id}</h2>", status_code=404
+            )
+
+        transcript_path = job.transcript_path
+
+    if not transcript_path:
+        return HTMLResponse(
+            content=f"<h2>No transcript available for job {job_id}</h2>",
+            status_code=404,
+        )
+
+    transcript_file = Path(transcript_path)
+    if not transcript_file.exists():
+        return HTMLResponse(
+            content=f"<h2>Transcript file not found at {transcript_file}</h2>",
+            status_code=404,
+        )
+
+    transcript_text = transcript_file.read_text(encoding="utf-8")
+    html = f"""
+    <html>
+      <head>
+        <title>Transcript for {job_id}</title>
+        <style>
+          body {{ background: #111; color: #eee; font-family: monospace; padding: 2rem; }}
+          pre {{ white-space: pre-wrap; word-wrap: break-word; }}
+        </style>
+      </head>
+      <body>
+        <h1>Transcript for Job ID: {job_id}</h1>
+        <pre>{transcript_text}</pre>
+      </body>
+    </html>
+    """
+    return HTMLResponse(content=html)
+
+
+@router.post("/jobs/{job_id}/restart")
+def restart_job(job_id: str):
+    with db_lock:
+        with SessionLocal() as db:
+            job = db.query(Job).filter_by(id=job_id).first()
+            if not job:
+                raise http_error(ErrorCode.JOB_NOT_FOUND)
+
+            saved_filename = job.saved_filename
+            model = job.model
+            upload_path = UPLOAD_DIR / saved_filename
+            job_dir = TRANSCRIPTS_DIR / job_id
+
+            if not upload_path.exists():
+                raise http_error(ErrorCode.FILE_NOT_FOUND)
+
+            shutil.rmtree(job_dir, ignore_errors=True)
+
+            job.status = JobStatusEnum.QUEUED
+            db.commit()
+
+    handle_whisper(job_id, upload_path, job_dir, model)
+    return {"status": "restarted"}

--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import PlainTextResponse
+
+from api.errors import ErrorCode, http_error
+from api.main import LOG_DIR, ACCESS_LOG, backend_log
+
+router = APIRouter()
+
+
+@router.get("/log/{job_id}", response_class=PlainTextResponse)
+def get_job_log(job_id: str):
+    log_path = LOG_DIR / f"{job_id}.log"
+    if not log_path.exists():
+        return PlainTextResponse("No log yet.", status_code=404)
+    return log_path.read_text(encoding="utf-8")
+
+
+@router.post("/log_event")
+async def log_event(request: Request):
+    try:
+        payload = await request.json()
+        event = payload.get("event", "unknown")
+        context = payload.get("context", {})
+        backend_log.info(f"Client Event: {event} | Context: {context}")
+        return {"status": "logged"}
+    except Exception as e:
+        backend_log.error(f"Failed to log client event: {e}")
+        return {"status": "error", "message": str(e)}
+
+
+@router.get("/logs/access", response_class=PlainTextResponse)
+def get_access_log():
+    if not ACCESS_LOG.exists():
+        return PlainTextResponse("", status_code=404)
+    return ACCESS_LOG.read_text()
+
+
+@router.get("/logs/{filename}", response_class=PlainTextResponse)
+def get_log_file(filename: str):
+    path = LOG_DIR / filename
+    if not path.exists():
+        raise http_error(ErrorCode.FILE_NOT_FOUND)
+    return path.read_text()


### PR DESCRIPTION
## Summary
- split `api/main.py` routes into dedicated modules
- add `api.routes.jobs`, `api.routes.admin`, `api.routes.logs`
- register the new routers in `api/main.py`

## Testing
- `black api/main.py api/routes`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6859cbdbab5083258b7f4dcc3197f24b