### PR TITLE
Update docs with OpenAI settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 - `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
 - `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
 - `MODEL_DIR` – directory containing Whisper model files (defaults to `models/`).
+- `OPENAI_API_KEY` – API key enabling transcript analysis via OpenAI.
+- `OPENAI_MODEL` – model name used when `OPENAI_API_KEY` is set (defaults to `gpt-3.5-turbo`).
 
 Configuration values are provided by `api/settings.py` using
 `pydantic_settings.BaseSettings`. An instance named `settings` is imported by the rest of the

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -84,6 +84,8 @@ object used throughout the code base. Available variables are:
 - `WHISPER_BIN` – path to the Whisper CLI executable (defaults to `whisper`).
 - `WHISPER_LANGUAGE` – language code passed to Whisper (defaults to `en`).
 - `MODEL_DIR` – directory containing Whisper models (defaults to `models/`).
+- `OPENAI_API_KEY` – API key enabling transcript analysis via OpenAI.
+- `OPENAI_MODEL` – model name used when `OPENAI_API_KEY` is set (defaults to `gpt-3.5-turbo`).
 
 ## API Overview
 - **Job management**: `POST /jobs` to upload, `GET /jobs` (with optional `search` query filtering by ID, filename or keywords) and `GET /jobs/{id}` to query, `DELETE /jobs/{id}` to remove, `POST /jobs/{id}/restart` to rerun, and `/jobs/{id}/download` to fetch the transcript. `GET /metadata/{id}` returns generated metadata.


### PR DESCRIPTION
## Summary
- document `OPENAI_API_KEY` and `OPENAI_MODEL` in environment variable lists

## Testing
- `black . --quiet`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f6b914f44832587b617bf8046016c