### PR TITLE
Add status filtering for jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,12 @@ The web UI converts them to your local timezone for display.
 
 ### Listing Jobs
 
-`GET /jobs` now accepts an optional `search` query parameter. When provided, the
-backend filters jobs whose ID, original filename or transcript keywords contain
-the given value (case-insensitive). The Completed Jobs page includes a search
-box that submits this parameter.
+`GET /jobs` now accepts optional `search` and `status` query parameters. The
+`search` filter matches the job ID, original filename or transcript keywords
+case-insensitively. The `status` value may include one or more pipe separated
+states (e.g. `queued|processing`). A value of `failed` matches any failure
+status. The Completed, Failed and Active Jobs pages use these parameters to
+request only the relevant jobs from the backend.
 
 ### Transcript Downloads
 

--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -46,8 +46,8 @@ async def submit_job(
 
 
 @router.get("/jobs", response_model=list[JobListOut])
-def list_jobs(search: str | None = None) -> list[JobListOut]:
-    jobs = service_list_jobs(search)
+def list_jobs(search: str | None = None, status: str | None = None) -> list[JobListOut]:
+    jobs = service_list_jobs(search, status)
     return [
         JobListOut(
             id=j.id,

--- a/frontend/src/pages/ActiveJobsPage.jsx
+++ b/frontend/src/pages/ActiveJobsPage.jsx
@@ -12,7 +12,7 @@ export default function ActiveJobsPage() {
 
   useEffect(() => {
     const load = () =>
-      dispatch(fetchJobs())
+      dispatch(fetchJobs({ status: 'queued|processing|enriching' }))
         .unwrap()
         .then(() => setLastUpdated(new Date()))
         .catch(() => dispatch(addToast("Failed to load jobs", "error")));

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -10,10 +10,12 @@ import { Table, Th, Td } from "../components/Table";
 export default function CompletedJobsPage() {
   const dispatch = useDispatch();
   const [search, setSearch] = useState("");
-  const jobs = useSelector(selectJobs).filter((j) => j.status === "completed");
+  const jobs = useSelector(selectJobs);
 
   useEffect(() => {
-    dispatch(fetchJobs(search)).unwrap().catch(() => dispatch(addToast("Failed to load completed jobs", "error")));
+    dispatch(fetchJobs({ search, status: "completed" }))
+      .unwrap()
+      .catch(() => dispatch(addToast("Failed to load completed jobs", "error")));
   }, [dispatch, search]);
 
   const handleView = (jobId) => {

--- a/frontend/src/pages/FailedJobsPage.jsx
+++ b/frontend/src/pages/FailedJobsPage.jsx
@@ -6,10 +6,12 @@ import { fetchJobs, deleteJob, restartJob, selectJobs, addToast } from "../store
 
 export default function FailedJobsPage() {
   const dispatch = useDispatch();
-  const jobs = useSelector(selectJobs).filter((j) => j.status.startsWith("failed"));
+  const jobs = useSelector(selectJobs);
 
   useEffect(() => {
-    dispatch(fetchJobs()).unwrap().catch(() => dispatch(addToast("Failed to load failed jobs", "error")));
+    dispatch(fetchJobs({ status: "failed" }))
+      .unwrap()
+      .catch(() => dispatch(addToast("Failed to load failed jobs", "error")));
   }, [dispatch]);
 
   const handleRestart = async (jobId) => {

--- a/frontend/src/store/jobsSlice.js
+++ b/frontend/src/store/jobsSlice.js
@@ -8,8 +8,12 @@ const authHeaders = () => {
   return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
-export const fetchJobs = createAsyncThunk('jobs/fetchJobs', async (search = '', { rejectWithValue }) => {
-  const url = search ? `${ROUTES.API}/jobs?search=${encodeURIComponent(search)}` : `${ROUTES.API}/jobs`;
+export const fetchJobs = createAsyncThunk('jobs/fetchJobs', async ({ search = '', status = '' } = {}, { rejectWithValue }) => {
+  let url = `${ROUTES.API}/jobs`;
+  const params = new URLSearchParams();
+  if (search) params.set('search', search);
+  if (status) params.set('status', status);
+  if ([...params].length) url += `?${params.toString()}`;
   const res = await fetch(url, { headers: authHeaders() });
   if (!res.ok) {
     return rejectWithValue(await res.text());


### PR DESCRIPTION
## Summary
- extend `list_jobs` service to filter by status strings
- expose `status` query param via `/jobs`
- update Redux `fetchJobs` and UI pages to pass the filter
- document `status` query parameter
- test API status filtering

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685edeb3180483258040726ed5a45c42