### PR TITLE
Add TTS playback support

### DIFF
--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -5,7 +5,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from api.routes import jobs, admin, logs, metrics, auth, users
-from api.routes import progress, audio
+from api.routes import progress, audio, tts
 from api.paths import storage, UPLOAD_DIR, TRANSCRIPTS_DIR
 from api.app_state import backend_log
 
@@ -20,6 +20,7 @@ def register_routes(app: FastAPI) -> None:
     app.include_router(auth.router)
     app.include_router(users.router)
     app.include_router(audio.router)
+    app.include_router(tts.router)
 
     app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR, html=True), name="uploads")
     app.mount(

--- a/api/routes/tts.py
+++ b/api/routes/tts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+
+from api.errors import ErrorCode, http_error
+from api.paths import storage, TRANSCRIPTS_DIR
+from api.services.jobs import get_job
+from api.exporters import srt_to_txt
+
+import pyttsx3
+
+router = APIRouter()
+
+
+@router.post("/tts/{job_id}")
+def generate_tts(job_id: str) -> dict[str, str]:
+    job = get_job(job_id)
+    if not job:
+        raise http_error(ErrorCode.JOB_NOT_FOUND)
+
+    if not job.transcript_path:
+        raise http_error(ErrorCode.FILE_NOT_FOUND)
+
+    transcript_file = Path(job.transcript_path)
+    if not transcript_file.exists():
+        raise http_error(ErrorCode.FILE_NOT_FOUND)
+
+    text = srt_to_txt(transcript_file)
+
+    out_dir = storage.get_transcript_dir(job_id) / "tts_output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "speech.wav"
+
+    engine = pyttsx3.init()
+    engine.save_to_file(text, str(out_path))
+    engine.runAndWait()
+
+    rel_path = f"/transcripts/{job_id}/tts_output/{out_path.name}"
+    return {"path": rel_path}

--- a/frontend/src/pages/CompletedJobsPage.jsx
+++ b/frontend/src/pages/CompletedJobsPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchJobs, deleteJob, selectJobs, addToast } from "../store";
+import { useApi } from "../api";
 import { STATUS_LABELS } from "../statusLabels";
 import PageContainer from "../components/PageContainer";
 import Button from "../components/Button";
@@ -9,6 +10,7 @@ import { Table, Th, Td } from "../components/Table";
 
 export default function CompletedJobsPage() {
   const dispatch = useDispatch();
+  const api = useApi();
   const [search, setSearch] = useState("");
   const jobs = useSelector(selectJobs);
 
@@ -24,6 +26,16 @@ export default function CompletedJobsPage() {
 
   const handleDownloadTranscript = (jobId) => {
     window.open(getTranscriptDownloadUrl(jobId), "_blank");
+  };
+
+  const handleListen = async (jobId) => {
+    try {
+      const data = await api.post(`/tts/${jobId}`);
+      const audio = new Audio(`${ROUTES.API}${data.path}`);
+      audio.play();
+    } catch {
+      dispatch(addToast("Failed to generate audio", "error"));
+    }
   };
 
   const handleDelete = async (jobId) => {
@@ -78,6 +90,7 @@ export default function CompletedJobsPage() {
                 <Td style={{ display: "flex", gap: "0.5rem" }}>
                   <Button title={`Job ID: ${job.id}`} onClick={() => handleView(job.id)}>View</Button>
                   <Button color="#16a34a" onClick={() => handleDownloadTranscript(job.id)}>Download</Button>
+                  <Button color="#0ea5e9" onClick={() => handleListen(job.id)}>Listen</Button>
                   <Button color="#dc2626" onClick={() => handleDelete(job.id)}>Delete</Button>
                 </Td>
               </tr>

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ torch>=2.2.2
 
 # --- Audio helpers ---
 pydub>=0.25.1
+pyttsx3>=2.90
 
 # --- .env file support ---
 python-dotenv>=1.1.0


### PR DESCRIPTION
## Summary
- implement `/tts/{job_id}` endpoint using pyttsx3 for text-to-speech
- wire up new router
- allow audio playback for completed jobs
- include pyttsx3 in requirements

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ee2fda5248325810ebcbb72704a92