### PR TITLE
Add health and version endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The backend exposes Prometheus metrics at `/metrics`. Authenticate with the JWT
 token obtained from the `/token` endpoint and send it as `Authorization: Bearer
 <token>`.
 
+### Health & Version
+
+Use `/health` to check server status. `/version` returns the current application version.
+
 ### Progress WebSocket
 
 Connect to `/ws/progress/{job_id}` with the same JWT credentials as other

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -102,6 +102,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 - Zip download of all data (`/admin/download-all`)
 - Expose `/metrics` endpoint for monitoring
 - Progress WebSocket (`/ws/progress/{job_id}`) sends status updates
+- Health check (`/health`) and version info (`/version`)
 
 ### Upcoming Ideas
 
@@ -109,7 +110,6 @@ This document summarizes the repository layout and how the core FastAPI service 
 
 | Rank | Feature Idea                                    | Reasoning                      | Considerations                  | Roadblocks                    |
 | ---- | ----------------------------------------------- | ------------------------------ | ------------------------------- | ----------------------------- |
-| 000  | Add `/health` and `/version` endpoints          | Just return status data        | Decide output format            | None                          |
 | 001  | Local-time timestamps instead of UTC            | Convert timestamps on display  | Timezone handling               | None                          |
 | 002  | Download transcripts as `.txt`                  | Plain text export from SRT     | Maintain timestamp accuracy     | None                          |
 | 003  | Download job archive (.zip)                     | Zip existing logs and results  | Avoid large file memory use     | None                          |


### PR DESCRIPTION
## Summary
- document new health and version endpoints
- mark endpoints completed in design scope

## Testing
- `black . --check`

------
https://chatgpt.com/codex/tasks/task_e_685c7a04dcfc83258bd4da1215d1ceba