### PR TITLE
Document ffmpeg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
    ```bash
    pip install -r requirements.txt
    ```
-2. Install frontend dependencies from the `frontend` directory:
+2. Install system dependencies. `ffmpeg` (providing `ffprobe`) must be present
+   for audio processing features. On Linux you can install it with:
+   ```bash
+   sudo apt-get install -y ffmpeg
+   ```
+3. Install frontend dependencies from the `frontend` directory:
    ```bash
  cd frontend
   npm install


### PR DESCRIPTION
## Summary
- update README instructions to mention ffmpeg (provides ffprobe) is required for audio processing
- show the Linux install command from requirements.txt

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f6e17a7208325ad92ddafd57c628a