### PR TITLE
Fix CI by installing black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install black
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- install black during CI

## Testing
- `black .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ac99c72208325904695fcee77cfcb