### PR TITLE
Add cleanup config API endpoints

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -97,3 +97,16 @@ class TranscriptMetadata(Base):
 
     def __repr__(self):
         return f"<Metadata job_id={self.job_id} tokens={self.tokens} duration={self.duration}>"
+
+
+# ─── Simple Config Table ─────────────────────────────────────────────────────
+class ConfigEntry(Base):
+    """Key/value storage for small configuration items."""
+
+    __tablename__ = "config"
+
+    key: Mapped[str] = mapped_column(String, primary_key=True)
+    value: Mapped[str] = mapped_column(String, nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<Config {self.key}={self.value}>"

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -65,3 +65,13 @@ class AdminStatsOut(BaseModel):
 class TokenOut(BaseModel):
     access_token: str
     token_type: str
+
+
+class CleanupConfigOut(BaseModel):
+    cleanup_enabled: bool
+    cleanup_days: int
+
+
+class CleanupConfigIn(BaseModel):
+    cleanup_enabled: Optional[bool] = None
+    cleanup_days: Optional[int] = None

--- a/api/services/config.py
+++ b/api/services/config.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from api.models import ConfigEntry
+from api.orm_bootstrap import SessionLocal
+from api.app_state import db_lock
+
+
+def get_value(key: str) -> Optional[str]:
+    with SessionLocal() as db:
+        entry = db.query(ConfigEntry).filter_by(key=key).first()
+        return entry.value if entry else None
+
+
+def set_value(key: str, value: str) -> None:
+    with db_lock:
+        with SessionLocal() as db:
+            entry = db.query(ConfigEntry).filter_by(key=key).first()
+            if entry:
+                entry.value = value
+            else:
+                entry = ConfigEntry(key=key, value=value)
+                db.add(entry)
+            db.commit()
+
+
+def get_cleanup_config(default_enabled: bool, default_days: int) -> dict:
+    enabled = get_value("cleanup_enabled")
+    days = get_value("cleanup_days")
+    return {
+        "cleanup_enabled": default_enabled if enabled is None else enabled == "1",
+        "cleanup_days": default_days if days is None else int(days),
+    }
+
+
+def update_cleanup_config(
+    enabled: Optional[bool],
+    days: Optional[int],
+    *,
+    default_enabled: bool,
+    default_days: int,
+) -> dict:
+    if enabled is not None:
+        set_value("cleanup_enabled", "1" if enabled else "0")
+        default_enabled = enabled
+    if days is not None:
+        set_value("cleanup_days", str(days))
+        default_days = days
+    return {
+        "cleanup_enabled": default_enabled,
+        "cleanup_days": default_days,
+    }

--- a/tests/test_admin_cleanup_config.py
+++ b/tests/test_admin_cleanup_config.py
@@ -1,0 +1,69 @@
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import paths, app_state
+from api.routes import admin, auth
+from api.services.job_queue import ThreadJobQueue
+from api.services.users import create_user
+from api.services import config as config_service
+
+
+@pytest.fixture
+def admin_client(temp_db, temp_dirs):
+    importlib.reload(app_state)
+    app_state.job_queue = ThreadJobQueue(1)
+    app_state.handle_whisper = lambda *a, **k: None
+    app_state.UPLOAD_DIR = paths.UPLOAD_DIR
+    app_state.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    app_state.LOG_DIR = paths.LOG_DIR
+
+    importlib.reload(admin)
+    admin.storage = paths.storage
+    admin.UPLOAD_DIR = paths.UPLOAD_DIR
+    admin.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    admin.LOG_DIR = paths.LOG_DIR
+
+    app = FastAPI()
+    for router in (admin.router, auth.router):
+        app.include_router(router)
+
+    client = TestClient(app)
+    yield client
+    app_state.job_queue.shutdown()
+
+
+def _token(client, username, password):
+    return client.post(
+        "/token", data={"username": username, "password": password}
+    ).json()["access_token"]
+
+
+def test_admin_update_persists(admin_client):
+    create_user("admin", "pw", role="admin")
+    token = _token(admin_client, "admin", "pw")
+
+    resp = admin_client.post(
+        "/admin/cleanup-config",
+        json={"cleanup_enabled": False, "cleanup_days": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"cleanup_enabled": False, "cleanup_days": 5}
+
+    values = config_service.get_cleanup_config(True, 30)
+    assert values == {"cleanup_enabled": False, "cleanup_days": 5}
+
+
+def test_non_admin_forbidden(admin_client):
+    create_user("bob", "pw", role="user")
+    token = _token(admin_client, "bob", "pw")
+
+    resp = admin_client.post(
+        "/admin/cleanup-config",
+        json={"cleanup_enabled": False, "cleanup_days": 5},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- allow storing cleanup settings in database
- expose `/admin/cleanup-config` GET/POST endpoints
- restrict updates to admin role only
- test persistence and permissions

## Testing
- `black .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685de01d214883258c1dedbd5d3bca1d