### PR TITLE
Add secure metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
 - `LOG_TO_STDOUT` – set to `true` to also mirror logs to the console.
+- `METRICS_TOKEN` – optional bearer token required to access `/metrics`.
 
 All configuration values are parsed once in `api/config.py` and imported by the
 rest of the application instead of calling `os.getenv` directly.
@@ -42,6 +43,11 @@ npm run build
 This outputs static files under `frontend/dist/`.
 The Dockerfile copies this directory into `api/static/` so the React
 application can be served with the backend.
+
+## Metrics
+
+The backend exposes Prometheus metrics at `/metrics`. When `METRICS_TOKEN` is
+set, requests must include `Authorization: Bearer <token>`.
 
 ## Usage Notes
 

--- a/api/config.py
+++ b/api/config.py
@@ -15,3 +15,6 @@ LOG_TO_STDOUT = os.getenv("LOG_TO_STDOUT", "false").lower() == "true"
 
 # Limit for simultaneous transcription jobs
 MAX_CONCURRENT_JOBS = int(os.getenv("MAX_CONCURRENT_JOBS", "2"))
+
+# Optional token required to access the /metrics endpoint
+METRICS_TOKEN = os.getenv("METRICS_TOKEN")

--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -1,11 +1,21 @@
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Response, Request, HTTPException, status
+
+from api import config
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 
 router = APIRouter()
 
 
 @router.get("/metrics")
-def metrics() -> Response:
+def metrics(request: Request) -> Response:
     """Return Prometheus metrics."""
+    token = config.METRICS_TOKEN
+    if token:
+        auth = request.headers.get("Authorization")
+        if not auth or not auth.startswith("Bearer "):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        if auth.split(" ", 1)[1] != token:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
     data = generate_latest(REGISTRY)
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
## Summary
- add optional METRICS_TOKEN config
- require bearer token on `/metrics` when token set
- document metrics endpoint and token usage

## Testing
- `black . --check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685c36aab9708325af66ad1393321500