### PR TITLE
Implement local time display

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,14 @@ resembles:
   "id": "123abc",
   "original_filename": "audio.wav",
   "model": "base",
-  "created_at": "2024-01-01T12:00:00",
-  "updated": "2024-01-01T12:05:00",
+  "created_at": "2024-01-01T12:00:00Z",
+  "updated": "2024-01-01T12:05:00Z",
   "status": "completed"
 }
 ```
+
+Timestamps returned by the API are in UTC (note the trailing `Z`).
+The web UI converts them to your local timezone for display.
 
 ## Usage Notes
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -103,6 +103,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 - Expose `/metrics` endpoint for monitoring
 - Progress WebSocket (`/ws/progress/{job_id}`) sends status updates
 - Health check (`/health`) and version info (`/version`)
+- Local-time timestamps shown in the UI
 
 ### Upcoming Ideas
 
@@ -110,7 +111,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 
 | Rank | Feature Idea                                    | Reasoning                      | Considerations                  | Roadblocks                    |
 | ---- | ----------------------------------------------- | ------------------------------ | ------------------------------- | ----------------------------- |
-| 001  | Local-time timestamps instead of UTC            | Convert timestamps on display  | Timezone handling               | None                          |
+| 001  | Local-time timestamps shown (done)              | Converted on display           | Timezone handling               | None                          |
 | 002  | Download transcripts as `.txt`                  | Plain text export from SRT     | Maintain timestamp accuracy     | None                          |
 | 003  | Download job archive (.zip)                     | Zip existing logs and results  | Avoid large file memory use     | None                          |
 | 004  | Support `.vtt` transcript export                | Convert from SRT to VTT        | Extra dependency for conversion | None                          |

--- a/frontend/src/pages/ActiveJobsPage.jsx
+++ b/frontend/src/pages/ActiveJobsPage.jsx
@@ -64,7 +64,7 @@ export default function ActiveJobsPage() {
                 <td style={tdStyle}>{job.original_filename}</td>
                 <td style={tdStyle}>{job.model}</td>
                 <td style={tdStyle}>{job.status}</td>
-                <td style={tdStyle}>{new Date(job.created_at).toLocaleString()}</td>
+                <td style={tdStyle}>{new Date(job.created_at + 'Z').toLocaleString()}</td>
                 <td style={{ ...tdStyle, display: "flex", gap: "0.5rem" }}>
                   <button
                     title={`Job ID: ${job.id}`}

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -91,7 +91,7 @@ export default function CompletedJobsPage() {
                   {job.original_filename}
                 </td>
                 <td style={tdStyle}>{job.model}</td>
-                <td style={tdStyle}>{new Date(job.created_at).toLocaleString()}</td>
+                <td style={tdStyle}>{new Date(job.created_at + 'Z').toLocaleString()}</td>
                 <td style={{ ...tdStyle, display: "flex", gap: "0.5rem" }}>
                   <button title={`Job ID: ${job.id}`} style={buttonStyle("#2563eb")} onClick={() => handleView(job.id)}>View</button>
                   <button style={buttonStyle("#16a34a")} onClick={() => handleDownloadTranscript(job.id)}>Download</button>

--- a/frontend/src/pages/FailedJobsPage.jsx
+++ b/frontend/src/pages/FailedJobsPage.jsx
@@ -94,7 +94,7 @@ export default function FailedJobsPage() {
               >
                 <td style={{ ...tdStyle, color: "#f87171" }}>{job.original_filename}</td>
                 <td style={tdStyle}>{job.model}</td>
-                <td style={tdStyle}>{new Date(job.created_at).toLocaleString()}</td>
+                <td style={tdStyle}>{new Date(job.created_at + 'Z').toLocaleString()}</td>
                 <td style={tdStyle}>{job.status}</td>
                 <td style={{ ...tdStyle, display: "flex", gap: "0.5rem" }}>
                   <button style={buttonStyle("#2563eb")} onClick={() => handleRestart(job.id)}>Restart</button>

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -53,8 +53,8 @@ export default function JobStatusPage() {
           <p><strong>Filename:</strong> {job.original_filename}</p>
           <p><strong>Model:</strong> {job.model}</p>
           <p><strong>Status:</strong> {job.status}</p>
-          <p><strong>Created:</strong> {new Date(job.created_at).toLocaleString()}</p>
-          <p><strong>Updated:</strong> {job.updated ? new Date(job.updated).toLocaleString() : "N/A"}</p>
+          <p><strong>Created:</strong> {new Date(job.created_at + 'Z').toLocaleString()}</p>
+          <p><strong>Updated:</strong> {job.updated ? new Date(job.updated + 'Z').toLocaleString() : "N/A"}</p>
 
           {job.status === "completed" && (
               <a


### PR DESCRIPTION
## Summary
- show job times in local timezone by parsing UTC strings
- document that the web UI converts UTC timestamps to local time
- note completed feature in design_scope

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c7b3290948325aac9a95599f838e0