### PR TITLE
Add configurable Whisper paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
+- `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
+- `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
+- `MODEL_DIR` – directory containing Whisper model files (defaults to `models/`).
 
 Configuration values are provided by `api/settings.py` using Pydantic's
 `BaseSettings`. An instance named `settings` is imported by the rest of the
@@ -187,7 +190,7 @@ The API offers several management routes that are restricted to users with the
 - Toast notifications show the result of actions across all pages.
 - Admins can manage user roles from the Settings page.
 - Cleanup options can be toggled and saved from the Admin page.
-- `models/` exists locally only and is never stored in Git. It must contain the Whisper `.pt` files before building or running the app. Ensure the files are present before building the Docker image.
+- `MODEL_DIR` points to the directory that holds the Whisper `.pt` files. The default is `models/`, ignored by Git. Populate this directory before building or running the application.
 - `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.
 - Uploaded files are stored under `uploads/` while transcripts and metadata are
   written to `transcripts/`. Per-job logs and the system log live in `logs/`.
@@ -196,9 +199,9 @@ When `STORAGE_BACKEND=cloud`, these folders act as a cache and transcript files
 
 ## Docker Usage
 
-Docker builds expect a populated `models/` directory and the compiled
+Docker builds expect a populated directory containing the Whisper models specified by `MODEL_DIR` along with the compiled
 `frontend/dist/` folder. During the build the Python script
-`validate_models_dir()` checks the `models/` directory so missing Whisper
+`validate_models_dir()` checks this directory so missing Whisper
 models fail the build early. Both directories are ignored by Git so they must
 be prepared manually before running `docker build`. Example:
 ```bash

--- a/api/app_state.py
+++ b/api/app_state.py
@@ -33,7 +33,7 @@ backend_log = get_logger("backend")
 ACCESS_LOG = LOG_DIR / "access.log"
 
 # ─── Whisper CLI Check ───
-WHISPER_BIN = shutil.which("whisper")
+WHISPER_BIN = shutil.which(settings.whisper_bin)
 
 # ─── DB Lock ───
 db_lock = threading.RLock()
@@ -76,7 +76,7 @@ def handle_whisper(
     from api.orm_bootstrap import SessionLocal
 
     global WHISPER_BIN
-    WHISPER_BIN = WHISPER_BIN or shutil.which("whisper")
+    WHISPER_BIN = WHISPER_BIN or shutil.which(settings.whisper_bin)
     if not WHISPER_BIN:
         raise RuntimeError(
             "Whisper CLI not found in PATH. Is it installed and in the environment?"
@@ -115,7 +115,7 @@ def handle_whisper(
                 "--output_format",
                 "srt",
                 "--language",
-                "en",
+                settings.whisper_language,
                 "--verbose",
                 "True",
             ]

--- a/api/paths.py
+++ b/api/paths.py
@@ -28,5 +28,5 @@ storage = _init_storage()
 
 UPLOAD_DIR = storage.upload_dir
 TRANSCRIPTS_DIR = storage.transcripts_dir
-MODEL_DIR = BASE_DIR / "models"
+MODEL_DIR = Path(settings.model_dir)
 LOG_DIR = storage.log_dir

--- a/api/settings.py
+++ b/api/settings.py
@@ -25,6 +25,12 @@ class Settings(BaseSettings):
     local_storage_dir: str = Field(
         default=str(Path(__file__).resolve().parent.parent), env="LOCAL_STORAGE_DIR"
     )
+    whisper_bin: str = Field("whisper", env="WHISPER_BIN")
+    whisper_language: str = Field("en", env="WHISPER_LANGUAGE")
+    model_dir: str = Field(
+        default=str(Path(__file__).resolve().parent.parent / "models"),
+        env="MODEL_DIR",
+    )
     aws_access_key_id: str | None = Field(None, env="AWS_ACCESS_KEY_ID")
     aws_secret_access_key: str | None = Field(None, env="AWS_SECRET_ACCESS_KEY")
     s3_bucket: str | None = Field(None, env="S3_BUCKET")

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -28,7 +28,7 @@ The application is considered working once these basics are functional:
 - `logs/` – rotating log files for jobs and the system.
 - When `STORAGE_BACKEND=cloud` these directories serve as a local cache and
   transcript files are synchronized from S3 when requested.
-- `models/` – directory for Whisper models. The folder is local only and never committed. It must contain `base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, and `tiny.pt` when building the image. The application checks for these files on startup. Ensure the directory contains the required models before running or building the container.
+ - `MODEL_DIR` specifies where the Whisper models are stored. By default this directory is `models/` which is local only and never committed. It must contain `base.pt`, `large-v3.pt`, `medium.pt`, `small.pt`, and `tiny.pt` when building the image. The application checks for these files on startup.
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 
@@ -76,6 +76,9 @@ object used throughout the code base. Available variables are:
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
+- `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
+- `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
+- `MODEL_DIR` – directory containing Whisper models (defaults to `models/`).
 
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.


### PR DESCRIPTION
## Summary
- allow customizing Whisper executable, language, and model directory via `Settings`
- use these settings when running Whisper
- point `api.paths.MODEL_DIR` to `Settings.model_dir`
- document new variables in README and design docs

## Testing
- `black . --check`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e10dacfcc8325b2123ace004087ec