### PR TITLE
Add user friendly job status labels

### DIFF
--- a/frontend/src/pages/ActiveJobsPage.jsx
+++ b/frontend/src/pages/ActiveJobsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { ROUTES } from "../routes";
+import { STATUS_LABELS } from "../statusLabels";
 export default function ActiveJobsPage() {
   const [jobs, setJobs] = useState([]);
   const [lastUpdated, setLastUpdated] = useState(new Date());
@@ -63,7 +64,7 @@ export default function ActiveJobsPage() {
               >
                 <td style={tdStyle}>{job.original_filename}</td>
                 <td style={tdStyle}>{job.model}</td>
-                <td style={tdStyle}>{job.status}</td>
+                <td style={tdStyle}>{STATUS_LABELS[job.status] || job.status}</td>
                 <td style={tdStyle}>{new Date(job.created_at + 'Z').toLocaleString()}</td>
                 <td style={{ ...tdStyle, display: "flex", gap: "0.5rem" }}>
                   <button

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
+import { STATUS_LABELS } from "../statusLabels";
 
 export default function CompletedJobsPage() {
   const [jobs, setJobs] = useState([]);

--- a/frontend/src/pages/FailedJobsPage.jsx
+++ b/frontend/src/pages/FailedJobsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { ROUTES } from "../routes";
+import { STATUS_LABELS } from "../statusLabels";
 
 export default function FailedJobsPage() {
   const [jobs, setJobs] = useState([]);
@@ -95,7 +96,7 @@ export default function FailedJobsPage() {
                 <td style={{ ...tdStyle, color: "#f87171" }}>{job.original_filename}</td>
                 <td style={tdStyle}>{job.model}</td>
                 <td style={tdStyle}>{new Date(job.created_at + 'Z').toLocaleString()}</td>
-                <td style={tdStyle}>{job.status}</td>
+                <td style={tdStyle}>{STATUS_LABELS[job.status] || job.status}</td>
                 <td style={{ ...tdStyle, display: "flex", gap: "0.5rem" }}>
                   <button style={buttonStyle("#2563eb")} onClick={() => handleRestart(job.id)}>Restart</button>
                   <button style={buttonStyle("#dc2626")} onClick={() => handleDelete(job.id)}>Delete</button>

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
+import { STATUS_LABELS } from "../statusLabels";
 import { useParams } from "react-router-dom";
 
 export default function JobStatusPage() {
@@ -52,7 +53,7 @@ export default function JobStatusPage() {
         <div style={{ marginTop: "1rem" }}>
           <p><strong>Filename:</strong> {job.original_filename}</p>
           <p><strong>Model:</strong> {job.model}</p>
-          <p><strong>Status:</strong> {job.status}</p>
+          <p><strong>Status:</strong> {STATUS_LABELS[job.status] || job.status}</p>
           <p><strong>Created:</strong> {new Date(job.created_at + 'Z').toLocaleString()}</p>
           <p><strong>Updated:</strong> {job.updated ? new Date(job.updated + 'Z').toLocaleString() : "N/A"}</p>
 

--- a/frontend/src/statusLabels.js
+++ b/frontend/src/statusLabels.js
@@ -1,0 +1,11 @@
+export const STATUS_LABELS = {
+  queued: "Queued",
+  processing: "Processing",
+  enriching: "Enriching metadata",
+  completed: "Completed",
+  failed_timeout: "Timed out",
+  failed_launch_error: "Launch error",
+  failed_whisper_error: "Whisper error",
+  failed_thread_exception: "Internal error",
+  failed_unknown: "Unknown error",
+};


### PR DESCRIPTION
## Summary
- add `STATUS_LABELS` dictionary for frontend
- import `STATUS_LABELS` where job statuses are shown
- display friendly labels instead of raw job status values

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685da08a486883258c8e81b0ecdf26d5