### PR TITLE
Update compose for Celery worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,18 +235,19 @@ Build and start all services with:
 docker compose up --build
 ```
 
-To use Celery for job processing, set `JOB_QUEUE_BACKEND=broker` and start the
-`worker` service defined in `docker-compose.yml`:
+The compose file mounts the `uploads`, `transcripts`, `logs` and `models`
+directories so data and models persist between runs. It also configures
+Celery with RabbitMQ by setting `JOB_QUEUE_BACKEND=broker`,
+`CELERY_BROKER_URL` and `CELERY_BACKEND_URL` on the API and worker services.
+
+Start everything with:
 
 ```bash
-JOB_QUEUE_BACKEND=broker docker compose up --build api worker broker db
+docker compose up --build api worker broker db
 ```
 
-The worker container runs `python worker.py` and listens for tasks from RabbitMQ.
-
-The compose file mounts the `uploads`, `transcripts` and `logs` directories so
-data persists between runs. Once running, access the API at
-`http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process
+jobs from RabbitMQ. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,14 @@ services:
       - "8000:8000"
     environment:
       - VITE_API_HOST=http://localhost:8000
+      - JOB_QUEUE_BACKEND=broker
+      - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
+      - CELERY_BACKEND_URL=rpc://
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts
       - ./logs:/app/logs
+      - ./models:/app/models:ro
     depends_on:
       - db
       - broker
@@ -34,9 +38,12 @@ services:
 
   worker:
     build: .
-    command: python worker.py
+    command: celery -A api.services.celery_app worker
     environment:
       - VITE_API_HOST=http://localhost:8000
+      - JOB_QUEUE_BACKEND=broker
+      - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
+      - CELERY_BACKEND_URL=rpc://
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts


### PR DESCRIPTION
## Summary
- mount `models/` in the API container and set Celery env vars
- run the worker with the Celery CLI
- describe compose usage in README

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dfff5b6e483258626176e4c523933