### PR TITLE
Centralize environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
 - `LOG_TO_STDOUT` – set to `true` to also mirror logs to the console.
 
+All configuration values are parsed once in `api/config.py` and imported by the
+rest of the application instead of calling `os.getenv` directly.
+
 ## Running
 
 Start the backend with `uvicorn`:

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# Raw environment variable for API host
+RAW_VITE_API_HOST = os.getenv("VITE_API_HOST")
+API_HOST = RAW_VITE_API_HOST or "http://localhost:8000"
+
+DB_PATH = os.getenv("DB", "api/jobs.db")
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()
+LOG_TO_STDOUT = os.getenv("LOG_TO_STDOUT", "false").lower() == "true"

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-import os
+from api import config
 
 from pathlib import Path
 from contextlib import asynccontextmanager
@@ -28,13 +28,9 @@ system_log = get_system_logger()
 ROOT = Path(__file__).parent
 
 # ─── ENV SAFETY CHECK ───
-from dotenv import load_dotenv
-
-load_dotenv()
-
 # Read API host from environment with a default for local development.
-API_HOST = os.getenv("VITE_API_HOST", "http://localhost:8000")
-if os.getenv("VITE_API_HOST") is None:
+API_HOST = config.API_HOST
+if config.RAW_VITE_API_HOST is None:
     system_log.warning("VITE_API_HOST not set, defaulting to http://localhost:8000")
 
 

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -7,8 +7,9 @@ from sqlalchemy import inspect, create_engine
 from sqlalchemy.orm import sessionmaker
 from api.models import Base
 from api.utils.logger import get_logger
+from api import config
 
-DB_PATH = os.getenv("DB", "api/jobs.db")
+DB_PATH = config.DB_PATH
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 SessionLocal = sessionmaker(bind=engine)

--- a/api/utils/logger.py
+++ b/api/utils/logger.py
@@ -6,6 +6,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from api.paths import LOG_DIR
+from api import config
 
 
 def get_logger(job_id: str) -> logging.Logger:
@@ -14,7 +15,7 @@ def get_logger(job_id: str) -> logging.Logger:
     log_path = LOG_DIR / f"{job_id}.log"
 
     logger = logging.getLogger(f"job_{job_id}")
-    level = os.getenv("LOG_LEVEL", "DEBUG").upper()
+    level = config.LOG_LEVEL
     logger.setLevel(getattr(logging, level, logging.DEBUG))
 
     # Avoid duplicate handlers
@@ -29,7 +30,7 @@ def get_logger(job_id: str) -> logging.Logger:
         logger.addHandler(handler)
 
         # Optional: also log to console if enabled in .env
-        if os.getenv("LOG_TO_STDOUT", "false").lower() == "true":
+        if config.LOG_TO_STDOUT:
             stream_handler = logging.StreamHandler()
             stream_handler.setFormatter(formatter)
             logger.addHandler(stream_handler)
@@ -41,7 +42,7 @@ def get_system_logger(name="system") -> logging.Logger:
     """Logger for application-wide events not tied to a job."""
     log_path = LOG_DIR / "system.log"
     logger = logging.getLogger(name)
-    level = os.getenv("LOG_LEVEL", "DEBUG").upper()
+    level = config.LOG_LEVEL
     logger.setLevel(getattr(logging, level, logging.DEBUG))
     logger.propagate = False
 
@@ -55,7 +56,7 @@ def get_system_logger(name="system") -> logging.Logger:
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-        if os.getenv("LOG_TO_STDOUT", "false").lower() == "true":
+        if config.LOG_TO_STDOUT:
             stream_handler = logging.StreamHandler()
             stream_handler.setFormatter(formatter)
             logger.addHandler(stream_handler)


### PR DESCRIPTION
## Summary
- collect environment variable handling into `api/config.py`
- use configuration module in the FastAPI entrypoint, ORM bootstrap, and logging helpers
- document configuration module in the README

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c158538088325be7f4ec9721197ec