### PR TITLE
Remove old DB overrides

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -15,8 +15,9 @@ load_dotenv()
 RAW_VITE_API_HOST = os.getenv("VITE_API_HOST")
 API_HOST = RAW_VITE_API_HOST or "http://localhost:8000"
 
-# PostgreSQL is required in production. Override ``DB_URL`` to use a different
-# database engine for development or testing.
+# PostgreSQL is required. Provide ``DB_URL`` with the connection string to your
+# PostgreSQL server. Using a different engine is only recommended for local
+# development or testing.
 DB_URL = os.getenv(
     "DB_URL",
     "postgresql+psycopg2://whisper:whisper@db:5432/whisper",


### PR DESCRIPTION
## Summary
- clarify PostgreSQL requirement in legacy settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6860377694a88325a49b189e8d685ba8