### PR TITLE
Add role-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,17 @@ application can be served with the backend.
 ### User Registration
 
 Create an account by sending your desired username and password to `/register`.
-Set `ALLOW_REGISTRATION=false` in production to disable this endpoint. Obtain a
-token from `/token` using the same credentials.
+Every account has a role of either `user` or `admin`. Registration always
+creates regular users. Set `ALLOW_REGISTRATION=false` in production to disable
+this endpoint. Obtain a token from `/token` using the same credentials. JWT
+payloads now include the user role so clients can inspect their privileges.
 
 ## Metrics
 
 
-The backend exposes Prometheus metrics at `/metrics`. Authenticate with the JWT
-token obtained from the `/token` endpoint and send it as `Authorization: Bearer
-<token>`.
+The backend exposes Prometheus metrics at `/metrics`. This and all `/admin`
+endpoints require an `admin` role. Authenticate with the JWT token obtained from
+the `/token` endpoint and send it as `Authorization: Bearer <token>`.
 
 ### Health & Version
 

--- a/api/migrations/versions/e0c45e6cf3db_add_role_column_to_user.py
+++ b/api/migrations/versions/e0c45e6cf3db_add_role_column_to_user.py
@@ -1,0 +1,29 @@
+"""Add role column to users
+
+Revision ID: e0c45e6cf3db
+Revises: 8f53d7a793bb
+Create Date: 2025-06-26
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e0c45e6cf3db"
+down_revision: Union[str, None] = "8f53d7a793bb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add role column with default 'user'."""
+    op.add_column(
+        "users", sa.Column("role", sa.String(), nullable=False, server_default="user")
+    )
+    op.alter_column("users", "role", server_default=None)
+
+
+def downgrade() -> None:
+    """Remove role column."""
+    op.drop_column("users", "role")

--- a/api/models.py
+++ b/api/models.py
@@ -19,6 +19,7 @@ class User(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     username: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
+    role: Mapped[str] = mapped_column(String, nullable=False, default="user")
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False
     )

--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect, Depends
 from api.routes.auth import get_current_user
+from api.models import User
 import asyncio
 from fastapi.responses import PlainTextResponse
 
@@ -21,7 +22,7 @@ def get_job_log(job_id: str):
 
 @router.websocket("/ws/logs/{job_id}")
 async def websocket_job_log(
-    websocket: WebSocket, job_id: str, user: str = Depends(get_current_user)
+    websocket: WebSocket, job_id: str, user: User = Depends(get_current_user)
 ):
     await websocket.accept()
     log_path = LOG_DIR / f"{job_id}.log"

--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Response, Request, Depends
-from api.routes.auth import get_current_user
+from api.routes.auth import require_admin
 
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 
@@ -7,7 +7,7 @@ router = APIRouter()
 
 
 @router.get("/metrics")
-def metrics(request: Request, user: str = Depends(get_current_user)) -> Response:
+def metrics(request: Request, user=Depends(require_admin)) -> Response:
     """Return Prometheus metrics."""
     data = generate_latest(REGISTRY)
     return Response(content=data, media_type=CONTENT_TYPE_LATEST)

--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -6,6 +6,7 @@ from typing import Dict, Set
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
 
 from api.routes.auth import get_current_user
+from api.models import User
 
 router = APIRouter()
 
@@ -41,7 +42,7 @@ def send_progress_update(job_id: str, status: str) -> None:
 
 @router.websocket("/ws/progress/{job_id}")
 async def websocket_progress(
-    websocket: WebSocket, job_id: str, user: str = Depends(get_current_user)
+    websocket: WebSocket, job_id: str, user: User = Depends(get_current_user)
 ) -> None:
     await websocket.accept()
     progress_connections.setdefault(job_id, set()).add(websocket)

--- a/api/routes/tests/test_progress.py
+++ b/api/routes/tests/test_progress.py
@@ -3,9 +3,16 @@ from fastapi.testclient import TestClient
 from api.main import app
 from api.routes.progress import send_progress_update
 from api.routes.auth import get_current_user
-from api.models import JobStatusEnum
+from api.models import JobStatusEnum, User
+from datetime import datetime
 
-app.dependency_overrides[get_current_user] = lambda: "testuser"
+app.dependency_overrides[get_current_user] = lambda: User(
+    id=1,
+    username="testuser",
+    hashed_password="hash",
+    role="user",
+    created_at=datetime.utcnow(),
+)
 client = TestClient(app)
 
 

--- a/api/services/users.py
+++ b/api/services/users.py
@@ -12,13 +12,16 @@ from api.app_state import db_lock
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def create_user(username: str, password: str) -> User:
+def create_user(username: str, password: str, role: str = "user") -> User:
     """Create and persist a new user."""
     hashed = pwd_context.hash(password)
     with db_lock:
         with SessionLocal() as db:
             user = User(
-                username=username, hashed_password=hashed, created_at=datetime.utcnow()
+                username=username,
+                hashed_password=hashed,
+                role=role,
+                created_at=datetime.utcnow(),
             )
             db.add(user)
             db.commit()

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -70,7 +70,7 @@ object used throughout the code base. Available variables are:
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.
 - **Admin actions** under `/admin` allow listing and deleting files, downloading all artifacts, resetting the system, and retrieving basic stats.
 - **Logging endpoints** expose job logs and the access log. If the access log does not exist, `/logs/access` returns a `404` with an empty body. Static files under `/uploads`, `/transcripts`, and `/static` are served directly.
-- **Authentication**: obtain tokens via `/token` using credentials stored in the `users` table. Accounts can be created through `/register` when enabled.
+- **Authentication**: obtain tokens via `/token` using credentials stored in the `users` table. Accounts can be created through `/register` when enabled. Each user has a `role` of `admin` or `user`. The `/admin` and `/metrics` routes are restricted to admins.
 
 ## Migrations and Logging
 - Database schema migrations are managed with Alembic in `api/migrations/`. The `env.py` file loads `Base.metadata` so new models are detected automatically. Migration scripts live in `api/migrations/versions/`.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,7 @@
 from api.routes import auth
+from api.services.users import create_user
+from jose import jwt
+from api.settings import settings
 
 
 def test_register_and_token(client):
@@ -6,11 +9,14 @@ def test_register_and_token(client):
     resp = client.post("/register", data={"username": "alice", "password": "pw"})
     assert resp.status_code == 201
     token = resp.json()["access_token"]
-    assert token
+    payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+    assert payload["role"] == "user"
 
     resp = client.post("/token", data={"username": "alice", "password": "pw"})
     assert resp.status_code == 200
-    assert resp.json()["access_token"]
+    token2 = resp.json()["access_token"]
+    payload2 = jwt.decode(token2, settings.secret_key, algorithms=[settings.algorithm])
+    assert payload2["role"] == "user"
 
 
 def test_protected_endpoint_requires_auth(client):
@@ -23,4 +29,11 @@ def test_protected_endpoint_requires_auth(client):
         "access_token"
     ]
     resp = client.get("/metrics", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+    create_user("admin", "pw", role="admin")
+    admin_token = client.post(
+        "/token", data={"username": "admin", "password": "pw"}
+    ).json()["access_token"]
+    resp = client.get("/metrics", headers={"Authorization": f"Bearer {admin_token}"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add `role` column to User model and migration
- include role claim in JWT tokens
- require admin role for metrics and /admin endpoints
- ensure test fixtures produce User objects
- update documentation for role-based auth

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dd83f0dbc83259dc4a931ec9628a6