### PR TITLE
docs: remove build-time model verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 COPY api         ./api
-RUN test -d /models \
- && test -f /models/base.pt \
- && test -f /models/large-v3.pt \
- && test -f /models/medium.pt \
- && test -f /models/small.pt \
- && test -f /models/tiny.pt \
- || (echo "Required model files missing in /models" >&2 && exit 1)
 RUN mkdir -p uploads transcripts
 COPY frontend/dist ./api/static
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This outputs static files under `api/static/`.
 
 ## Usage Notes
 
-- `models/` will never be checked into Git. Ensure the five Whisper model files (tiny, base, small, medium and large) exist locally before building or running the application. Populate the folder with `./download_models.sh` or supply a populated directory when running `docker build --build-arg MODELS_DIR=/path/to/models`. If using a prebuilt container, mount the same directory at runtime. The build and application fail if this directory is missing or empty. The download script writes progress to `logs/model_download.log`.
+- `models/` will never be checked into Git. Ensure the five Whisper model files (`base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, `tiny.pt`) exist locally before building or running the application. Populate the folder with `./download_models.sh` or supply a populated directory when running `docker build --build-arg MODELS_DIR=/path/to/models`. The application performs a check on startup and will fail if models are missing. When using a prebuilt container, mount the models directory at runtime. The download script skips models that are already cached and logs progress to `logs/model_download.log`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are
   written to `transcripts/`. Per-job logs and the system log live in `logs/`.
 
@@ -49,7 +49,7 @@ This outputs static files under `api/static/`.
 Docker builds require `--build-arg MODELS_DIR=/path/to/models` pointing to the populated models directory. If you use a prebuilt image instead, mount the same directory at runtime.
 ```bash
 docker build --build-arg MODELS_DIR=/path/to/models -t whisper-app .
-# The build will fail if the models directory is empty. When running an image built elsewhere, mount the populated models directory with `-v /path/to/models:/app/models`.
+# Mount the same models directory at runtime with `-v /path/to/models:/app/models` when using a prebuilt image.
 ```
 
 Run the container with the application directories mounted so that

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -22,7 +22,7 @@ The application is considered working once these basics are functional:
 - `uploads/` – user-uploaded audio files.
 - `transcripts/` – per‑job folders containing `.srt` results and metadata.
 - `logs/` – rotating log files for jobs and the system.
-- `models/` – directory for Whisper models. The folder will never be checked into Git. All five Whisper model files (tiny, base, small, medium and large) must exist here before building or running the application. Populate it using `download_models.sh` or supply a populated folder via `--build-arg MODELS_DIR=/path/to/models` when building the Docker image, or mount it at runtime. Both the Docker build and application startup fail if it is missing or empty.
+- `models/` – directory for Whisper models. The folder will never be checked into Git. The required files are `base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, and `tiny.pt`. Populate this directory with `./download_models.sh` or pass a populated folder using `--build-arg MODELS_DIR=/path/to/models` when building the Docker image. The application checks for these files on startup. When using a prebuilt image, mount the models directory at runtime. The download script skips already cached files.
 - `frontend/` – React app bundled into `api/static/` for the UI.
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.


### PR DESCRIPTION
## Summary
- remove model file verification step from Dockerfile
- update README and design scope docs for model checks at runtime only

## Testing
- `black . --check --exclude '/docs/historic/'`


------
https://chatgpt.com/codex/tasks/task_e_6859c5315cb48325a446bbce67537f2d