### PR TITLE
Add cleanup interval setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
   `true`.
 - `CLEANUP_DAYS` – how many days to keep transcripts when cleanup is enabled
   (defaults to `30`).
+- `CLEANUP_INTERVAL_SECONDS` – how often the cleanup task runs
+  (defaults to `86400`).
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).

--- a/api/app_state.py
+++ b/api/app_state.py
@@ -301,11 +301,11 @@ def cleanup_once() -> None:
             pass
 
 
-def _cleanup_task(interval: int = 86400) -> None:
+def _cleanup_task(interval: int = settings.cleanup_interval_seconds) -> None:
     while True:
         cleanup_once()
         threading.Event().wait(interval)
 
 
-def start_cleanup_thread(interval: int = 86400) -> None:
+def start_cleanup_thread(interval: int = settings.cleanup_interval_seconds) -> None:
     threading.Thread(target=_cleanup_task, args=(interval,), daemon=True).start()

--- a/api/settings.py
+++ b/api/settings.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     celery_backend_url: str = Field("rpc://", env="CELERY_BACKEND_URL")
     cleanup_enabled: bool = Field(True, env="CLEANUP_ENABLED")
     cleanup_days: int = Field(30, env="CLEANUP_DAYS")
+    cleanup_interval_seconds: int = Field(86400, env="CLEANUP_INTERVAL_SECONDS")
     enable_server_control: bool = Field(False, env="ENABLE_SERVER_CONTROL")
     timezone: str = Field("UTC", env="TIMEZONE")
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -71,6 +71,8 @@ object used throughout the code base. Available variables are:
 - `CLEANUP_ENABLED` – toggle periodic cleanup of old transcripts (default `true`).
 - `CLEANUP_DAYS` – number of days to retain transcripts when cleanup is enabled
   (defaults to `30`).
+- `CLEANUP_INTERVAL_SECONDS` – how often the cleanup task runs
+  (defaults to `86400`).
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).


### PR DESCRIPTION
## Summary
- add `cleanup_interval_seconds` option to settings
- respect `settings.cleanup_interval_seconds` in cleanup thread
- document the environment variable

## Testing
- `black .`
- `coverage run -m pytest` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e1007c49c8325885b7ab8305dba5d