### PR TITLE
Add server control flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
   `true`.
 - `CLEANUP_DAYS` – how many days to keep transcripts when cleanup is enabled
   (defaults to `30`).
+- `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
+  endpoints (defaults to `false`).
 
 Configuration values are provided by `api/settings.py` using Pydantic's
 `BaseSettings`. An instance named `settings` is imported by the rest of the

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 import io
 import shutil
@@ -105,6 +105,12 @@ def admin_stats(user=Depends(require_admin)) -> AdminStatsOut:
 def shutdown_server(user=Depends(require_admin)) -> StatusOut:
     """Shut down the running server process."""
 
+    if not settings.enable_server_control:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Server control disabled",
+        )
+
     def _exit():
         os._exit(0)
 
@@ -115,6 +121,12 @@ def shutdown_server(user=Depends(require_admin)) -> StatusOut:
 @router.post("/restart", response_model=StatusOut)
 def restart_server(user=Depends(require_admin)) -> StatusOut:
     """Restart the running server process."""
+
+    if not settings.enable_server_control:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Server control disabled",
+        )
 
     def _restart():
         os.execv(sys.executable, [sys.executable] + sys.argv)

--- a/api/settings.py
+++ b/api/settings.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     celery_backend_url: str = Field("rpc://", env="CELERY_BACKEND_URL")
     cleanup_enabled: bool = Field(True, env="CLEANUP_ENABLED")
     cleanup_days: int = Field(30, env="CLEANUP_DAYS")
+    enable_server_control: bool = Field(False, env="ENABLE_SERVER_CONTROL")
 
     # Not configurable via environment
     algorithm: str = "HS256"

--- a/tests/test_admin_server_control.py
+++ b/tests/test_admin_server_control.py
@@ -1,0 +1,64 @@
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import paths, app_state
+from api.routes import admin, auth
+from api.services.job_queue import ThreadJobQueue
+from api.services.users import create_user
+from api.settings import settings
+
+
+@pytest.fixture
+def admin_client(temp_db, temp_dirs, monkeypatch):
+    importlib.reload(app_state)
+    monkeypatch.setattr(settings, "enable_server_control", False)
+    app_state.job_queue = ThreadJobQueue(1)
+    app_state.handle_whisper = lambda *a, **k: None
+    app_state.UPLOAD_DIR = paths.UPLOAD_DIR
+    app_state.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    app_state.LOG_DIR = paths.LOG_DIR
+
+    importlib.reload(admin)
+    admin.storage = paths.storage
+    admin.UPLOAD_DIR = paths.UPLOAD_DIR
+    admin.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    admin.LOG_DIR = paths.LOG_DIR
+
+    app = FastAPI()
+    for router in (admin.router, auth.router):
+        app.include_router(router)
+
+    client = TestClient(app)
+    yield client
+    app_state.job_queue.shutdown()
+
+
+def _token(client, username, password):
+    return client.post(
+        "/token", data={"username": username, "password": password}
+    ).json()["access_token"]
+
+
+def test_shutdown_forbidden(admin_client):
+    create_user("admin", "pw", role="admin")
+    token = _token(admin_client, "admin", "pw")
+
+    resp = admin_client.post(
+        "/admin/shutdown",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_restart_forbidden(admin_client):
+    create_user("admin", "pw", role="admin")
+    token = _token(admin_client, "admin", "pw")
+
+    resp = admin_client.post(
+        "/admin/restart",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add ENABLE_SERVER_CONTROL setting
- protect /admin/shutdown and /admin/restart
- document new environment variable
- test that server control endpoints return 403 when disabled

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ded24197c8325b8544d75f9dac4a0