### PR TITLE
Add spinner for queued job statuses

### DIFF
--- a/frontend/src/Spinner.jsx
+++ b/frontend/src/Spinner.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export default function Spinner({ size = "2rem" }) {
+  const circleStyle = {
+    width: size,
+    height: size,
+    border: "4px solid #e5e7eb",
+    borderTopColor: "#3b82f6",
+    borderRadius: "50%",
+    animation: "spin 1s linear infinite",
+  };
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center", padding: "1rem" }}>
+      <style>{"@keyframes spin { to { transform: rotate(360deg); } }"}</style>
+      <div style={circleStyle} />
+    </div>
+  );
+}

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 import { STATUS_LABELS } from "../statusLabels";
+import Spinner from "../Spinner";
 import { useParams } from "react-router-dom";
 
 export default function JobStatusPage() {
@@ -90,6 +91,12 @@ export default function JobStatusPage() {
           <p><strong>Status:</strong> {STATUS_LABELS[job.status] || job.status}</p>
           <p><strong>Created:</strong> {new Date(job.created_at + 'Z').toLocaleString()}</p>
           <p><strong>Updated:</strong> {job.updated ? new Date(job.updated + 'Z').toLocaleString() : "N/A"}</p>
+
+          {[
+            "queued",
+            "processing",
+            "enriching",
+          ].includes(job.status) && <Spinner />}
 
           {job.status === "completed" && (
               <a


### PR DESCRIPTION
## Summary
- create a minimal Spinner component
- show Spinner while a job is queued, processing, or enriching

## Testing
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685da3e351a48325bbc1468c65b117b8