### PR TITLE
Add search filter for jobs listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ resembles:
 Timestamps returned by the API are in UTC (note the trailing `Z`).
 The web UI converts them to your local timezone for display.
 
+### Listing Jobs
+
+`GET /jobs` now accepts an optional `search` query parameter. When provided, the
+backend filters jobs whose ID, original filename or transcript keywords contain
+the given value (case-insensitive). The Completed Jobs page includes a search
+box that submits this parameter.
+
 ### Transcript Downloads
 
 Use `/jobs/{id}/download` to retrieve the transcript. The optional `format`
@@ -203,6 +210,8 @@ displayed all files at once.
 - The Admin page shows the system log via `/ws/logs/system`.
 - Toast notifications show the result of actions across all pages.
 - Admins can manage user roles from the Settings page.
+- The Completed Jobs page provides a search box that filters results using the
+  `search` query parameter on `/jobs`.
 - Cleanup options can be toggled and saved from the Admin page.
 - `MODEL_DIR` points to the directory that holds the Whisper `.pt` files. The default is `models/`, ignored by Git. Populate this directory before building or running the application.
 - `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -46,8 +46,8 @@ async def submit_job(
 
 
 @router.get("/jobs", response_model=list[JobListOut])
-def list_jobs() -> list[JobListOut]:
-    jobs = service_list_jobs()
+def list_jobs(search: str | None = None) -> list[JobListOut]:
+    jobs = service_list_jobs(search)
     return [
         JobListOut(
             id=j.id,

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -85,7 +85,7 @@ object used throughout the code base. Available variables are:
 - `MODEL_DIR` – directory containing Whisper models (defaults to `models/`).
 
 ## API Overview
-- **Job management**: `POST /jobs` to upload, `GET /jobs` and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.
+- **Job management**: `POST /jobs` to upload, `GET /jobs` (with optional `search` query filtering by ID, filename or keywords) and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.
 - **Admin actions** under `/admin` allow listing and deleting files, downloading all artifacts, resetting the system, configuring cleanup via `/admin/cleanup-config`, and retrieving CPU/memory stats plus job KPIs.
 - **Logging endpoints** expose job logs and the access log. If the access log does not exist, `/logs/access` returns a `404` with an empty body. Static files under `/uploads`, `/transcripts`, and `/static` are served directly.
 - **Log streaming**: connect to `/ws/logs/{job_id}` to receive new log lines in real time. The frontend's job log view opens this socket and appends each message as it arrives.
@@ -105,6 +105,7 @@ This document summarizes the repository layout and how the core FastAPI service 
   which the Dockerfile copies to `api/static/` for serving.
 - Upload page lets users choose audio files and Whisper model size, then starts jobs and links to a status view.
 - Active, Completed and Failed pages display jobs filtered by status with actions to view logs or restart/remove.
+- Completed Jobs now includes a search box that filters results via the `/jobs` `search` query, matching job IDs, filenames or metadata keywords.
 - Transcript viewer shows the final text in a simple styled page.
 - Admin page lists server files, shows CPU/memory usage and KPIs (completed job count, average job time and queue length), and provides buttons to reset the system or download all data.
 
@@ -137,7 +138,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | Settings page to customize default model                             | Open      | UI for selecting models          | Persist user prefs              | None                          |
 | Allow multiple files per upload with validation                      | Open      | Adjust upload handler            | File size and concurrency       | None                          |
 | Web-based log viewer                                                 | Open      | Simple log tail view             | Log file rotation               | Large logs                    |
-| Sortable and searchable job lists                                    | Open      | Add filters on table views       | DB query optimization           | None                          |
+| Sortable and searchable job lists                                    | Partial   | Search filter added via `/jobs`  | Sorting not implemented        | None                          |
 | Status toasts for admin actions                                      | Open      | Display toast on success/failure | Frontend state management       | None                          |
 | Playback or text toggle for completed jobs                           | Open      | Switch between audio and text    | Media player integration        | None                          |
 | Use `updated_at` for job sorting/pagination                          | Open      | Modify queries                   | Add index                       | None                          |

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchJobs, deleteJob, selectJobs, addToast } from "../store";
@@ -9,11 +9,12 @@ import { Table, Th, Td } from "../components/Table";
 
 export default function CompletedJobsPage() {
   const dispatch = useDispatch();
+  const [search, setSearch] = useState("");
   const jobs = useSelector(selectJobs).filter((j) => j.status === "completed");
 
   useEffect(() => {
-    dispatch(fetchJobs()).unwrap().catch(() => dispatch(addToast("Failed to load completed jobs", "error")));
-  }, [dispatch]);
+    dispatch(fetchJobs(search)).unwrap().catch(() => dispatch(addToast("Failed to load completed jobs", "error")));
+  }, [dispatch, search]);
 
   const handleView = (jobId) => {
     window.open(`${ROUTES.API}/transcript/${jobId}/view`, "_blank");
@@ -33,6 +34,12 @@ export default function CompletedJobsPage() {
   return (
     <PageContainer>
       <h2 className="page-title">Completed Jobs</h2>
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search jobs or keywords..."
+        style={{ marginTop: "1rem", padding: "0.5rem", width: "100%" }}
+      />
 
       <Table style={{ marginTop: "2rem" }}>
         <thead style={{ backgroundColor: "#27272a" }}> {/* zinc-800 */}

--- a/frontend/src/store/jobsSlice.js
+++ b/frontend/src/store/jobsSlice.js
@@ -8,8 +8,9 @@ const authHeaders = () => {
   return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
-export const fetchJobs = createAsyncThunk('jobs/fetchJobs', async (_, { rejectWithValue }) => {
-  const res = await fetch(`${ROUTES.API}/jobs`, { headers: authHeaders() });
+export const fetchJobs = createAsyncThunk('jobs/fetchJobs', async (search = '', { rejectWithValue }) => {
+  const url = search ? `${ROUTES.API}/jobs?search=${encodeURIComponent(search)}` : `${ROUTES.API}/jobs`;
+  const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) {
     return rejectWithValue(await res.text());
   }


### PR DESCRIPTION
## Summary
- allow searching /jobs with a `search` query parameter
- wire optional search arg through service layer
- update the Completed Jobs page with a search box
- document the new search parameter and UI search box
- test search filtering logic
- extend search to transcript keywords

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685e245236188325a4f309392311bca0