### PR TITLE
Refactor job tests to generate wav on the fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ logs/
 *.orig
 *.rej
 models/
+tests/assets/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+black

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import wave
+import pytest
+
+
+@pytest.fixture
+def sample_wav(tmp_path):
+    path = tmp_path / "sample.wav"
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # 16-bit samples
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 16000)  # 1 second of silence
+    return path

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,66 @@
+import os
+import importlib
+from fastapi.testclient import TestClient
+
+from api import models, orm_bootstrap
+
+
+def create_test_app(tmp_path):
+    os.environ["DB"] = str(tmp_path / "test.db")
+    importlib.reload(orm_bootstrap)
+    models.Base.metadata.create_all(orm_bootstrap.engine)
+
+    from api import app_state
+    from api import paths
+
+    paths.UPLOAD_DIR = tmp_path / "uploads"
+    paths.TRANSCRIPTS_DIR = tmp_path / "transcripts"
+    paths.LOG_DIR = tmp_path / "logs"
+    for p in (paths.UPLOAD_DIR, paths.TRANSCRIPTS_DIR, paths.LOG_DIR):
+        p.mkdir(parents=True, exist_ok=True)
+
+    app_state.UPLOAD_DIR = paths.UPLOAD_DIR
+    app_state.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    app_state.LOG_DIR = paths.LOG_DIR
+
+    app_state.handle_whisper = lambda *a, **k: None
+
+    from api.routes import jobs
+
+    importlib.reload(jobs)
+
+    jobs.SessionLocal = orm_bootstrap.SessionLocal
+    jobs.UPLOAD_DIR = paths.UPLOAD_DIR
+    jobs.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    jobs.LOG_DIR = paths.LOG_DIR
+    jobs.handle_whisper = app_state.handle_whisper
+
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(jobs.router)
+    return app
+
+
+def test_submit_and_fetch_job(tmp_path, sample_wav):
+    app = create_test_app(tmp_path)
+    client = TestClient(app)
+
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/jobs",
+            data={"model": "base"},
+            files={"file": ("test.wav", f, "audio/wav")},
+        )
+
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    resp = client.get(f"/jobs/{job_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["id"] == job_id
+    assert data["original_filename"] == "test.wav"
+    assert data["model"] == "base"
+    assert data["status"] == "queued"


### PR DESCRIPTION
## Summary
- ignore generated test wav assets
- add `sample_wav` fixture for creating a temporary WAV file
- update job tests to use the new fixture
- add `requirements-dev.txt` for test dependencies

## Testing
- `black .`
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'fastapi'`)*
- `pip install -r requirements.txt` *(fails: could not install packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685dd0dbc7d48325a4a0f1eeffab916b