### PR TITLE
Remove metrics token configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
 - `LOG_TO_STDOUT` – set to `true` to also mirror logs to the console.
-- `METRICS_TOKEN` – optional bearer token required to access `/metrics`.
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
 - `SECRET_KEY` – secret used to sign JWT tokens.

--- a/api/config.py
+++ b/api/config.py
@@ -34,9 +34,6 @@ JOB_QUEUE_BACKEND = os.getenv("JOB_QUEUE_BACKEND", "thread")
 # providers. Only 'local' is implemented here.
 STORAGE_BACKEND = os.getenv("STORAGE_BACKEND", "local")
 
-# Optional token required to access the /metrics endpoint
-METRICS_TOKEN = os.getenv("METRICS_TOKEN")
-
 # Authentication settings
 AUTH_USERNAME = os.getenv("AUTH_USERNAME", "admin")
 AUTH_PASSWORD = os.getenv("AUTH_PASSWORD", "admin")

--- a/api/settings.py
+++ b/api/settings.py
@@ -13,7 +13,6 @@ class Settings(BaseSettings):
     vite_api_host: str = Field("http://localhost:8000", env="VITE_API_HOST")
     log_level: str = Field("DEBUG", env="LOG_LEVEL")
     log_to_stdout: bool = Field(False, env="LOG_TO_STDOUT")
-    metrics_token: str | None = Field(None, env="METRICS_TOKEN")
     allow_registration: bool = Field(True, env="ALLOW_REGISTRATION")
     auth_username: str = Field("admin", env="AUTH_USERNAME")
     auth_password: str = Field("admin", env="AUTH_PASSWORD")

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -52,7 +52,6 @@ object used throughout the code base. Available variables are:
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – log level for backend loggers.
 - `LOG_TO_STDOUT` – mirror logs to the console when `true`.
-- `METRICS_TOKEN` – optional bearer token for `/metrics`.
 - `AUTH_USERNAME` / `AUTH_PASSWORD` – *(deprecated)* old static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint.
 - `SECRET_KEY` – secret for JWT signing.


### PR DESCRIPTION
## Summary
- drop `metrics_token` from settings and legacy config
- remove `METRICS_TOKEN` from docs and README

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685df0dd2ea48325aa23868acab99621