### PR TITLE
Validate models directory during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY api         ./api
 COPY models      ./models
+RUN python -c "from api.utils.model_validation import validate_models_dir; validate_models_dir()"
 RUN mkdir -p uploads transcripts
 COPY frontend/dist ./api/static
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,10 @@ When `STORAGE_BACKEND=cloud`, these folders act as a cache and transcript files
 ## Docker Usage
 
 Docker builds expect a populated `models/` directory and the compiled
-`frontend/dist/` folder. Both directories are ignored by Git so they must be
-prepared manually before running `docker build`. Example:
+`frontend/dist/` folder. During the build the Python script
+`validate_models_dir()` checks the `models/` directory so missing Whisper
+models fail the build early. Both directories are ignored by Git so they must
+be prepared manually before running `docker build`. Example:
 ```bash
 cd frontend
 npm run build


### PR DESCRIPTION
## Summary
- validate Whisper model files during Docker build
- document model validation in Docker build instructions

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dff27d480832596f6e97e00379563