### PR TITLE
Refactor main modules

### DIFF
--- a/api/middlewares/access_log.py
+++ b/api/middlewares/access_log.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import time
+from fastapi import Request
+
+from api.app_state import LOCAL_TZ, ACCESS_LOG
+
+
+async def access_logger(request: Request, call_next):
+    """Log each request/response pair with timing information."""
+    start = time.time()
+    response = await call_next(request)
+    duration = time.time() - start
+    host = getattr(request.client, "host", "localtest")
+    with ACCESS_LOG.open("a", encoding="utf-8") as fh:
+        fh.write(
+            f"[{datetime.now(LOCAL_TZ).isoformat()}] {host} "
+            f"{request.method} {request.url.path} -> "
+            f"{response.status_code} in {duration:.2f}s\n"
+        )
+    return response

--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from api.routes import jobs, admin, logs
+from api.app_state import UPLOAD_DIR, TRANSCRIPTS_DIR, backend_log
+
+
+def register_routes(app: FastAPI) -> None:
+    """Attach all API routers and static paths."""
+    app.include_router(jobs.router)
+    app.include_router(admin.router)
+    app.include_router(logs.router)
+
+    app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
+    app.mount(
+        "/transcripts",
+        StaticFiles(directory=TRANSCRIPTS_DIR, html=True),
+        name="transcripts",
+    )
+
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=static_dir, html=True), name="static")
+
+    @app.get("/", include_in_schema=False)
+    def spa_index():
+        return FileResponse(static_dir / "index.html")
+
+    @app.get("/{full_path:path}", include_in_schema=False)
+    def spa_fallback(full_path: str):
+        protected = (
+            "static",
+            "uploads",
+            "transcripts",
+            "jobs",
+            "log",
+            "admin/files",
+            "admin/reset",
+            "admin/download-all",
+            "health",
+            "docs",
+            "openapi.json",
+        )
+        if full_path.startswith(protected):
+            raise HTTPException(status_code=404, detail="Not Found")
+        return FileResponse(static_dir / "index.html")
+
+    backend_log.debug("\nSTATIC ROUTE CHECK:")
+    for route in app.routes:
+        backend_log.debug(
+            f"Path: {getattr(route, 'path', 'n/a')}  →  Name: {getattr(route, 'name', 'n/a')}  →  Type: {type(route)}"
+        )

--- a/api/utils/model_validation.py
+++ b/api/utils/model_validation.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from api.app_state import MODEL_DIR
+from api.utils.logger import get_system_logger
+
+
+system_log = get_system_logger()
+
+
+def validate_models_dir():
+    """Ensure MODEL_DIR contains all required Whisper model files."""
+    if not MODEL_DIR.exists():
+        system_log.critical(
+            "Missing models directory. Populate models/ before running."
+        )
+        raise RuntimeError("Whisper models required; see download_models.sh")
+
+    required_models = [
+        "base.pt",
+        "large-v3.pt",
+        "medium.pt",
+        "small.pt",
+        "tiny.pt",
+    ]
+
+    missing = [m for m in required_models if not (MODEL_DIR / m).is_file()]
+
+    if missing:
+        system_log.critical(
+            "Missing model files in %s: %s",
+            MODEL_DIR,
+            ", ".join(missing),
+        )
+        raise RuntimeError(
+            f"Required model files missing: {', '.join(missing)}; see download_models.sh"
+        )


### PR DESCRIPTION
## Summary
- move model validation logic into `utils/model_validation.py`
- create middleware module for access logging
- extract router registration into `router_setup.py`
- keep `api/main.py` focused on startup and lifespan

## Testing
- `black api tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685a21688104832580eb113228529e8b