### PR TITLE
Update DB_URL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 
 `api/settings.py` reads the following environment variables at startup:
 
-- `DB_URL` – SQLAlchemy database URL for the PostgreSQL database. Defaults to
-  `postgresql+psycopg2://whisper:whisper@db:5432/whisper`.
+- `DB_URL` – SQLAlchemy connection string for the required PostgreSQL
+  database. The default `postgresql+psycopg2://whisper:whisper@db:5432/whisper`
+  points to the `db` service defined in `docker-compose.yml`.
 - `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
@@ -83,7 +84,8 @@ Start the backend with `uvicorn`:
 uvicorn api.main:app
 ```
 
-A running PostgreSQL service configured by the default `DB_URL` is required.
+PostgreSQL must be available. The default `DB_URL` targets the `db` service
+from `docker-compose.yml`.
 
 When `JOB_QUEUE_BACKEND` is set to `broker` a Celery worker must also be
 started:
@@ -290,8 +292,8 @@ If you use a prebuilt image, mount the models directory at runtime.
 
 Run the container with the application directories mounted so that
 uploads, transcripts and logs persist on the host. Set `VITE_API_HOST` to
-the URL where the backend is reachable. Provide a `DB_URL` pointing to your
-PostgreSQL database:
+the URL where the backend is reachable. Ensure `DB_URL` points to your
+PostgreSQL instance; the compose file defaults to the `db` service:
 
 ```bash
 docker run -p 8000:8000 \

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -49,7 +49,10 @@ Application settings come from `api/settings.py`. It reads environment
 variables once using `pydantic_settings.BaseSettings` and exposes a `settings`
 object used throughout the code base. Available variables are:
 
-- `DB_URL` – SQLAlchemy database URL for the required PostgreSQL database.
+- `DB_URL` – SQLAlchemy connection string for the required PostgreSQL
+  database. The default
+  `postgresql+psycopg2://whisper:whisper@db:5432/whisper` points to the `db`
+  service defined in `docker-compose.yml`.
 - `VITE_API_HOST` – base URL for the frontend to reach the API.
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – log level for backend loggers.


### PR DESCRIPTION
## Summary
- describe PostgreSQL requirement in README and design docs
- mention that DB_URL points to the `db` service in docker-compose

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68603cc52b1c83259e0f879db558565b