### PR TITLE
Add Celery worker setup and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Start the backend with `uvicorn`:
 uvicorn api.main:app
 ```
 
+When `JOB_QUEUE_BACKEND` is set to `broker` a Celery worker must also be
+started:
+
+```bash
+python worker.py
+```
+
 To build the React frontend for production run:
 
 ```bash
@@ -214,6 +221,15 @@ Build and start all services with:
 ```bash
 docker compose up --build
 ```
+
+To use Celery for job processing, set `JOB_QUEUE_BACKEND=broker` and start the
+`worker` service defined in `docker-compose.yml`:
+
+```bash
+JOB_QUEUE_BACKEND=broker docker compose up --build api worker broker db
+```
+
+The worker container runs `python worker.py` and listens for tasks from RabbitMQ.
 
 The compose file mounts the `uploads`, `transcripts` and `logs` directories so
 data persists between runs. Once running, access the API at

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,18 @@ services:
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
 
+  worker:
+    build: .
+    command: python worker.py
+    environment:
+      - VITE_API_HOST=http://localhost:8000
+    volumes:
+      - ./uploads:/app/uploads
+      - ./transcripts:/app/transcripts
+      - ./logs:/app/logs
+    depends_on:
+      - broker
+
 volumes:
   db_data:
   rabbitmq_data:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -43,3 +43,15 @@ def test_broker_job_queue_sends_task():
         func = pickle.loads(payload)
         assert name == "run_callable"
         assert func is sample_task
+
+
+def test_broker_backend_dispatch(monkeypatch):
+    monkeypatch.setenv("JOB_QUEUE_BACKEND", "broker")
+    import importlib
+
+    with patch("api.services.celery_app.celery_app.send_task") as send_task:
+        import api.app_state as app_state
+
+        importlib.reload(app_state)
+        app_state.job_queue.enqueue(sample_task)
+        send_task.assert_called_once()

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,4 @@
+from api.services.celery_app import celery_app
+
+if __name__ == "__main__":
+    celery_app.worker_main()


### PR DESCRIPTION
## Summary
- add simple Celery worker script
- run worker from docker-compose
- document how to start Celery worker
- test dispatch when broker backend is selected

## Testing
- `black .`
- `coverage run -m pytest` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685df5fb230c8325951841a17c22c78e