### PR TITLE
Add API helper module with auth context

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useContext } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import { ROUTES } from "./routes";
 import UploadPage from "./pages/UploadPage";
@@ -10,19 +10,21 @@ import JobStatusPage from "./pages/JobStatusPage";
 import FailedJobsPage from "./pages/FailedJobsPage";
 import JobProgressPage from "./pages/JobProgressPage";
 import LoginPage from "./pages/LoginPage";
+import { AuthContext } from "./context/AuthContext";
+import { useApi } from "./api";
 
 export default function App() {
+  const api = useApi();
   useEffect(() => {
-    fetch('/log_event', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ event: 'frontend_loaded', timestamp: new Date().toISOString() })
+    api.post('/log_event', {
+      event: 'frontend_loaded',
+      timestamp: new Date().toISOString()
     }).catch(() => {});
   }, []);
 
-  const token = localStorage.getItem("token");
+  const { token, setToken } = useContext(AuthContext);
   const handleLogout = () => {
-    localStorage.removeItem("token");
+    setToken(null);
     window.location.href = ROUTES.LOGIN;
   };
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -1,0 +1,70 @@
+import { useContext } from "react";
+import { AuthContext } from "../context/AuthContext";
+import { ROUTES } from "../routes";
+
+const BASE_URL = ROUTES.API;
+
+function parseResponse(res) {
+  return res.text().then((text) => {
+    try {
+      return { ok: res.ok, data: JSON.parse(text) };
+    } catch {
+      return { ok: res.ok, data: text };
+    }
+  });
+}
+
+export function useApi() {
+  const { token } = useContext(AuthContext);
+
+  const request = async (method, path, options = {}) => {
+    const headers = { ...(options.headers || {}) };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch(`${BASE_URL}${path}`, {
+      ...options,
+      method,
+      headers,
+    });
+    const { ok, data } = await parseResponse(res);
+    if (!ok) {
+      const msg = typeof data === "string" ? data : data.error || "Request failed";
+      throw new Error(msg);
+    }
+    return data;
+  };
+
+  const get = (path, options) => request("GET", path, options);
+  const del = (path, options) => request("DELETE", path, options);
+  const post = (path, body, options = {}) => {
+    const opts = { ...options };
+    if (body !== undefined) {
+      if (
+        !(body instanceof FormData) &&
+        !(typeof body === "string") &&
+        !(body instanceof URLSearchParams)
+      ) {
+        opts.headers = { "Content-Type": "application/json", ...(opts.headers || {}) };
+        body = JSON.stringify(body);
+      }
+      opts.body = body;
+    }
+    return request("POST", path, opts);
+  };
+  const put = (path, body, options = {}) => {
+    const opts = { ...options };
+    if (body !== undefined) {
+      if (
+        !(body instanceof FormData) &&
+        !(typeof body === "string") &&
+        !(body instanceof URLSearchParams)
+      ) {
+        opts.headers = { "Content-Type": "application/json", ...(opts.headers || {}) };
+        body = JSON.stringify(body);
+      }
+      opts.body = body;
+    }
+    return request("PUT", path, opts);
+  };
+
+  return { get, post, put, del };
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,21 @@
+import { createContext, useState, useEffect } from "react";
+
+export const AuthContext = createContext({ token: null, setToken: () => {} });
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(() => localStorage.getItem("token"));
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem("token", token);
+    } else {
+      localStorage.removeItem("token");
+    }
+  }, [token]);
+
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
 import './index.css';
 import './global.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/ActiveJobsPage.jsx
+++ b/frontend/src/pages/ActiveJobsPage.jsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
 import { ROUTES } from "../routes";
+import { useApi } from "../api";
 import { STATUS_LABELS } from "../statusLabels";
 import Button from "../components/Button";
 import { Table, Th, Td } from "../components/Table";
 export default function ActiveJobsPage() {
+  const api = useApi();
   const [jobs, setJobs] = useState([]);
   const [lastUpdated, setLastUpdated] = useState(new Date());
 
   const fetchJobs = () => {
-    fetch(`${import.meta.env.VITE_API_HOST}/jobs`)
-      .then(res => res.json())
-      .then(data => {
+    api
+      .get("/jobs")
+      .then((data) => {
         setJobs(data);
         setLastUpdated(new Date());
       })

--- a/frontend/src/pages/AdminPage.jsx
+++ b/frontend/src/pages/AdminPage.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { ROUTES } from "../routes";
+import { useApi } from "../api";
 export default function AdminPage() {
+  const api = useApi();
   const [logs, setLogs] = useState([]);
   const [uploads, setUploads] = useState([]);
   const [transcripts, setTranscripts] = useState([]);
@@ -12,9 +14,7 @@ export default function AdminPage() {
 
   const fetchStats = async () => {
     try {
-      const res = await fetch(`${API_HOST}/admin/stats`);
-      if (!res.ok) throw new Error();
-      const data = await res.json();
+      const data = await api.get("/admin/stats");
       setStats(data);
     } catch {
       setStats(null);
@@ -31,21 +31,12 @@ useEffect(() => {
 
   const fetchFiles = async () => {
     try {
-      const res = await fetch(`${API_HOST}/admin/files`);
-      if (!res.ok) throw new Error();
-      const raw = await res.text();
-
-      try {
-        const data = JSON.parse(raw);
-        setLogs(data.logs || []);
-        setUploads(data.uploads || []);
-        setTranscripts(data.transcripts || []);
-        setError(null);
-        setFeedback("File lists refreshed.");
-      } catch {
-        setError("Failed to parse server response.");
-        return;
-      }
+      const data = await api.get("/admin/files");
+      setLogs(data.logs || []);
+      setUploads(data.uploads || []);
+      setTranscripts(data.transcripts || []);
+      setError(null);
+      setFeedback("File lists refreshed.");
     } catch {
       setError("Failed to load file listings.");
     }
@@ -66,12 +57,10 @@ useEffect(() => {
     const confirmed = window.confirm(`Delete ${filename} from ${dir}?`);
     if (!confirmed) return;
     try {
-      const res = await fetch(`${API_HOST}/admin/files`, {
-        method: "DELETE",
+      await api.del("/admin/files", {
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ folder: dir, filename }),
+        body: JSON.stringify({ folder: dir, filename })
       });
-      if (!res.ok) throw new Error();
       setFeedback(`Deleted ${filename} from ${dir}.`);
       setRefreshToggle(prev => !prev);
     } catch {
@@ -85,8 +74,7 @@ useEffect(() => {
     );
     if (!confirmed) return;
     try {
-      const res = await fetch(`${API_HOST}/admin/reset`, { method: "POST" });
-      if (!res.ok) throw new Error();
+      await api.post("/admin/reset");
       setFeedback("System reset complete.");
       setRefreshToggle(prev => !prev);
     } catch {
@@ -102,8 +90,7 @@ useEffect(() => {
     const confirmed = window.confirm("Shut down the server?");
     if (!confirmed) return;
     try {
-      const res = await fetch(`${API_HOST}/admin/shutdown`, { method: "POST" });
-      if (!res.ok) throw new Error();
+      await api.post("/admin/shutdown");
       setFeedback("Server shutting down...");
     } catch {
       setFeedback("Failed to shut down server.");
@@ -114,8 +101,7 @@ useEffect(() => {
     const confirmed = window.confirm("Restart the server?");
     if (!confirmed) return;
     try {
-      const res = await fetch(`${API_HOST}/admin/restart`, { method: "POST" });
-      if (!res.ok) throw new Error();
+      await api.post("/admin/restart");
       setFeedback("Server restarting...");
     } catch {
       setFeedback("Failed to restart server.");

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -1,18 +1,20 @@
 import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
+import { useApi } from "../api";
 import { STATUS_LABELS } from "../statusLabels";
 import PageContainer from "../components/PageContainer";
 import Button from "../components/Button";
 import { Table, Th, Td } from "../components/Table";
 
 export default function CompletedJobsPage() {
+  const api = useApi();
   const [jobs, setJobs] = useState([]);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch(`${ROUTES.API}/jobs`)
-      .then(res => res.json())
-      .then(data => setJobs(data.filter(job => job.status === "completed")))
+    api
+      .get("/jobs")
+      .then((data) => setJobs(data.filter((job) => job.status === "completed")))
       .catch(() => setError("Failed to load completed jobs"));
   }, []);
 
@@ -26,11 +28,8 @@ export default function CompletedJobsPage() {
 
   const handleDelete = async (jobId) => {
     try {
-      const res = await fetch(`${ROUTES.API}/jobs/${jobId}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) throw new Error();
-      setJobs(jobs.filter(job => job.id !== jobId));
+      await api.del(`/jobs/${jobId}`);
+      setJobs(jobs.filter((job) => job.id !== jobId));
     } catch {
       alert("Error deleting job");
     }

--- a/frontend/src/pages/FailedJobsPage.jsx
+++ b/frontend/src/pages/FailedJobsPage.jsx
@@ -1,24 +1,23 @@
 import { useEffect, useState } from "react";
 import { ROUTES } from "../routes";
 import { STATUS_LABELS } from "../statusLabels";
+import { useApi } from "../api";
 
 export default function FailedJobsPage() {
+  const api = useApi();
   const [jobs, setJobs] = useState([]);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch(`${ROUTES.API}/jobs`)
-      .then(res => res.json())
-      .then(data => setJobs(data.filter(job => job.status.startsWith("failed"))))
+    api
+      .get("/jobs")
+      .then((data) => setJobs(data.filter((job) => job.status.startsWith("failed"))))
       .catch(() => setError("Failed to load failed jobs"));
   }, []);
 
   const handleRestart = async (jobId) => {
     try {
-      const res = await fetch(`${ROUTES.API}/jobs/${jobId}/restart`, {
-        method: "POST",
-      });
-      if (!res.ok) throw new Error();
+      await api.post(`/jobs/${jobId}/restart`);
       setJobs(jobs.filter(job => job.id !== jobId));
     } catch {
       alert("Error restarting job");
@@ -27,10 +26,7 @@ export default function FailedJobsPage() {
 
   const handleDelete = async (jobId) => {
     try {
-      const res = await fetch(`${ROUTES.API}/jobs/${jobId}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) throw new Error();
+      await api.del(`/jobs/${jobId}`);
       setJobs(jobs.filter(job => job.id !== jobId));
     } catch {
       alert("Error deleting job");

--- a/frontend/src/pages/JobProgressPage.jsx
+++ b/frontend/src/pages/JobProgressPage.jsx
@@ -1,21 +1,28 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { ROUTES } from "../routes";
 import { useParams } from "react-router-dom";
+import { AuthContext } from "../context/AuthContext";
+import { useApi } from "../api";
 
 export default function JobProgressPage() {
   const { jobId } = useParams();
+  const { token } = useContext(AuthContext);
+  const api = useApi();
   const [log, setLog] = useState("Loading log...");
   const [lastUpdated, setLastUpdated] = useState(null);
 
   useEffect(() => {
     let ws;
-    const token = localStorage.getItem("token");
 
     const fetchLog = () => {
-      fetch(`${ROUTES.API}/log/${jobId}`)
-        .then((res) => res.text())
+      api
+        .get(`/log/${jobId}`)
         .then((data) => {
-          setLog(data);
+          if (typeof data === "string") {
+            setLog(data);
+          } else {
+            setLog(JSON.stringify(data));
+          }
           setLastUpdated(new Date().toLocaleTimeString());
         })
         .catch(() => setLog("Failed to load log"));

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -1,13 +1,17 @@
 // frontend/src/pages/JobStatusPage.jsx
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 import { STATUS_LABELS } from "../statusLabels";
 import Spinner from "../Spinner";
 import { useParams } from "react-router-dom";
+import { AuthContext } from "../context/AuthContext";
+import { useApi } from "../api";
 
 export default function JobStatusPage() {
   const { jobId } = useParams();
+  const { token } = useContext(AuthContext);
+  const api = useApi();
   const [job, setJob] = useState(null);
   const [error, setError] = useState(null);
 
@@ -16,23 +20,15 @@ export default function JobStatusPage() {
     let interval;
     let ws;
 
-    const token = localStorage.getItem("token");
-
     const fetchJob = async () => {
       try {
-        const res = await fetch(`${ROUTES.API}/jobs/${jobId}`);
-        const data = await res.json();
-
+        const data = await api.get(`/jobs/${jobId}`);
         if (!isCancelled) {
-          if (res.ok) {
-            setJob(data);
-            setError(null);
-          } else {
-            setError(data.error || "Failed to fetch job");
-          }
+          setJob(data);
+          setError(null);
         }
-      } catch {
-        if (!isCancelled) setError("Network error");
+      } catch (err) {
+        if (!isCancelled) setError(err.message || "Network error");
       }
     };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,28 +1,27 @@
-import { useState } from "react";
+import { useState, useContext } from "react";
 import { ROUTES } from "../routes";
+import { AuthContext } from "../context/AuthContext";
+import { useApi } from "../api";
 
 export default function LoginPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState(null);
+  const { setToken } = useContext(AuthContext);
+  const api = useApi();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
     try {
       const body = new URLSearchParams({ username, password });
-      const res = await fetch(`${ROUTES.API}/token`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      const data = await api.post(
+        "/token",
         body,
-      });
-      if (res.ok) {
-        const data = await res.json();
-        localStorage.setItem("token", data.access_token);
-        window.location.href = ROUTES.UPLOAD;
-      } else {
-        setError("Invalid credentials");
-      }
+        { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
+      );
+      setToken(data.access_token);
+      window.location.href = ROUTES.UPLOAD;
     } catch {
       setError("Network error");
     }

--- a/frontend/src/pages/TranscriptViewPage.jsx
+++ b/frontend/src/pages/TranscriptViewPage.jsx
@@ -2,19 +2,21 @@
 import { useEffect, useState } from "react";
 import { ROUTES } from "../routes";
 import { useParams } from "react-router-dom";
+import { useApi } from "../api";
 
 export default function TranscriptViewPage() {
   const { jobId } = useParams();
+  const api = useApi();
   const [transcript, setTranscript] = useState("");
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch(`${ROUTES.API}/transcript/${jobId}/view`)
-      .then((res) => {
-        if (!res.ok) throw new Error("Transcript not found");
-        return res.text();
+    api
+      .get(`/transcript/${jobId}/view`)
+      .then((data) => {
+        if (typeof data === "string") setTranscript(data);
+        else setTranscript(JSON.stringify(data));
       })
-      .then(setTranscript)
       .catch((err) => setError(err.message));
   }, [jobId]);
 

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -1,11 +1,13 @@
 import { useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "../routes";
+import { useApi } from "../api";
 const MAX_FILES = 10;
 const MAX_SIZE_MB = 2048;
 const ALLOWED_TYPES = ["audio/wav", "audio/mpeg", "audio/mp3", "audio/x-m4a", "audio/mp4", "audio/x-wav"];
 
 export default function UploadPage() {
+  const api = useApi();
   const [files, setFiles] = useState([]);
   const [model, setModel] = useState("tiny");
   const [status, setStatus] = useState(null);
@@ -79,17 +81,8 @@ const handleNewJob = () => {
         });
 
       try {
-        const res = await fetch(`${import.meta.env.VITE_API_HOST}/jobs`, { method: "POST", body: formData });
-        let data = {};
-        try {
-          data = await res.json();
-        } catch {
-          setStatus(`❌ ${file.name}: Invalid JSON response`);
-          updateJob({ status: "❌ Invalid JSON response" });
-          continue;
-        }
-
-        if (res.ok && data.job_id) {
+        const data = await api.post("/jobs", formData);
+        if (data.job_id) {
           setStatus(`✅ Job started: ${file.name}`);
           setJobId(data.job_id);
           setShowNewJobBtn(true);


### PR DESCRIPTION
## Summary
- add `AuthContext` for managing auth token
- provide `useApi` helper with automatic Authorization header
- replace direct fetch calls across pages with API helpers

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685dad8c46388325b5097e3607dfd14c