### PR TITLE
Fix Alembic invocation env and Docker PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+ENV PYTHONPATH=/app
 COPY requirements.txt .
 COPY alembic.ini .
 RUN pip install --no-cache-dir --upgrade pip && \

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -28,8 +28,12 @@ def validate_or_initialize_database():
     log.info("Running Alembic migrations to ensure schema is current...")
     ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
     try:
+        env = os.environ.copy()
+        env.update({"PYTHONPATH": str(Path(__file__).resolve().parent.parent)})
         subprocess.run(
-            ["alembic", "-c", str(ALEMBIC_INI), "upgrade", "head"], check=True
+            ["alembic", "-c", str(ALEMBIC_INI), "upgrade", "head"],
+            check=True,
+            env=env,
         )
         log.info("Alembic migrations applied successfully.")
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- ensure Alembic runs with PYTHONPATH set inside `validate_or_initialize_database`
- set `PYTHONPATH` in Dockerfile after creating the workdir

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_685b22d2b70083259d78d0d71601f1a2