### PR TITLE
Enable file browser in admin

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import JobStatusPage from "./pages/JobStatusPage";
 import FailedJobsPage from "./pages/FailedJobsPage";
 import JobProgressPage from "./pages/JobProgressPage";
 import LoginPage from "./pages/LoginPage";
+import FileBrowserPage from "./pages/FileBrowserPage";
 import { AuthContext } from "./context/AuthContext";
 import { useApi } from "./api";
 import Layout from "./components/Layout";
@@ -36,6 +37,7 @@ export default function App() {
           <Route path={ROUTES.ACTIVE} element={isAuthenticated ? <ActiveJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.COMPLETED} element={isAuthenticated ? <CompletedJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.ADMIN} element={isAuthenticated ? <AdminPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
+          <Route path={ROUTES.FILE_BROWSER} element={isAuthenticated ? <FileBrowserPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.SETTINGS} element={isAuthenticated && role === "admin" ? <SettingsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.TRANSCRIPT_VIEW} element={isAuthenticated ? <TranscriptViewPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.STATUS} element={isAuthenticated ? <JobStatusPage /> : <Navigate to={ROUTES.LOGIN} replace />} />

--- a/frontend/src/pages/FileBrowserPage.jsx
+++ b/frontend/src/pages/FileBrowserPage.jsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import PageContainer from "../components/PageContainer";
+import FileBrowser from "../components/FileBrowser";
+
+export default function FileBrowserPage() {
+  const [folder, setFolder] = useState("logs");
+
+  return (
+    <PageContainer>
+      <h2 className="page-title">File Browser</h2>
+      <div style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+        <label>
+          Folder:
+          <select
+            value={folder}
+            onChange={(e) => setFolder(e.target.value)}
+            style={{ marginLeft: "0.5rem" }}
+          >
+            <option value="logs">logs</option>
+            <option value="uploads">uploads</option>
+            <option value="transcripts">transcripts</option>
+          </select>
+        </label>
+      </div>
+      <FileBrowser folder={folder} />
+    </PageContainer>
+  );
+}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -9,6 +9,7 @@ export const ROUTES = {
   TRANSCRIPT_VIEW: "/transcript/:jobId/view",
   STATUS: "/status/:jobId",
   PROGRESS: "/progress/:jobId",
+  FILE_BROWSER: "/admin/files",
   API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
 };
 


### PR DESCRIPTION
## Summary
- add route constant and page for browsing files
- link the page from Admin and App router
- cleanup file list logic from AdminPage

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e2001f8cc83259b4af3be7c2057c3