### PR TITLE
docs: clarify model verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This outputs static files under `api/static/`.
 
 ## Usage Notes
 
-- `models/` will never be checked into Git. Ensure the five Whisper model files (tiny, base, small, medium and large) exist locally before building or running the application. Populate the folder with `./download_models.sh` or supply a populated directory when running `docker build --build-arg MODELS_DIR=/path/to/models`. If using a prebuilt container, mount the same directory at runtime. The build and application fail if this directory is missing or empty. The download script writes progress to `logs/model_download.log`.
+- `models/` will never be checked into Git. Ensure the five Whisper model files (`base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, `tiny.pt`) exist locally before building or running the application. Populate the folder with `./download_models.sh` or supply a populated directory when running `docker build --build-arg MODELS_DIR=/path/to/models`. The Dockerfile verifies these files and fails the build if any are missing. The application performs the same check on startup. When using a prebuilt container, mount the models directory at runtime. The download script skips models that are already cached and logs progress to `logs/model_download.log`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are
   written to `transcripts/`. Per-job logs and the system log live in `logs/`.
 
@@ -49,7 +49,7 @@ This outputs static files under `api/static/`.
 Docker builds require `--build-arg MODELS_DIR=/path/to/models` pointing to the populated models directory. If you use a prebuilt image instead, mount the same directory at runtime.
 ```bash
 docker build --build-arg MODELS_DIR=/path/to/models -t whisper-app .
-# The build will fail if the models directory is empty. When running an image built elsewhere, mount the populated models directory with `-v /path/to/models:/app/models`.
+# The build will fail if any required model file is missing. When running an image built elsewhere, mount the populated models directory with `-v /path/to/models:/app/models`.
 ```
 
 Run the container with the application directories mounted so that

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -22,7 +22,7 @@ The application is considered working once these basics are functional:
 - `uploads/` – user-uploaded audio files.
 - `transcripts/` – per‑job folders containing `.srt` results and metadata.
 - `logs/` – rotating log files for jobs and the system.
-- `models/` – directory for Whisper models. The folder will never be checked into Git. All five Whisper model files (tiny, base, small, medium and large) must exist here before building or running the application. Populate it using `download_models.sh` or supply a populated folder via `--build-arg MODELS_DIR=/path/to/models` when building the Docker image, or mount it at runtime. Both the Docker build and application startup fail if it is missing or empty.
+- `models/` – directory for Whisper models. The folder will never be checked into Git. The required files are `base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, and `tiny.pt`. Populate this directory with `./download_models.sh` or pass a populated folder using `--build-arg MODELS_DIR=/path/to/models` when building the Docker image. The Dockerfile verifies these files and fails the build if any are missing; the application performs the same check on startup. When using a prebuilt image, mount the models directory at runtime. The download script skips already cached files.
 - `frontend/` – React app bundled into `api/static/` for the UI.
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.


### PR DESCRIPTION
## Summary
- clarify that the five model files must be present
- mention Dockerfile and runtime checks for model files
- note that `download_models.sh` skips cached models

## Testing
- `black . --check --exclude '/docs/historic/'`

------
https://chatgpt.com/codex/tasks/task_e_6859c5315cb48325a446bbce67537f2d