### PR TITLE
Add admin server control buttons

### DIFF
--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -44,6 +44,8 @@ def register_routes(app: FastAPI) -> None:
             "admin/files",
             "admin/reset",
             "admin/download-all",
+            "admin/shutdown",
+            "admin/restart",
             "health",
             "docs",
             "openapi.json",

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -5,6 +5,9 @@ import shutil
 import zipfile
 from pathlib import Path
 
+import os
+import sys
+import threading
 import psutil
 
 from api.errors import ErrorCode, http_error
@@ -92,3 +95,25 @@ def admin_stats() -> AdminStatsOut:
         mem_used_mb=round(mem.used / (1024 * 1024), 1),
         mem_total_mb=round(mem.total / (1024 * 1024), 1),
     )
+
+
+@router.post("/shutdown", response_model=StatusOut)
+def shutdown_server() -> StatusOut:
+    """Shut down the running server process."""
+
+    def _exit():
+        os._exit(0)
+
+    threading.Thread(target=_exit, daemon=True).start()
+    return StatusOut(status="shutting down")
+
+
+@router.post("/restart", response_model=StatusOut)
+def restart_server() -> StatusOut:
+    """Restart the running server process."""
+
+    def _restart():
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+
+    threading.Thread(target=_restart, daemon=True).start()
+    return StatusOut(status="restarting")

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -98,6 +98,30 @@ useEffect(() => {
     window.open(`${API_HOST}/admin/download-all`);
   };
 
+  const handleShutdown = async () => {
+    const confirmed = window.confirm("Shut down the server?");
+    if (!confirmed) return;
+    try {
+      const res = await fetch(`${API_HOST}/admin/shutdown`, { method: "POST" });
+      if (!res.ok) throw new Error();
+      setFeedback("Server shutting down...");
+    } catch {
+      setFeedback("Failed to shut down server.");
+    }
+  };
+
+  const handleRestart = async () => {
+    const confirmed = window.confirm("Restart the server?");
+    if (!confirmed) return;
+    try {
+      const res = await fetch(`${API_HOST}/admin/restart`, { method: "POST" });
+      if (!res.ok) throw new Error();
+      setFeedback("Server restarting...");
+    } catch {
+      setFeedback("Failed to restart server.");
+    }
+  };
+
   const renderFileList = (title, list, dir) => (
     <div style={{ marginBottom: "2rem" }}>
       <h3 style={{ fontSize: "1.125rem", marginBottom: "0.5rem" }}>{title}</h3>
@@ -181,6 +205,18 @@ useEffect(() => {
           style={{ backgroundColor:"#2563eb", color:"white", border:"none",
                   padding:"0.5rem 1rem", borderRadius:"0.25rem", cursor:"pointer" }}>
           Download All Data (ZIP)
+        </button>
+
+        <button onClick={handleShutdown}
+          style={{ backgroundColor:"#6b7280", color:"white", border:"none",
+                  padding:"0.5rem 1rem", borderRadius:"0.25rem", cursor:"pointer" }}>
+          Shutdown Server
+        </button>
+
+        <button onClick={handleRestart}
+          style={{ backgroundColor:"#6b7280", color:"white", border:"none",
+                  padding:"0.5rem 1rem", borderRadius:"0.25rem", cursor:"pointer" }}>
+          Restart Server
         </button>
 
       </div>


### PR DESCRIPTION
## Summary
- add backend endpoints to shut down or restart the server
- protect new routes from SPA fallback
- add Admin page handlers and buttons for restarting or shutting down

## Testing
- `black .`
- `black --check api/routes/admin.py api/router_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_685c913ac9b08325a639a10adcfd24b5