### PR TITLE
Add transcript search

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ displayed all files at once.
 - Admins can manage user roles from the Settings page.
 - The Completed Jobs page provides a search box that filters results using the
   `search` query parameter on `/jobs`.
+- The Transcript Viewer page includes a search field to highlight text and can
+  optionally display only matching lines.
 - Cleanup options can be toggled and saved from the Admin page.
 - `MODEL_DIR` points to the directory that holds the Whisper `.pt` files. The default is `models/`, ignored by Git. Populate this directory before building or running the application.
 - `frontend/dist/` is not tracked by Git. Build it from the `frontend` directory with `npm run build` before any `docker build`.

--- a/frontend/src/pages/TranscriptViewPage.jsx
+++ b/frontend/src/pages/TranscriptViewPage.jsx
@@ -1,5 +1,5 @@
 // frontend/src/pages/TranscriptViewPage.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ROUTES } from "../routes";
 import { useParams } from "react-router-dom";
 import { useApi } from "../api";
@@ -9,6 +9,9 @@ export default function TranscriptViewPage() {
   const api = useApi();
   const [transcript, setTranscript] = useState("");
   const [error, setError] = useState(null);
+  const [search, setSearch] = useState("");
+  const [showMatchesOnly, setShowMatchesOnly] = useState(false);
+  const containerRef = useRef(null);
 
   useEffect(() => {
     api
@@ -20,6 +23,39 @@ export default function TranscriptViewPage() {
       .catch((err) => setError(err.message));
   }, [jobId]);
 
+  useEffect(() => {
+    if (!search) return;
+    const el = containerRef.current?.querySelector("mark");
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [search]);
+
+  const escapeRegExp = (string) =>
+    string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  const highlight = (text, query) => {
+    if (!query) return text;
+    const regex = new RegExp(`(${escapeRegExp(query)})`, "gi");
+    const parts = text.split(regex);
+    return parts.map((part, i) =>
+      regex.test(part) ? (
+        <mark key={i} style={{ backgroundColor: "yellow", color: "black" }}>
+          {part}
+        </mark>
+      ) : (
+        part
+      )
+    );
+  };
+
+  const transcriptLines = transcript.split(/\r?\n/);
+  const filteredLines = search && showMatchesOnly
+    ? transcriptLines.filter((line) =>
+        line.toLowerCase().includes(search.toLowerCase())
+      )
+    : transcriptLines;
+
   return (
     <div style={{ padding: "1.5rem", color: "white" }}>
 
@@ -27,18 +63,42 @@ export default function TranscriptViewPage() {
         Transcript Viewer
       </h1>
 
+      <input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search transcript..."
+        style={{ marginBottom: "0.5rem", padding: "0.5rem", width: "100%" }}
+      />
+      <label style={{ display: "block", marginBottom: "1rem" }}>
+        <input
+          type="checkbox"
+          checked={showMatchesOnly}
+          onChange={(e) => setShowMatchesOnly(e.target.checked)}
+          style={{ marginRight: "0.5rem" }}
+        />
+        Show matches only
+      </label>
+
       {error ? (
         <div style={{ color: "red", fontSize: "0.9rem" }}>{error}</div>
       ) : (
         <pre
+          ref={containerRef}
           style={{
             whiteSpace: "pre-wrap",
             backgroundColor: "#27272a", // zinc-800 equivalent
             padding: "1rem",
-            borderRadius: "0.5rem"
+            borderRadius: "0.5rem",
+            maxHeight: "60vh",
+            overflowY: "auto"
           }}
         >
-          {transcript}
+          {filteredLines.map((line, idx) => (
+            <span key={idx}>
+              {highlight(line, search)}
+              {"\n"}
+            </span>
+          ))}
         </pre>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add search and filtering in TranscriptViewPage
- document search in transcript viewer

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Could not find a version)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685e27d914448325a31cbfd6908d0d40