### PR TITLE
Switch Alembic default to SQLite

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 script_location = api/migrations
-sqlalchemy.url = postgresql+psycopg2://whisper:whisper@db:5432/whisper
+sqlalchemy.url = sqlite:///jobs.db
 
 # Logging settings (minimal for local dev)
 [loggers]


### PR DESCRIPTION
## Summary
- default alembic DB is now a local SQLite file
- confirm migrations still override the URL from env vars

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6860215a6538832584dfb614aff7619c