### PR TITLE
Move db_lock to utils

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -36,7 +36,7 @@ ACCESS_LOG = LOG_DIR / "access.log"
 WHISPER_BIN = shutil.which(settings.whisper_bin)
 
 # ─── DB Lock ───
-db_lock = threading.RLock()
+from api.utils.db_lock import db_lock
 
 # ─── Job Queue ───
 if settings.job_queue_backend == "thread":

--- a/api/main.py
+++ b/api/main.py
@@ -15,8 +15,8 @@ from api.utils.model_validation import validate_models_dir
 from api.router_setup import register_routes
 from api.middlewares.access_log import access_logger
 from api.paths import storage, UPLOAD_DIR, TRANSCRIPTS_DIR
+from api.utils.db_lock import db_lock
 from api.app_state import (
-    db_lock,
     handle_whisper,
     LOCAL_TZ,
     backend_log,

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -14,7 +14,7 @@ from api.errors import ErrorCode, http_error
 from api.models import Job, JobStatusEnum
 from api.orm_bootstrap import SessionLocal
 from api.paths import storage, UPLOAD_DIR, TRANSCRIPTS_DIR, LOG_DIR
-from api.app_state import db_lock
+from api.utils.db_lock import db_lock
 import api.app_state as app_state
 from api.services.job_queue import ThreadJobQueue
 from api.schemas import FileListOut, StatusOut, AdminStatsOut, BrowseOut

--- a/api/services/config.py
+++ b/api/services/config.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from api.models import ConfigEntry
 from api.orm_bootstrap import SessionLocal
-from api.app_state import db_lock
+from api.utils.db_lock import db_lock
 
 
 def get_value(key: str) -> Optional[str]:

--- a/api/services/jobs.py
+++ b/api/services/jobs.py
@@ -7,7 +7,7 @@ from sqlalchemy import or_
 
 from api.models import Job, JobStatusEnum, TranscriptMetadata
 from api.orm_bootstrap import SessionLocal
-from api.app_state import db_lock
+from api.utils.db_lock import db_lock
 
 
 def create_job(

--- a/api/services/user_settings.py
+++ b/api/services/user_settings.py
@@ -4,7 +4,7 @@ from typing import Dict
 
 from api.models import UserSetting
 from api.orm_bootstrap import SessionLocal
-from api.app_state import db_lock
+from api.utils.db_lock import db_lock
 
 
 def get_settings(user_id: int) -> Dict[str, str]:

--- a/api/services/users.py
+++ b/api/services/users.py
@@ -7,7 +7,7 @@ from passlib.context import CryptContext
 
 from api.models import User
 from api.orm_bootstrap import SessionLocal
-from api.app_state import db_lock
+from api.utils.db_lock import db_lock
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/api/utils/db_lock.py
+++ b/api/utils/db_lock.py
@@ -1,0 +1,3 @@
+import threading
+
+db_lock = threading.RLock()


### PR DESCRIPTION
## Summary
- centralize db_lock creation in api.utils.db_lock
- import new db_lock in services, admin routes, and main
- update app_state to use db_lock from utils

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f20ddca0083258e28b28131245faf