### PR TITLE
Move timezone and log constants to app_state

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -5,11 +5,11 @@ import threading
 from pathlib import Path
 from subprocess import Popen, PIPE
 from typing import Union
+from zoneinfo import ZoneInfo
 
 from api.metadata_writer import run_metadata_writer
 from api.orm_bootstrap import SessionLocal
 from api.models import Job, JobStatusEnum
-from api.utils.logger import get_logger
 
 # ─── Paths ───
 ROOT = Path(__file__).parent
@@ -21,6 +21,14 @@ LOG_DIR = ROOT.parent / "logs"
 # Ensure directories exist
 for p in (UPLOAD_DIR, TRANSCRIPTS_DIR, MODEL_DIR, LOG_DIR):
     p.mkdir(parents=True, exist_ok=True)
+
+# ─── Config ───
+LOCAL_TZ = ZoneInfo("America/Chicago")
+
+from api.utils.logger import get_logger
+
+backend_log = get_logger("backend")
+ACCESS_LOG = LOG_DIR / "access.log"
 
 # ─── Whisper CLI Check ───
 WHISPER_BIN = shutil.which("whisper")

--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from api.routes import jobs, admin, logs
 
-from api.utils.logger import get_logger
 from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
 from api.models import JobStatusEnum
@@ -24,18 +23,16 @@ from api.app_state import (
     LOG_DIR,
     db_lock,
     handle_whisper,
+    LOCAL_TZ,
+    backend_log,
+    ACCESS_LOG,
 )
-from zoneinfo import ZoneInfo
-
-LOCAL_TZ = ZoneInfo("America/Chicago")
 
 # ─── Logging ───
-backend_log = get_logger("backend")
 system_log = get_system_logger()
 
 # ─── Paths ───
 ROOT = Path(__file__).parent
-ACCESS_LOG = LOG_DIR / "access.log"
 
 # ─── ENV SAFETY CHECK ───
 from dotenv import load_dotenv

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -8,7 +8,7 @@ import uuid
 from api.errors import ErrorCode, http_error
 from api.models import Job, JobStatusEnum, TranscriptMetadata
 from api.orm_bootstrap import SessionLocal
-from api.main import LOCAL_TZ
+from api.app_state import LOCAL_TZ
 from api.app_state import (
     UPLOAD_DIR,
     TRANSCRIPTS_DIR,

--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -2,8 +2,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
 from api.errors import ErrorCode, http_error
-from api.main import ACCESS_LOG, backend_log
-from api.app_state import LOG_DIR
+from api.app_state import LOG_DIR, ACCESS_LOG, backend_log
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary
- centralize LOCAL_TZ, backend_log and ACCESS_LOG in `api.app_state`
- update routes and main module to import these symbols from `app_state`

## Testing
- `black api/app_state.py api/main.py api/routes/jobs.py api/routes/logs.py`

------
https://chatgpt.com/codex/tasks/task_e_685a061b8e04832599b03e3e023d13d1