### PR TITLE
Add DB_URL to compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - JOB_QUEUE_BACKEND=broker
       - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
       - CELERY_BACKEND_URL=rpc://
+      - DB_URL=postgresql+psycopg2://whisper:whisper@db:5432/whisper
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts
@@ -44,6 +45,7 @@ services:
       - JOB_QUEUE_BACKEND=broker
       - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
       - CELERY_BACKEND_URL=rpc://
+      - DB_URL=postgresql+psycopg2://whisper:whisper@db:5432/whisper
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts


### PR DESCRIPTION
## Summary
- add the database URL to the `api` and `worker` service configs

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68601f97dec083259a408e54d59668f8