### PR TITLE
Add Prometheus job queue metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ The backend exposes Prometheus metrics at `/metrics`. This and all `/admin`
 endpoints require an `admin` role. Authenticate with the JWT token obtained from
 the `/token` endpoint and send it as `Authorization: Bearer <token>`.
 
+Available metrics:
+
+- `jobs_queued_total` – Counter of jobs submitted to the queue
+- `jobs_in_progress` – Gauge tracking currently executing jobs
+- `job_duration_seconds` – Histogram of job execution time
+
 ### Health & Version
 
 Use `/health` to check server status. `/version` returns the current application version.

--- a/api/routes/metrics.py
+++ b/api/routes/metrics.py
@@ -3,6 +3,9 @@ from api.routes.auth import require_admin
 
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
 
+# Import metrics so they are registered on startup
+from api.services import job_queue  # noqa: F401
+
 router = APIRouter()
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,11 +1,20 @@
 import pickle
 from unittest.mock import patch
 
-from api.services.job_queue import ThreadJobQueue, BrokerJobQueue
+from api.services.job_queue import (
+    ThreadJobQueue,
+    BrokerJobQueue,
+    jobs_queued_total,
+    jobs_in_progress,
+    job_duration_seconds,
+)
 
 
 def test_thread_job_queue_executes_job():
     calls = []
+
+    start_queued = jobs_queued_total._value.get()
+    start_duration = job_duration_seconds._count.get()
 
     def task():
         calls.append(1)
@@ -13,7 +22,11 @@ def test_thread_job_queue_executes_job():
     q = ThreadJobQueue(1)
     q.enqueue(task)
     q.join()
+
     assert calls == [1]
+    assert jobs_queued_total._value.get() == start_queued + 1
+    assert jobs_in_progress._value.get() == 0
+    assert job_duration_seconds._count.get() == start_duration + 1
 
 
 def sample_task():


### PR DESCRIPTION
## Summary
- track jobs queued, in progress and duration with Prometheus
- expose metrics by importing job_queue in metrics route
- verify metric updates in queue tests
- document available metrics

## Testing
- `black api/services/job_queue.py api/routes/metrics.py tests/test_queue.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685df32111808325bf4b9f198d0d39c4