### PR TITLE
Document cleanup variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `S3_BUCKET` – name of the bucket to store uploads and transcripts.
 - `CELERY_BROKER_URL` and `CELERY_BACKEND_URL` – message broker and result
   backend used when `JOB_QUEUE_BACKEND` is set to `broker`.
+- `CLEANUP_ENABLED` – toggle periodic cleanup of old transcripts. Defaults to
+  `true`.
+- `CLEANUP_DAYS` – how many days to keep transcripts when cleanup is enabled
+  (defaults to `30`).
 
 Configuration values are provided by `api/settings.py` using Pydantic's
 `BaseSettings`. An instance named `settings` is imported by the rest of the

--- a/api/settings.py
+++ b/api/settings.py
@@ -29,6 +29,8 @@ class Settings(BaseSettings):
         "amqp://guest:guest@broker:5672//", env="CELERY_BROKER_URL"
     )
     celery_backend_url: str = Field("rpc://", env="CELERY_BACKEND_URL")
+    cleanup_enabled: bool = Field(True, env="CLEANUP_ENABLED")
+    cleanup_days: int = Field(30, env="CLEANUP_DAYS")
 
     # Not configurable via environment
     algorithm: str = "HS256"

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -65,6 +65,9 @@ object used throughout the code base. Available variables are:
 - `S3_BUCKET` – name of the bucket used by `CloudStorage`.
 - `CELERY_BROKER_URL` and `CELERY_BACKEND_URL` – URLs for the broker and
   result backend when using the `broker` queue backend.
+- `CLEANUP_ENABLED` – toggle periodic cleanup of old transcripts (default `true`).
+- `CLEANUP_DAYS` – number of days to retain transcripts when cleanup is enabled
+  (defaults to `30`).
 
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.


### PR DESCRIPTION
## Summary
- add `cleanup_enabled` and `cleanup_days` settings
- document cleanup environment variables in README and docs

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685ddc769a30832591851f79357d74d7