### PR TITLE
Add audio conversion endpoint

### DIFF
--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -5,7 +5,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from api.routes import jobs, admin, logs, metrics, auth, users
-from api.routes import progress
+from api.routes import progress, audio
 from api.paths import storage, UPLOAD_DIR, TRANSCRIPTS_DIR
 from api.app_state import backend_log
 
@@ -19,6 +19,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(metrics.router)
     app.include_router(auth.router)
     app.include_router(users.router)
+    app.include_router(audio.router)
 
     app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
     app.mount(

--- a/api/routes/audio.py
+++ b/api/routes/audio.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, File, Form, UploadFile
+
+from api.paths import storage, UPLOAD_DIR
+from api.errors import ErrorCode, http_error
+
+ALLOWED_FORMATS = {"mp3", "m4a", "wav", "flac"}
+
+router = APIRouter()
+
+
+@router.post("/convert")
+async def convert_audio(
+    file: UploadFile = File(...), target_format: str = Form(...)
+) -> dict[str, str]:
+    if target_format not in ALLOWED_FORMATS:
+        raise http_error(ErrorCode.UNSUPPORTED_MEDIA)
+
+    file_id = uuid.uuid4().hex
+    saved_name = f"{file_id}_{file.filename}"
+    try:
+        src_path = storage.save_upload(file.file, saved_name)
+    except Exception:
+        raise http_error(ErrorCode.FILE_SAVE_FAILED)
+
+    dest_name = f"{Path(file.filename).stem}_{file_id}.{target_format}"
+    dest_path = UPLOAD_DIR / dest_name
+    try:
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", str(src_path), str(dest_path)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception:
+        raise http_error(ErrorCode.UNSUPPORTED_MEDIA)
+
+    return {"path": str(dest_path)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api import models, orm_bootstrap, paths, app_state
-from api.routes import jobs, auth, logs, metrics, progress
+from api.routes import jobs, auth, logs, metrics, progress, audio
 from api.services.job_queue import ThreadJobQueue
 
 
@@ -53,6 +53,10 @@ def client(temp_db, temp_dirs):
     jobs.LOG_DIR = paths.LOG_DIR
     jobs.handle_whisper = app_state.handle_whisper
 
+    importlib.reload(audio)
+    audio.UPLOAD_DIR = paths.UPLOAD_DIR
+    audio.storage = paths.storage
+
     app = FastAPI()
     for router in (
         jobs.router,
@@ -60,6 +64,7 @@ def client(temp_db, temp_dirs):
         logs.router,
         metrics.router,
         progress.router,
+        audio.router,
     ):
         app.include_router(router)
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import subprocess
+import shutil
+
+from api.errors import ErrorCode
+
+
+def test_convert_success(client, sample_wav, monkeypatch, tmp_path):
+    def fake_run(cmd, check, stdout=None, stderr=None):
+        dest = Path(cmd[-1])
+        shutil.copy(sample_wav, dest)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/convert",
+            data={"target_format": "mp3"},
+            files={"file": ("in.wav", f, "audio/wav")},
+        )
+    assert resp.status_code == 200
+    path = Path(resp.json()["path"])
+    assert path.exists()
+    assert path.suffix == ".mp3"
+
+
+def test_convert_unsupported_format(client, sample_wav):
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/convert",
+            data={"target_format": "xyz"},
+            files={"file": ("in.wav", f, "audio/wav")},
+        )
+    assert resp.status_code == 415
+    detail = resp.json()
+    assert detail["code"] == ErrorCode.UNSUPPORTED_MEDIA


### PR DESCRIPTION
## Summary
- implement `/convert` endpoint for audio conversion
- register new audio router
- cover conversion flow with tests

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ee059b3908325b4a86d1cb1b8dd96