### PR TITLE
Remove deprecated DB setting

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from pydantic import Field, model_validator
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -11,7 +11,6 @@ class Settings(BaseSettings):
     db_url: str = Field(
         "postgresql+psycopg2://whisper:whisper@db:5432/whisper", env="DB_URL"
     )
-    db: str | None = Field(None, env="DB")
     vite_api_host: str = Field("http://localhost:8000", env="VITE_API_HOST")
     log_level: str = Field("DEBUG", env="LOG_LEVEL")
     log_to_stdout: bool = Field(False, env="LOG_TO_STDOUT")
@@ -52,12 +51,6 @@ class Settings(BaseSettings):
 
     # Not configurable via environment
     algorithm: str = "HS256"
-
-    @model_validator(mode="after")
-    def _override_db_url(cls, values: "Settings") -> "Settings":
-        if values.db:
-            values.db_url = f"sqlite:///{values.db}"
-        return values
 
     class Config:
         env_file = ".env"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from api.services.job_queue import ThreadJobQueue
 @pytest.fixture
 def temp_db(tmp_path):
     db_file = tmp_path / "test.db"
-    os.environ["DB"] = str(db_file)
+    os.environ["DB_URL"] = f"sqlite:///{db_file}"
     import api.settings as settings
 
     importlib.reload(settings)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,10 @@ from api import models, orm_bootstrap
 
 
 def create_test_app(tmp_path):
-    os.environ["DB"] = str(tmp_path / "test.db")
+    os.environ["DB_URL"] = f"sqlite:///{tmp_path / 'test.db'}"
+    import api.settings as settings
+
+    importlib.reload(settings)
     importlib.reload(orm_bootstrap)
     models.Base.metadata.create_all(orm_bootstrap.engine)
 


### PR DESCRIPTION
## Summary
- remove `db` and DB override logic from `Settings`
- adapt tests to configure `DB_URL` for SQLite

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68602db1a3148325ae515864171c513a