### PR TITLE
Update Alembic connection

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,8 +1,6 @@
-# A generic, SQLite-safe alembic.ini config for MVP usage
-
 [alembic]
 script_location = api/migrations
-sqlalchemy.url = sqlite:///jobs.db
+sqlalchemy.url = postgresql+psycopg2://whisper:whisper@db:5432/whisper
 
 # Logging settings (minimal for local dev)
 [loggers]


### PR DESCRIPTION
## Summary
- point Alembic to the Postgres database by default
- drop the outdated SQLite-safe comment

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68603229927c8325b190f92f3c769939