### PR TITLE
Add docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,28 @@ docker run -p 8000:8000 \
   whisper-app
 ```
 
+## Docker Compose
+
+A `docker-compose.yml` is included to start the API together with example
+PostgreSQL and RabbitMQ services. These additional services are placeholders for
+future features but are not required today.
+
+Prepare the models and build the frontend before running compose:
+
+```bash
+cd frontend
+npm run build
+cd ..
+```
+
+Build and start all services with:
+
+```bash
+docker compose up --build
+```
+
+The compose file mounts the `uploads`, `transcripts` and `logs` directories so
+data persists between runs. Once running, access the API at
+`http://localhost:8000`.
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.8"
+
+services:
+  api:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      - VITE_API_HOST=http://localhost:8000
+    volumes:
+      - ./uploads:/app/uploads
+      - ./transcripts:/app/transcripts
+      - ./logs:/app/logs
+    depends_on:
+      - db
+      - broker
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: whisper
+      POSTGRES_PASSWORD: whisper
+      POSTGRES_DB: whisper
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  broker:
+    image: rabbitmq:3-management
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+volumes:
+  db_data:
+  rabbitmq_data:


### PR DESCRIPTION
## Summary
- add docker-compose with API, database and broker services
- document docker-compose usage

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` in `frontend` *(fails: 403 Forbidden)*
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685c28abe9f08325af82bef391f40beb