### PR TITLE
Add timezone setting for app

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
   (defaults to `30`).
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
+- `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
 
 Configuration values are provided by `api/settings.py` using Pydantic's
 `BaseSettings`. An instance named `settings` is imported by the rest of the

--- a/api/app_state.py
+++ b/api/app_state.py
@@ -21,8 +21,9 @@ from api.paths import (
 # ─── Paths ─── (imported from api.paths)
 
 # ─── Config ───
-LOCAL_TZ = ZoneInfo("America/Chicago")
 from api.settings import settings
+
+LOCAL_TZ = ZoneInfo(settings.timezone)
 from api.services.job_queue import JobQueue, ThreadJobQueue, BrokerJobQueue
 
 from api.utils.logger import get_logger

--- a/api/settings.py
+++ b/api/settings.py
@@ -35,6 +35,7 @@ class Settings(BaseSettings):
     cleanup_enabled: bool = Field(True, env="CLEANUP_ENABLED")
     cleanup_days: int = Field(30, env="CLEANUP_DAYS")
     enable_server_control: bool = Field(False, env="ENABLE_SERVER_CONTROL")
+    timezone: str = Field("UTC", env="TIMEZONE")
 
     # Not configurable via environment
     algorithm: str = "HS256"

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -73,6 +73,7 @@ object used throughout the code base. Available variables are:
   (defaults to `30`).
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
+- `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
 
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.


### PR DESCRIPTION
## Summary
- expose `TIMEZONE` option in `Settings`
- read timezone from settings in `app_state`
- document the new variable in `README.md` and `docs/design_scope.md`

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_685e0bb767ec832594cda866aed3f80c