### PR TITLE
Implement TXT as web download default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `DB` – path to a SQLite database file used mainly for tests. When set it
   overrides `DB_URL`.
 - `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
+- `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
 - `LOG_TO_STDOUT` – set to `true` to also mirror logs to the console.
 - `METRICS_TOKEN` – optional bearer token required to access `/metrics`.
@@ -108,6 +109,15 @@ resembles:
 
 Timestamps returned by the API are in UTC (note the trailing `Z`).
 The web UI converts them to your local timezone for display.
+
+### Transcript Downloads
+
+Use `/jobs/{id}/download` to retrieve the transcript. The optional `format`
+parameter supports `srt` (default), `txt` for plain text, and `vtt` for WebVTT.
+
+The React UI downloads transcripts in plain text by default using
+`?format=txt`. This default can be overridden with the `VITE_DEFAULT_TRANSCRIPT_FORMAT`
+build variable or by storing a `downloadFormat` value in `localStorage`.
 
 ## Usage Notes
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -49,6 +49,7 @@ object used throughout the code base. Available variables are:
 - `DB_URL` – database URL.
 - `DB` – SQLite path overriding `DB_URL`.
 - `VITE_API_HOST` – base URL for the frontend to reach the API.
+- `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – log level for backend loggers.
 - `LOG_TO_STDOUT` – mirror logs to the console when `true`.
 - `METRICS_TOKEN` – optional bearer token for `/metrics`.
@@ -104,6 +105,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 - Progress WebSocket (`/ws/progress/{job_id}`) sends status updates
 - Health check (`/health`) and version info (`/version`)
 - Local-time timestamps shown in the UI
+- Download transcripts as `.txt` (default in UI)
 
 ### Upcoming Ideas
 
@@ -112,7 +114,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | Rank | Feature Idea                                    | Reasoning                      | Considerations                  | Roadblocks                    |
 | ---- | ----------------------------------------------- | ------------------------------ | ------------------------------- | ----------------------------- |
 | 001  | Local-time timestamps shown (done)              | Converted on display           | Timezone handling               | None                          |
-| 002  | Download transcripts as `.txt`                  | Plain text export from SRT     | Maintain timestamp accuracy     | None                          |
+| 002  | Download transcripts as `.txt` (done, default UI format)           | Plain text export from SRT     | Maintain timestamp accuracy     | None                          |
 | 003  | Download job archive (.zip)                     | Zip existing logs and results  | Avoid large file memory use     | None                          |
 | 004  | Support `.vtt` transcript export                | Convert from SRT to VTT        | Extra dependency for conversion | None                          |
 | 005  | Provide CLI wrapper for non-UI usage            | Wrapper script around API calls| Package distribution            | None                          |

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ROUTES } from "../routes";
+import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 
 export default function CompletedJobsPage() {
   const [jobs, setJobs] = useState([]);
@@ -17,7 +17,7 @@ export default function CompletedJobsPage() {
   };
 
   const handleDownloadTranscript = (jobId) => {
-    window.open(`${ROUTES.API}/jobs/${jobId}/download?format=txt`, "_blank");
+    window.open(getTranscriptDownloadUrl(jobId), "_blank");
   };
 
   const handleDelete = async (jobId) => {

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -1,7 +1,7 @@
 // frontend/src/pages/JobStatusPage.jsx
 
 import { useEffect, useState } from "react";
-import { ROUTES } from "../routes";
+import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 import { useParams } from "react-router-dom";
 
 export default function JobStatusPage() {
@@ -58,7 +58,7 @@ export default function JobStatusPage() {
 
           {job.status === "completed" && (
               <a
-                href={`${ROUTES.API}/jobs/${jobId}/download?format=txt`}
+                href={getTranscriptDownloadUrl(jobId)}
                 download
               style={{
                 display: "inline-block",

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -10,3 +10,15 @@ export const ROUTES = {
   PROGRESS: "/progress/:jobId",
   API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
 };
+
+export const DEFAULT_DOWNLOAD_FORMAT =
+  localStorage.getItem("downloadFormat") ||
+  import.meta.env.VITE_DEFAULT_TRANSCRIPT_FORMAT ||
+  "txt";
+
+export function getTranscriptDownloadUrl(
+  jobId,
+  format = DEFAULT_DOWNLOAD_FORMAT
+) {
+  return `${ROUTES.API}/jobs/${jobId}/download?format=${format}`;
+}


### PR DESCRIPTION
## Summary
- add `DEFAULT_DOWNLOAD_FORMAT` constant and URL helper
- use the helper when downloading transcripts from the UI
- document `VITE_DEFAULT_TRANSCRIPT_FORMAT` env variable
- note TXT default in design docs and README

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685c7cfe2b5c8325a2e38c2e31714b8c