### PR TITLE
Add convert endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Send a file to `/edit` to perform basic operations on the clip. Provide optional
 adjust loudness. The endpoint saves the modified file under `uploads/` and
 returns the path to this new file.
 
+Use `/convert` to change an uploaded clip to another format. Supply the file and
+a `target_format` form field set to `mp3`, `m4a`, `wav` or `flac`. The endpoint
+saves the re-encoded file under `uploads/` and returns its path.
+
 ### Admin Endpoints
 
 - The API offers several management routes that are restricted to users with the

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -153,7 +153,7 @@ This document summarizes the repository layout and how the core FastAPI service 
 | UI progress bars with word-level timestamps                          | Open      | Parse SRT positions              | Frequent UI updates             | None                          |
 | Auto-delete old transcripts after 30 days                            | Done         | Background cleanup task          | Configurable retention          | None                          |
 | Workflow automation hooks                                            | Open      | Fire webhook on job completion   | Configurable URLs               | Security of hooks             |
-| Audio format conversion                                              | Open      | Use ffmpeg for re-encoding       | Manage codecs                   | None                          |
+| Audio format conversion                                              | Done      | `/convert` re-encodes uploads    | Allowed: mp3, m4a, wav, flac     | None                          |
 | Audio cleanup utilities                                              | Open      | Noise reduction pipeline         | CPU usage                       | External libs                 |
 | Integration with meeting platforms                                   | Open      | OAuth with Zoom/Meet APIs        | API rate limits                 | Authentication complexity     |
 | Searchable transcript archive                                        | Open      | Full-text search index           | Storage footprint               | Search engine setup           |


### PR DESCRIPTION
## Summary
- document the `/convert` route and allowed output formats in README
- mark `Audio format conversion` as Done in the design scope table

## Testing
- `black README.md docs/design_scope.md` *(fails: Cannot parse README.md)*

------
https://chatgpt.com/codex/tasks/task_e_685f30960b7083258b1f0874b8e1c300