### PR TITLE
Add metrics and version endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -69,6 +69,17 @@ def health_check():
     return {"status": "ok"}
 
 
+@app.get("/version")
+def version() -> dict:
+    """Return the application version from pyproject.toml."""
+    pyproject = ROOT.parent / "pyproject.toml"
+    import tomllib
+
+    data = tomllib.loads(pyproject.read_text())
+    version = data.get("project", {}).get("version", "unknown")
+    return {"version": version}
+
+
 def rehydrate_incomplete_jobs():
     with SessionLocal() as db:
         jobs = (

--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from api.routes import jobs, admin, logs
+from api.routes import jobs, admin, logs, metrics
 from api.paths import UPLOAD_DIR, TRANSCRIPTS_DIR
 from api.app_state import backend_log
 
@@ -14,6 +14,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(jobs.router)
     app.include_router(admin.router)
     app.include_router(logs.router)
+    app.include_router(metrics.router)
 
     app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
     app.mount(

--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Response
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
+
+router = APIRouter()
+
+
+@router.get("/metrics")
+def metrics() -> Response:
+    """Return Prometheus metrics."""
+    data = generate_latest(REGISTRY)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ python-dotenv>=1.1.0
 
 # --- JSON performance boost (optional but auto-detected by FastAPI) ---
 orjson>=3.10.0
+prometheus-client>=0.20.0
 
 
 # ------------------------------------------------


### PR DESCRIPTION
## Summary
- expose Prometheus metrics at `/metrics`
- add `/version` endpoint returning the pyproject version
- register metrics router
- include `prometheus-client` in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685c1f7f2bac83258cecf8a41a947eb4