### PR TITLE
Add alembic.ini to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY requirements.txt .
+COPY alembic.ini .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- include `alembic.ini` in Docker build so migrations know where to look

## Testing
- `black .`
- `docker build -t whisper-app .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aecf487e88325aeea49d976ec21c8