### PR TITLE
Clarify model requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,16 @@ This outputs static files under `api/static/`.
 
 ## Usage Notes
 
-- `models/` is intentionally excluded from version control. Populate it by running
-  `./download_models.sh` or by providing a directory when building the Docker
-  image via `--build-arg MODELS_DIR=/path/to/models`. The Docker build and
-  application startup fail if this directory is missing or empty. The download
-  script writes progress to `logs/model_download.log`.
+- `models/` will never be checked into Git. Ensure the five Whisper model files (tiny, base, small, medium and large) exist locally before building or running the application. Populate the folder with `./download_models.sh` or supply a populated directory when running `docker build --build-arg MODELS_DIR=/path/to/models`. If using a prebuilt container, mount the same directory at runtime. The build and application fail if this directory is missing or empty. The download script writes progress to `logs/model_download.log`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are
   written to `transcripts/`. Per-job logs and the system log live in `logs/`.
 
 ## Docker Usage
 
-To build the Docker image with pre-downloaded models, pass the models
-directory via a build argument:
-
+Docker builds require `--build-arg MODELS_DIR=/path/to/models` pointing to the populated models directory. If you use a prebuilt image instead, mount the same directory at runtime.
 ```bash
 docker build --build-arg MODELS_DIR=/path/to/models -t whisper-app .
+# The build will fail if the models directory is empty. When running an image built elsewhere, mount the populated models directory with `-v /path/to/models:/app/models`.
 ```
 
 Run the container with the application directories mounted so that

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -22,11 +22,7 @@ The application is considered working once these basics are functional:
 - `uploads/` – user-uploaded audio files.
 - `transcripts/` – per‑job folders containing `.srt` results and metadata.
 - `logs/` – rotating log files for jobs and the system.
-- `models/` – directory for Whisper models. The folder is intentionally excluded
-  from Git. Populate it by running `download_models.sh` or by supplying a models
-  directory when building the Docker image with
-  `--build-arg MODELS_DIR=/path/to/models`. Both the Docker build and
-  application startup fail if it is missing or empty.
+- `models/` – directory for Whisper models. The folder will never be checked into Git. All five Whisper model files (tiny, base, small, medium and large) must exist here before building or running the application. Populate it using `download_models.sh` or supply a populated folder via `--build-arg MODELS_DIR=/path/to/models` when building the Docker image, or mount it at runtime. Both the Docker build and application startup fail if it is missing or empty.
 - `frontend/` – React app bundled into `api/static/` for the UI.
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.


### PR DESCRIPTION
## Summary
- document that `models/` will never be tracked in Git
- state that all five Whisper models must exist before running
- describe `MODELS_DIR` usage and runtime mount for Docker

## Testing
- `black --exclude docs/historic .`

------
https://chatgpt.com/codex/tasks/task_e_685a15451a5c8325aa9b120374a98011