### PR TITLE
Expand test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ The compose file mounts the `uploads`, `transcripts` and `logs` directories so
 data persists between runs. Once running, access the API at
 `http://localhost:8000`.
 
+## Testing
+
+Install the development requirements and run the test suite with coverage:
+
+```bash
+pip install -r requirements-dev.txt
+coverage run -m pytest
+coverage report
+```
+
 
 ## Contributing
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 pytest
 httpx
 black
+pytest-asyncio
+coverage

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,26 @@
+from api.routes import auth
+
+
+def test_register_and_token(client):
+    client.app.dependency_overrides.clear()
+    resp = client.post("/register", data={"username": "alice", "password": "pw"})
+    assert resp.status_code == 201
+    token = resp.json()["access_token"]
+    assert token
+
+    resp = client.post("/token", data={"username": "alice", "password": "pw"})
+    assert resp.status_code == 200
+    assert resp.json()["access_token"]
+
+
+def test_protected_endpoint_requires_auth(client):
+    client.app.dependency_overrides.clear()
+    resp = client.get("/metrics")
+    assert resp.status_code == 401
+
+    client.post("/register", data={"username": "bob", "password": "pw"})
+    token = client.post("/token", data={"username": "bob", "password": "pw"}).json()[
+        "access_token"
+    ]
+    resp = client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from api.orm_bootstrap import SessionLocal
+from api.models import Job, JobStatusEnum
+from api.paths import TRANSCRIPTS_DIR
+
+
+def test_job_lifecycle(client, sample_wav):
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/jobs",
+            data={"model": "base"},
+            files={"file": ("test.wav", f, "audio/wav")},
+        )
+    assert resp.status_code == 202
+    job_id = resp.json()["job_id"]
+
+    resp = client.get("/jobs")
+    assert any(j["id"] == job_id for j in resp.json())
+
+    resp = client.get(f"/jobs/{job_id}")
+    assert resp.status_code == 200
+
+    resp = client.post(f"/jobs/{job_id}/restart")
+    assert resp.json()["status"] == "restarted"
+
+    transcript = TRANSCRIPTS_DIR / job_id / "out.srt"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text("1\n00:00:00,000 --> 00:00:01,000\nHello\n")
+    with SessionLocal() as db:
+        job = db.query(Job).get(job_id)
+        job.status = JobStatusEnum.COMPLETED
+        job.transcript_path = str(transcript)
+        db.commit()
+
+    resp = client.get(f"/jobs/{job_id}/download")
+    assert resp.status_code == 200
+    assert "attachment" in resp.headers.get("content-disposition", "")
+
+    resp = client.delete(f"/jobs/{job_id}")
+    assert resp.json()["status"] == "deleted"
+    with SessionLocal() as db:
+        assert db.query(Job).get(job_id) is None

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,32 @@
+import pickle
+from unittest.mock import patch
+
+from api.services.job_queue import ThreadJobQueue, BrokerJobQueue
+
+
+def test_thread_job_queue_executes_job():
+    calls = []
+
+    def task():
+        calls.append(1)
+
+    q = ThreadJobQueue(1)
+    q.enqueue(task)
+    q.join()
+    assert calls == [1]
+
+
+def sample_task():
+    return 42
+
+
+def test_broker_job_queue_sends_task():
+    with patch("api.services.celery_app.celery_app.send_task") as send_task:
+        q = BrokerJobQueue()
+        q.enqueue(sample_task)
+        send_task.assert_called_once()
+        name = send_task.call_args.args[0]
+        payload = send_task.call_args.kwargs["args"][0]
+        func = pickle.loads(payload)
+        assert name == "run_callable"
+        assert func is sample_task


### PR DESCRIPTION
## Summary
- add coverage and pytest-asyncio to dev requirements
- extend test fixtures for temporary DB, paths, and auth override
- add auth and job lifecycle tests
- cover thread and Celery job queues
- document running tests

## Testing
- `black .`
- `coverage run -m pytest` *(fails: coverage not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685dd53a8f408325b3192d74f1580f0d