### PR TITLE
Add pytest usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,19 @@ docker run -p 8000:8000 \
   whisper-app
 ```
 
+## Testing
+
+After installing the requirements, install the project in editable mode with the
+development extras:
+
+```bash
+pip install -e .[dev]
+```
+
+This installs `httpx` and other packages required by `pytest`.
+Run the test suite from the repository root with:
+
+```bash
+pytest
+```
+


### PR DESCRIPTION
## Summary
- document how to install dev requirements
- show example pytest command

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685aeaaf173883259ad03ac8ab6d1699