### PR TITLE
Implement settings page with role-based user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ creates regular users. Set `ALLOW_REGISTRATION=false` in production to disable
 this endpoint. Obtain a token from `/token` using the same credentials. JWT
 payloads now include the user role so clients can inspect their privileges.
 
+### User Management
+
+Admins can manage accounts via two endpoints:
+
+- `GET /users` lists all users.
+- `PUT /users/{id}` updates a user's role.
+
+The React Settings page at `/settings` provides a simple interface for these actions.
+
 ## Metrics
 
 
@@ -132,6 +141,7 @@ build variable or by storing a `downloadFormat` value in `localStorage`.
 - Real-time job status messages appear in the UI via the progress WebSocket with
   friendlier labels for each state.
 - Toast notifications show the result of actions across all pages.
+- Admins can manage user roles from the Settings page.
 - `models/` exists locally only and is never stored in Git. It must contain the Whisper `.pt` files before building or running the app. Ensure the files are present before building the Docker image.
 - `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are

--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from api.routes import jobs, admin, logs, metrics, auth
+from api.routes import jobs, admin, logs, metrics, auth, users
 from api.routes import progress
 from api.paths import storage, UPLOAD_DIR, TRANSCRIPTS_DIR
 from api.app_state import backend_log
@@ -18,6 +18,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(progress.router)
     app.include_router(metrics.router)
     app.include_router(auth.router)
+    app.include_router(users.router)
 
     app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
     app.mount(

--- a/api/routes/users.py
+++ b/api/routes/users.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.routes.auth import require_admin
+from api.services.users import list_users, update_user_role
+from api.schemas import UserListOut, UserOut, UserUpdateIn
+
+router = APIRouter(prefix="/users")
+
+
+@router.get("", response_model=UserListOut)
+def get_users(user=Depends(require_admin)) -> UserListOut:
+    users = list_users()
+    return UserListOut(users=users)
+
+
+@router.put("/{user_id}", response_model=UserOut)
+def change_role(
+    user_id: int, payload: UserUpdateIn, user=Depends(require_admin)
+) -> UserOut:
+    updated = update_user_role(user_id, payload.role)
+    if not updated:
+        raise HTTPException(status_code=404, detail="User not found")
+    return updated

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -75,3 +75,20 @@ class CleanupConfigOut(BaseModel):
 class CleanupConfigIn(BaseModel):
     cleanup_enabled: Optional[bool] = None
     cleanup_days: Optional[int] = None
+
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    role: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserListOut(BaseModel):
+    users: list[UserOut]
+
+
+class UserUpdateIn(BaseModel):
+    role: str

--- a/api/services/users.py
+++ b/api/services/users.py
@@ -38,3 +38,22 @@ def get_user_by_username(username: str) -> Optional[User]:
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     """Return True if password matches hashed password."""
     return pwd_context.verify(plain_password, hashed_password)
+
+
+def list_users() -> list[User]:
+    """Return all users."""
+    with SessionLocal() as db:
+        return db.query(User).order_by(User.id).all()
+
+
+def update_user_role(user_id: int, role: str) -> Optional[User]:
+    """Update a user's role and return the updated user or None."""
+    with db_lock:
+        with SessionLocal() as db:
+            user = db.query(User).get(user_id)
+            if not user:
+                return None
+            user.role = role
+            db.commit()
+            db.refresh(user)
+            return user

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -106,7 +106,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | Sortable job table component                                        | Open   | Track jobs more easily            | Table library, UI state         | None                        |
 | Notification/toast system                                           | Done   | Surface status messages          | Auto-dismiss timing             | None                        |
 | Admin dashboard KPIs                                                | Open   | Monitor throughput               | Metrics queries                 | None                        |
-| Role-based auth with settings page                                  | Open   | Restrict features per role       | Session handling, UI            | User management complexity    |
+| Role-based auth with settings page                                  | Done   | Restrict features per role       | Session handling, UI            | User management complexity    |
 | Download job archive (.zip)                                          | Open      | Zip existing logs and results    | Avoid large file memory use     | None                          |
 | Support `.vtt` transcript export                                     | Done      | Convert from SRT to VTT          | Extra dependency for conversion | None                          |
 | Provide CLI wrapper for non-UI usage                                 | On Hold      | Wrapper script around API calls  | Package distribution            | None                          |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ROUTES } from "./routes";
 import UploadPage from "./pages/UploadPage";
 import CompletedJobsPage from "./pages/CompletedJobsPage";
 import AdminPage from "./pages/AdminPage";
+import SettingsPage from "./pages/SettingsPage";
 import ActiveJobsPage from "./pages/ActiveJobsPage";
 import TranscriptViewPage from "./pages/TranscriptViewPage";
 import JobStatusPage from "./pages/JobStatusPage";
@@ -23,7 +24,7 @@ export default function App() {
     }).catch(() => {});
   }, []);
 
-  const { isAuthenticated } = useContext(AuthContext);
+  const { isAuthenticated, role } = useContext(AuthContext);
 
   return (
     <Router>
@@ -35,6 +36,7 @@ export default function App() {
           <Route path={ROUTES.ACTIVE} element={isAuthenticated ? <ActiveJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.COMPLETED} element={isAuthenticated ? <CompletedJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.ADMIN} element={isAuthenticated ? <AdminPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
+          <Route path={ROUTES.SETTINGS} element={isAuthenticated && role === "admin" ? <SettingsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.TRANSCRIPT_VIEW} element={isAuthenticated ? <TranscriptViewPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.STATUS} element={isAuthenticated ? <JobStatusPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.FAILED} element={isAuthenticated ? <FailedJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -5,7 +5,7 @@ import { AuthContext } from "../context/AuthContext";
 import ToastContainer from "./ToastContainer";
 
 export default function Layout({ children }) {
-  const { logout, isAuthenticated } = useContext(AuthContext);
+  const { logout, isAuthenticated, role } = useContext(AuthContext);
 
   const handleLogout = () => {
     logout();
@@ -40,6 +40,11 @@ export default function Layout({ children }) {
         <Link to={ROUTES.ADMIN} style={linkStyle}>
           Admin
         </Link>
+        {role === "admin" && (
+          <Link to={ROUTES.SETTINGS} style={linkStyle}>
+            Settings
+          </Link>
+        )}
         {isAuthenticated ? (
           <button onClick={handleLogout} style={linkStyle}>
             Logout

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,15 @@
 import { createContext, useState, useEffect } from "react";
 
+function getRole(token) {
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return payload.role;
+  } catch {
+    return null;
+  }
+}
+
 export const AuthContext = createContext({
   token: null,
   login: () => {},
@@ -9,26 +19,31 @@ export const AuthContext = createContext({
 
 export function AuthProvider({ children }) {
   const [token, setToken] = useState(() => localStorage.getItem("token"));
+  const [role, setRole] = useState(() => getRole(localStorage.getItem("token")));
 
   const login = (newToken) => {
     setToken(newToken);
+    setRole(getRole(newToken));
   };
 
   const logout = () => {
     setToken(null);
+    setRole(null);
   };
 
   useEffect(() => {
     if (token) {
       localStorage.setItem("token", token);
+      setRole(getRole(token));
     } else {
       localStorage.removeItem("token");
+      setRole(null);
     }
   }, [token]);
 
   return (
     <AuthContext.Provider
-      value={{ token, login, logout, isAuthenticated: Boolean(token) }}
+      value={{ token, role, login, logout, isAuthenticated: Boolean(token) }}
     >
       {children}
     </AuthContext.Provider>

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useApi } from "../api";
+import { addToast } from "../store";
+import { Table, Th, Td } from "../components/Table";
+
+export default function SettingsPage() {
+  const api = useApi();
+  const dispatch = useDispatch();
+  const [users, setUsers] = useState([]);
+
+  const loadUsers = async () => {
+    try {
+      const data = await api.get("/users");
+      setUsers(data.users || []);
+    } catch {
+      dispatch(addToast("Failed to load users", "error"));
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const toggleRole = async (user) => {
+    const newRole = user.role === "admin" ? "user" : "admin";
+    try {
+      await api.put(`/users/${user.id}`, { role: newRole });
+      dispatch(addToast("Role updated", "success"));
+      loadUsers();
+    } catch {
+      dispatch(addToast("Failed to update role", "error"));
+    }
+  };
+
+  return (
+    <div className="page-content" style={{ minHeight: "100vh", backgroundColor: "#18181b", color: "white" }}>
+      <h2 style={{ fontSize: "1.25rem", marginBottom: "1rem" }}>User Management</h2>
+      <Table>
+        <thead style={{ backgroundColor: "#27272a" }}>
+          <tr>
+            <Th>Username</Th>
+            <Th>Role</Th>
+            <Th>Created</Th>
+            <Th>Actions</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              <Td>{u.username}</Td>
+              <Td>{u.role}</Td>
+              <Td>{new Date(u.created_at).toLocaleString()}</Td>
+              <Td>
+                <button
+                  onClick={() => toggleRole(u)}
+                  style={{ backgroundColor: "#2563eb", color: "white", border: "none", padding: "0.25rem 0.5rem", borderRadius: "0.25rem", cursor: "pointer" }}
+                >
+                  Make {u.role === "admin" ? "User" : "Admin"}
+                </button>
+              </Td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -5,6 +5,7 @@ export const ROUTES = {
   COMPLETED: "/completed",
   FAILED: "/failed",
   ADMIN: "/admin",
+  SETTINGS: "/settings",
   TRANSCRIPT_VIEW: "/transcript/:jobId/view",
   STATUS: "/status/:jobId",
   PROGRESS: "/progress/:jobId",


### PR DESCRIPTION
## Summary
- add `/users` API endpoints for listing and updating roles
- register new router
- provide React Settings page for admin role management
- expose settings route and parse role from JWT
- document settings functionality
- mark role-based settings feature as done

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dea628a388325b918f7ca08f76b3f