### PR TITLE
Refactor path constants

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -8,19 +8,15 @@ from typing import Union
 from zoneinfo import ZoneInfo
 
 from api.metadata_writer import run_metadata_writer
-from api.orm_bootstrap import SessionLocal
 from api.models import Job, JobStatusEnum
+from api.paths import (
+    UPLOAD_DIR,
+    TRANSCRIPTS_DIR,
+    MODEL_DIR,
+    LOG_DIR,
+)
 
-# ─── Paths ───
-ROOT = Path(__file__).parent
-UPLOAD_DIR = ROOT.parent / "uploads"
-TRANSCRIPTS_DIR = ROOT.parent / "transcripts"
-MODEL_DIR = ROOT.parent / "models"
-LOG_DIR = ROOT.parent / "logs"
-
-# Ensure directories exist
-for p in (UPLOAD_DIR, TRANSCRIPTS_DIR, MODEL_DIR, LOG_DIR):
-    p.mkdir(parents=True, exist_ok=True)
+# ─── Paths ─── (imported from api.paths)
 
 # ─── Config ───
 LOCAL_TZ = ZoneInfo("America/Chicago")
@@ -63,6 +59,8 @@ def get_duration(path: Union[str, os.PathLike]) -> float:
 
 
 def handle_whisper(job_id: str, upload: Path, job_dir: Path, model: str):
+    from api.orm_bootstrap import SessionLocal
+
     global WHISPER_BIN
     WHISPER_BIN = WHISPER_BIN or shutil.which("whisper")
     if not WHISPER_BIN:

--- a/api/main.py
+++ b/api/main.py
@@ -13,9 +13,8 @@ from api.utils.logger import get_system_logger
 from api.utils.model_validation import validate_models_dir
 from api.router_setup import register_routes
 from api.middlewares.access_log import access_logger
+from api.paths import UPLOAD_DIR, TRANSCRIPTS_DIR
 from api.app_state import (
-    UPLOAD_DIR,
-    TRANSCRIPTS_DIR,
     db_lock,
     handle_whisper,
     LOCAL_TZ,

--- a/api/metadata_writer.py
+++ b/api/metadata_writer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from api.orm_bootstrap import SessionLocal
 from api.models import TranscriptMetadata
 from api.utils.logger import get_logger
-from api.app_state import TRANSCRIPTS_DIR
+from api.paths import TRANSCRIPTS_DIR
 
 
 def clean_text(text: str) -> str:

--- a/api/paths.py
+++ b/api/paths.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parent
+UPLOAD_DIR = ROOT.parent / "uploads"
+TRANSCRIPTS_DIR = ROOT.parent / "transcripts"
+MODEL_DIR = ROOT.parent / "models"
+LOG_DIR = ROOT.parent / "logs"
+
+for path in (UPLOAD_DIR, TRANSCRIPTS_DIR, MODEL_DIR, LOG_DIR):
+    path.mkdir(parents=True, exist_ok=True)

--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -5,7 +5,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from api.routes import jobs, admin, logs
-from api.app_state import UPLOAD_DIR, TRANSCRIPTS_DIR, backend_log
+from api.paths import UPLOAD_DIR, TRANSCRIPTS_DIR
+from api.app_state import backend_log
 
 
 def register_routes(app: FastAPI) -> None:

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -10,7 +10,8 @@ import psutil
 from api.errors import ErrorCode, http_error
 from api.models import Job
 from api.orm_bootstrap import SessionLocal
-from api.app_state import UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR, db_lock
+from api.paths import UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR
+from api.app_state import db_lock
 
 router = APIRouter(prefix="/admin")
 

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -8,14 +8,8 @@ import uuid
 from api.errors import ErrorCode, http_error
 from api.models import Job, JobStatusEnum, TranscriptMetadata
 from api.orm_bootstrap import SessionLocal
-from api.app_state import LOCAL_TZ
-from api.app_state import (
-    UPLOAD_DIR,
-    TRANSCRIPTS_DIR,
-    LOG_DIR,
-    db_lock,
-    handle_whisper,
-)
+from api.app_state import LOCAL_TZ, db_lock, handle_whisper
+from api.paths import UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR
 
 router = APIRouter()
 

--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Request
 from fastapi.responses import PlainTextResponse
 
 from api.errors import ErrorCode, http_error
-from api.app_state import LOG_DIR, ACCESS_LOG, backend_log
+from api.paths import LOG_DIR
+from api.app_state import ACCESS_LOG, backend_log
 
 router = APIRouter()
 

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -5,7 +5,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
-from api.app_state import LOG_DIR
+from api.paths import LOG_DIR
 
 
 def get_logger(job_id: str) -> logging.Logger:

--- a/api/utils/model_validation.py
+++ b/api/utils/model_validation.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from api.app_state import MODEL_DIR
+from api.paths import MODEL_DIR
 from api.utils.logger import get_system_logger
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -12,12 +12,17 @@ def create_test_app(tmp_path):
     models.Base.metadata.create_all(orm_bootstrap.engine)
 
     from api import app_state
+    from api import paths
 
-    app_state.UPLOAD_DIR = tmp_path / "uploads"
-    app_state.TRANSCRIPTS_DIR = tmp_path / "transcripts"
-    app_state.LOG_DIR = tmp_path / "logs"
-    for p in (app_state.UPLOAD_DIR, app_state.TRANSCRIPTS_DIR, app_state.LOG_DIR):
+    paths.UPLOAD_DIR = tmp_path / "uploads"
+    paths.TRANSCRIPTS_DIR = tmp_path / "transcripts"
+    paths.LOG_DIR = tmp_path / "logs"
+    for p in (paths.UPLOAD_DIR, paths.TRANSCRIPTS_DIR, paths.LOG_DIR):
         p.mkdir(parents=True, exist_ok=True)
+
+    app_state.UPLOAD_DIR = paths.UPLOAD_DIR
+    app_state.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    app_state.LOG_DIR = paths.LOG_DIR
 
     app_state.handle_whisper = lambda *a, **k: None
 
@@ -26,9 +31,9 @@ def create_test_app(tmp_path):
     importlib.reload(jobs)
 
     jobs.SessionLocal = orm_bootstrap.SessionLocal
-    jobs.UPLOAD_DIR = app_state.UPLOAD_DIR
-    jobs.TRANSCRIPTS_DIR = app_state.TRANSCRIPTS_DIR
-    jobs.LOG_DIR = app_state.LOG_DIR
+    jobs.UPLOAD_DIR = paths.UPLOAD_DIR
+    jobs.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    jobs.LOG_DIR = paths.LOG_DIR
     jobs.handle_whisper = app_state.handle_whisper
 
     from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- centralize path variables in `api/paths`
- import new path module in remaining code
- patch tests to use the new constants
- move SessionLocal import inside `handle_whisper`

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685ae913b1008325bacdfaa4d007056c