### PR TITLE
Switch to pydantic-settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
 - `MODEL_DIR` – directory containing Whisper model files (defaults to `models/`).
 
-Configuration values are provided by `api/settings.py` using Pydantic's
-`BaseSettings`. An instance named `settings` is imported by the rest of the
+Configuration values are provided by `api/settings.py` using
+`pydantic_settings.BaseSettings`. An instance named `settings` is imported by the rest of the
 application so environment variables are loaded only once.
 
 ## Running

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from pydantic import BaseSettings, Field, model_validator
+from pydantic import Field, model_validator
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -45,7 +45,7 @@ Key environment files include `pyproject.toml`, `requirements.txt`, and the `Doc
 ## Configuration
 
 Application settings come from `api/settings.py`. It reads environment
-variables once using `pydantic.BaseSettings` and exposes a `settings`
+variables once using `pydantic_settings.BaseSettings` and exposes a `settings`
 object used throughout the code base. Available variables are:
 
 - `DB_URL` – database URL.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "sqlalchemy~=2.0",
     "python-multipart",       # Required for file uploads
     "pydantic",               # Used in FastAPI models
+    "pydantic-settings",
     "alembic",                # Keep for DB migration
     "psycopg2-binary",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pydub>=0.25.1
 
 # --- .env file support ---
 python-dotenv>=1.1.0
+pydantic-settings>=2.2.1
 
 # --- JSON performance boost (optional but auto-detected by FastAPI) ---
 orjson>=3.10.0


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic_settings`
- list `pydantic-settings` in `requirements.txt`
- depend on `pydantic-settings` in `pyproject.toml`
- update docs to point at the new import path
- run `black` to keep consistent formatting

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.0)*

------
https://chatgpt.com/codex/tasks/task_e_685ece900b048325bfbde46418d9ebe6