### PR TITLE
Update status messaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Use `/health` to check server status. `/version` returns the current application
 ### Progress WebSocket
 
 Connect to `/ws/progress/{job_id}` with the same JWT credentials as other
-endpoints. The server sends JSON messages when a job moves through the
-`queued`, `processing`, `enriching` and final `completed` or `failed` states.
+endpoints. The server now pushes real-time status messages so the UI updates
+immediately with friendlier labels. Messages reflect the `queued`, `processing`,
+`enriching` and final `completed` or `failed` states.
 
 ### Example Job Response
 
@@ -121,6 +122,8 @@ build variable or by storing a `downloadFormat` value in `localStorage`.
 
 ## Usage Notes
 
+- Real-time job status messages appear in the UI via the progress WebSocket with
+  friendlier labels for each state.
 - `models/` exists locally only and is never stored in Git. It must contain the Whisper `.pt` files before building or running the app. Ensure the files are present before building the Docker image.
 - `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -103,7 +103,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | Download job archive (.zip)                                          | Open      | Zip existing logs and results    | Avoid large file memory use     | None                          |
 | Support `.vtt` transcript export                                     | Open      | Convert from SRT to VTT          | Extra dependency for conversion | None                          |
 | Provide CLI wrapper for non-UI usage                                 | Open      | Wrapper script around API calls  | Package distribution            | None                          |
-| Improve status messaging in UI                                       | Open      | Better frontend labels           | Localization, UX tweaks         | None                          |
+| Improve status messaging in UI                                       | Done      | Real-time updates via progress WebSocket | Friendlier labels, localization | None                          |
 | Job runtime display (live & final)                                   | Open      | Track job start and end times    | Store runtime data              | None                          |
 | Admin panel health checks and job cleanup                            | Open      | Add checks and cleanup hooks     | Permission checks               | None                          |
 | Queue limit or concurrency throttle                                  | Open      | Throttle worker count            | Configurable limits             | None                          |


### PR DESCRIPTION
## Summary
- mark UI status messaging improvement as done
- highlight real-time status WebSocket and friendly labels

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685da643ee948325921c625fd06b4cc6