### PR TITLE
Enforce DB_URL env var for Alembic

### DIFF
--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -10,11 +10,10 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 import os
-import sys
 
 db_url = os.getenv("DB_URL")
 if not db_url:
-    sys.exit("DB_URL environment variable is required")
+    raise SystemExit("DB_URL environment variable is required")
 
 config.set_main_option("sqlalchemy.url", db_url)
 


### PR DESCRIPTION
## Summary
- require `DB_URL` when running Alembic migrations

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68603a9a6fb08325aa8d6b6b5d33bd95