### PR TITLE
Document manual build dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,20 @@ application can be served with the backend.
 ## Usage Notes
 
 - `models/` exists locally only and is never stored in Git. It must contain the Whisper `.pt` files before building or running the app. Populate it with `./download_models.sh` if needed.
+- `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are
   written to `transcripts/`. Per-job logs and the system log live in `logs/`.
 
 ## Docker Usage
 
-Docker builds expect a populated `models/` directory. Before building the image,
-run the frontend build so `frontend/dist/` exists. These files are copied to
-`api/static/` by the Dockerfile:
+Docker builds expect a populated `models/` directory and the compiled
+`frontend/dist/` folder. Both directories are ignored by Git so they must be
+prepared manually before running `docker build`. Example:
 ```bash
 cd frontend
 npm run build
 cd ..
+./download_models.sh
 ```
 Build the image with:
 ```bash

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -26,6 +26,15 @@ The application is considered working once these basics are functional:
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 
+Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
+before running `docker build`:
+```bash
+cd frontend
+npm run build
+cd ..
+./download_models.sh
+```
+
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.
 
 ## API Overview


### PR DESCRIPTION
## Summary
- clarify that `frontend/dist/` must be built and `models/` must contain model files
- note both directories are git-ignored and show how to prepare them

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ac8bdc1788325830fbd79efe115e7