### PR TITLE
Fix Docker build context and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,7 +21,6 @@ logs/
 
 # frontend
 frontend/node_modules/
-frontend/dist/
 
 # build artifacts
 build/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd frontend
 npm run build
 ```
 
-This outputs static files under `api/static/`.
+This outputs static files under `frontend/dist/`.
 
 ## Usage Notes
 
@@ -46,7 +46,14 @@ This outputs static files under `api/static/`.
 
 ## Docker Usage
 
-Docker builds expect a populated `models/` directory. Build with:
+Docker builds expect a populated `models/` directory. Before building the image,
+run the frontend build so `frontend/dist/` exists:
+```bash
+cd frontend
+npm run build
+cd ..
+```
+Build the image with:
 ```bash
 docker build -t whisper-app .
 ```


### PR DESCRIPTION
## Summary
- allow Docker builds to include compiled frontend files by keeping `frontend/dist/`
- document React build output location and require running it before Docker build

## Testing
- `black . --check`

------
https://chatgpt.com/codex/tasks/task_e_685ac101ab988325bd9c8f8f578af7e0