### PR TITLE
Remove forced style banner

### DIFF
--- a/frontend/src/pages/TranscriptViewPage.jsx
+++ b/frontend/src/pages/TranscriptViewPage.jsx
@@ -22,17 +22,6 @@ export default function TranscriptViewPage() {
 
   return (
     <div style={{ padding: "1.5rem", color: "white" }}>
-      <div
-        style={{
-          backgroundColor: "red",
-          color: "white",
-          padding: "1rem",
-          borderRadius: "0.5rem",
-          marginBottom: "1rem"
-        }}
-      >
-        🧪 Forced Style Test — no Tailwind involved
-      </div>
 
       <h1 style={{ fontSize: "1.5rem", fontWeight: "bold", marginBottom: "1rem" }}>
         Transcript Viewer


### PR DESCRIPTION
## Summary
- clean up TranscriptViewPage by removing the Forced Style Test banner

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db3166d84832593c7edd612c37a26