### PR TITLE
Add status badge for job pages

### DIFF
--- a/frontend/src/components/StatusBadge.jsx
+++ b/frontend/src/components/StatusBadge.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { STATUS_LABELS } from "../statusLabels";
+
+export default function StatusBadge({ status }) {
+  const colors = {
+    queued: "#f59e0b", // amber
+    processing: "#3b82f6", // blue
+    enriching: "#10b981", // green-teal
+    completed: "#16a34a", // green
+  };
+
+  const bgColor = colors[status] || (status.startsWith("failed") ? "#dc2626" : "#6b7280");
+
+  const style = {
+    backgroundColor: bgColor,
+    color: "#fff",
+    padding: "0.15rem 0.5rem",
+    borderRadius: "0.25rem",
+    fontSize: "0.75rem",
+    whiteSpace: "nowrap",
+  };
+
+  return <span style={style}>{STATUS_LABELS[status] || status}</span>;
+}

--- a/frontend/src/pages/ActiveJobsPage.jsx
+++ b/frontend/src/pages/ActiveJobsPage.jsx
@@ -3,6 +3,7 @@ import { ROUTES } from "../routes";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchJobs, selectJobs, addToast } from "../store";
 import { STATUS_LABELS } from "../statusLabels";
+import StatusBadge from "../components/StatusBadge";
 import Button from "../components/Button";
 import { Table, Th, Td } from "../components/Table";
 export default function ActiveJobsPage() {
@@ -60,7 +61,9 @@ export default function ActiveJobsPage() {
               >
                 <Td>{job.original_filename}</Td>
                 <Td>{job.model}</Td>
-                <Td>{STATUS_LABELS[job.status] || job.status}</Td>
+                <Td>
+                  <StatusBadge status={job.status} />
+                </Td>
                 <Td>{new Date(job.created_at + 'Z').toLocaleString()}</Td>
                 <Td style={{ display: "flex", gap: "0.5rem" }}>
                   <Button

--- a/frontend/src/pages/JobStatusPage.jsx
+++ b/frontend/src/pages/JobStatusPage.jsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState, useContext } from "react";
 import { ROUTES, getTranscriptDownloadUrl } from "../routes";
-import { STATUS_LABELS } from "../statusLabels";
 import Spinner from "../Spinner";
+import StatusBadge from "../components/StatusBadge";
 import { useParams } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import { useApi } from "../api";
@@ -84,7 +84,9 @@ export default function JobStatusPage() {
         <div style={{ marginTop: "1rem" }}>
           <p><strong>Filename:</strong> {job.original_filename}</p>
           <p><strong>Model:</strong> {job.model}</p>
-          <p><strong>Status:</strong> {STATUS_LABELS[job.status] || job.status}</p>
+          <p>
+            <strong>Status:</strong> <StatusBadge status={job.status} />
+          </p>
           <p><strong>Created:</strong> {new Date(job.created_at + 'Z').toLocaleString()}</p>
           <p><strong>Updated:</strong> {job.updated ? new Date(job.updated + 'Z').toLocaleString() : "N/A"}</p>
 


### PR DESCRIPTION
## Summary
- show color-coded badges for job statuses
- use `StatusBadge` on active jobs table
- use `StatusBadge` on job status page

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f1977c8c883258982db0c07736410