### PR TITLE
Update Dockerfile with default DB path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+ENV DB=/app/jobs.db
 ENV PYTHONPATH=/app
 COPY requirements.txt .
 COPY alembic.ini .


### PR DESCRIPTION
## Summary
- set `ENV DB=/app/jobs.db` in Dockerfile so image runs without manually passing DB variable

## Testing
- `black . --check`
- `docker build -t whisper-app .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601edde79c8325939c11a7923421b9