### PR TITLE
Update Black check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: frontend
 
       - name: Black check
-        run: black --check .
+        run: black --check --exclude '/docs/historic/' .
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary
- exclude archived docs from Black CI step

## Testing
- `black . --exclude '/docs/historic/'`
- `pytest` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685a20bf9fcc832598650adc264145aa