### PR TITLE
Fix missing db commit on whisper failure

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -207,6 +207,7 @@ def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
                         if job:
                             job.status = JobStatusEnum.FAILED_WHISPER_ERROR
                             job.log_path = str(log_path)
+                            db.commit()
         except Exception as e:
             logger.critical(f"CRITICAL thread error: {e}")
             with db_lock:


### PR DESCRIPTION
## Summary
- add `db.commit()` in the non-zero return code branch of `handle_whisper`

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685ac04fa0288325b9b3938d23df3ef3