### PR TITLE
Remove default DB_URL in Alembic config

### DIFF
--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -10,11 +10,12 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 import os
+import sys
 
-db_url = os.getenv(
-    "DB_URL",
-    "postgresql+psycopg2://whisper:whisper@db:5432/whisper",
-)
+db_url = os.getenv("DB_URL")
+if not db_url:
+    sys.exit("DB_URL environment variable is required")
+
 config.set_main_option("sqlalchemy.url", db_url)
 
 # === PATCH: enable autogeneration by pointing to SQLAlchemy metadata


### PR DESCRIPTION
## Summary
- rely exclusively on the `DB_URL` environment variable for migrations
- exit migrations with a clear error if `DB_URL` is not provided

## Testing
- `black . --quiet`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6860337fc3d88325b42efb62de2df517