### PR TITLE
Remove unused SQLite autoincrement flag

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -73,11 +73,6 @@ class Job(Base):
 class TranscriptMetadata(Base):
     __tablename__ = "metadata"
 
-    __table_args__ = (
-        # Enforces better SQLite compatibility and future-proofing
-        {"sqlite_autoincrement": True},
-    )
-
     job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.id"), primary_key=True)
     tokens: Mapped[int] = mapped_column(Integer, nullable=False)
     duration: Mapped[int] = mapped_column(Integer, nullable=False)


### PR DESCRIPTION
## Summary
- drop `sqlite_autoincrement` option from `TranscriptMetadata`

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68603b71d29483259cf7b58644b847b2