### PR TITLE
Use temporary Postgres for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ jobs from RabbitMQ. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 
-Install the development requirements and run the test suite with coverage:
+Install the development requirements and run the test suite with coverage. The
+tests use `pytest-postgresql` to launch a temporary PostgreSQL instance:
 
 ```bash
 pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ httpx
 black
 pytest-asyncio
 coverage
+pytest-postgresql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,15 +12,15 @@ from api.services.job_queue import ThreadJobQueue
 
 
 @pytest.fixture
-def temp_db(tmp_path):
-    db_file = tmp_path / "test.db"
-    os.environ["DB_URL"] = f"sqlite:///{db_file}"
+def temp_db(postgresql):
+    os.environ["DB_URL"] = postgresql.url()
     import api.settings as settings
 
     importlib.reload(settings)
     importlib.reload(orm_bootstrap)
     models.Base.metadata.create_all(orm_bootstrap.engine)
-    return db_file
+    yield postgresql
+    models.Base.metadata.drop_all(orm_bootstrap.engine)
 
 
 @pytest.fixture

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,8 +5,8 @@ from fastapi.testclient import TestClient
 from api import models, orm_bootstrap
 
 
-def create_test_app(tmp_path):
-    os.environ["DB_URL"] = f"sqlite:///{tmp_path / 'test.db'}"
+def create_test_app(postgresql, tmp_path):
+    os.environ["DB_URL"] = postgresql.url()
     import api.settings as settings
 
     importlib.reload(settings)
@@ -45,8 +45,8 @@ def create_test_app(tmp_path):
     return app
 
 
-def test_submit_and_fetch_job(tmp_path, sample_wav):
-    app = create_test_app(tmp_path)
+def test_submit_and_fetch_job(postgresql, tmp_path, sample_wav):
+    app = create_test_app(postgresql, tmp_path)
     client = TestClient(app)
 
     with sample_wav.open("rb") as f:


### PR DESCRIPTION
## Summary
- update dev requirements to include pytest-postgresql
- use pytest-postgresql in tests
- note temporary postgres requirement in README

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: could not find packages due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68604004449c83258ddfa60b2f6e730e