### PR TITLE
Update design scope docs

### DIFF
--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -71,10 +71,12 @@ object used throughout the code base. Available variables are:
 - `CLEANUP_ENABLED` – toggle periodic cleanup of old transcripts (default `true`).
 - `CLEANUP_DAYS` – number of days to retain transcripts when cleanup is enabled
   (defaults to `30`).
+- `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
+  endpoints (defaults to `false`).
 
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.
-- **Admin actions** under `/admin` allow listing and deleting files, downloading all artifacts, resetting the system, and retrieving CPU/memory stats plus job KPIs.
+- **Admin actions** under `/admin` allow listing and deleting files, downloading all artifacts, resetting the system, configuring cleanup via `/admin/cleanup-config`, and retrieving CPU/memory stats plus job KPIs.
 - **Logging endpoints** expose job logs and the access log. If the access log does not exist, `/logs/access` returns a `404` with an empty body. Static files under `/uploads`, `/transcripts`, and `/static` are served directly.
 - **Log streaming**: connect to `/ws/logs/{job_id}` to receive new log lines in real time. The frontend's job log view opens this socket and appends each message as it arrives.
 - **System log streaming**: connect to `/ws/logs/system` to watch the access log or `system.log` in real time from the Admin page.
@@ -132,7 +134,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | Enhance CLI orchestrate.py with watch mode                           | Open      | Poll API in loop                 | Handle auth tokens              | None                          |
 | Heartbeat table and `/heartbeat` endpoint                            | Open      | Record worker heartbeats         | Extra DB writes                 | None                          |
 | Kill (cancel) a running job                                          | Open      | Send termination signal          | Handle partial output           | Process management            |
-| Stop / Restart server from Admin                                     | Open      | Admin commands to stop and start | Risk of accidental shutdown     | Requires elevated permissions |
+| Stop / Restart server from Admin                                     | Done      | Admin commands to stop and start | Risk of accidental shutdown     | Requires elevated permissions |
 | Shell/CLI access from admin page                                     | Open      | Web terminal component           | Security and sandboxing         | Major security risk           |
 | Resume jobs after crash or cancel                                    | Open      | Persist intermediate state       | Robust job recovery             | Complex state handling        |
 | Stream logs to UI via WebSocket                                      | Done      | Push log lines live              | Scalability of sockets          | None                          |


### PR DESCRIPTION
## Summary
- add ENABLE_SERVER_CONTROL variable to docs
- document /admin/cleanup-config endpoint
- mark admin stop/restart feature as done

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e08fec01483258e28e572c5fc6272