### PR TITLE
Improve model download skip check

### DIFF
--- a/download_models.sh
+++ b/download_models.sh
@@ -24,8 +24,15 @@ fi
 
 # Download loop
 for MODEL in "${MODELS[@]}"; do
+  MODEL_FILE="$MODEL_DIR/${MODEL}.pt"
+
+  if [ -f "$MODEL_FILE" ]; then
+    log "⚡ Model '$MODEL' already cached at $MODEL_FILE — skipping"
+    continue
+  fi
+
   log "🔽 Attempting download for model: $MODEL"
-  
+
   whisper "$DUMMY_WAV" \
     --model "$MODEL" \
     --model_dir "$MODEL_DIR" \


### PR DESCRIPTION
## Summary
- skip Whisper downloads when model file already cached

## Testing
- `pip install -r requirements.txt` *(fails: no internet access)*
- `black api`

------
https://chatgpt.com/codex/tasks/task_e_685a1650f73c8325b2a20a06c32705bf