### PR TITLE
Add job queue for concurrency control

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -12,3 +12,6 @@ DB_PATH = os.getenv("DB", "api/jobs.db")
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "DEBUG").upper()
 LOG_TO_STDOUT = os.getenv("LOG_TO_STDOUT", "false").lower() == "true"
+
+# Limit for simultaneous transcription jobs
+MAX_CONCURRENT_JOBS = int(os.getenv("MAX_CONCURRENT_JOBS", "2"))

--- a/api/services/job_queue.py
+++ b/api/services/job_queue.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import threading
+from queue import Queue
+from typing import Callable
+
+
+class JobQueue:
+    """Simple worker queue that limits concurrent job execution."""
+
+    def __init__(self, max_workers: int) -> None:
+        self._queue: "Queue[Callable[[], None]]" = Queue()
+        self._threads: list[threading.Thread] = []
+        self._shutdown = threading.Event()
+        for _ in range(max_workers):
+            t = threading.Thread(target=self._worker, daemon=True)
+            t.start()
+            self._threads.append(t)
+
+    def _worker(self) -> None:
+        while not self._shutdown.is_set():
+            func = self._queue.get()
+            try:
+                func()
+            finally:
+                self._queue.task_done()
+
+    def enqueue(self, func: Callable[[], None]) -> None:
+        """Add a callable to be executed by the worker pool."""
+        self._queue.put(func)
+
+    def join(self) -> None:
+        self._queue.join()
+
+    def shutdown(self) -> None:
+        self._shutdown.set()
+        for _ in self._threads:
+            self.enqueue(lambda: None)
+        for t in self._threads:
+            t.join()


### PR DESCRIPTION
## Summary
- add `JobQueue` with worker threads
- allow configuration of max concurrent jobs via `MAX_CONCURRENT_JOBS`
- expose `job_queue` in `app_state`
- queue transcription jobs instead of running them directly
- support running `handle_whisper` synchronously

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black . --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c257ea5a083259bc34d880226d89b