### PR TITLE
Add configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
+- `CORS_ORIGINS` – comma-separated list of origins allowed for CORS (defaults to `*`).
 - `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
 - `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
 - `MODEL_DIR` – directory containing Whisper model files (defaults to `models/`).

--- a/api/main.py
+++ b/api/main.py
@@ -57,7 +57,7 @@ app = FastAPI(lifespan=lifespan)
 # ─── Middleware ───
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins.split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/api/settings.py
+++ b/api/settings.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     cleanup_interval_seconds: int = Field(86400, env="CLEANUP_INTERVAL_SECONDS")
     enable_server_control: bool = Field(False, env="ENABLE_SERVER_CONTROL")
     timezone: str = Field("UTC", env="TIMEZONE")
+    cors_origins: str = Field("*", env="CORS_ORIGINS")
 
     # Not configurable via environment
     algorithm: str = "HS256"

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -76,6 +76,7 @@ object used throughout the code base. Available variables are:
 - `ENABLE_SERVER_CONTROL` – allow `/admin/shutdown` and `/admin/restart`
   endpoints (defaults to `false`).
 - `TIMEZONE` – local timezone name used for log timestamps (defaults to `UTC`).
+- `CORS_ORIGINS` – comma-separated list of allowed CORS origins (defaults to `*`).
 - `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
 - `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
 - `MODEL_DIR` – directory containing Whisper models (defaults to `models/`).


### PR DESCRIPTION
## Summary
- allow configuring allowed CORS origins via `CORS_ORIGINS`
- document the new variable

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e1230f9608325bb5c85e05eaf83b2