### PR TITLE
Add compose startup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,9 @@ Start everything with:
 docker compose up --build api worker broker db
 ```
 
-The worker container runs `celery -A api.services.celery_app worker` to process
-jobs from RabbitMQ. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
+An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. Use `docker compose down` to stop all services.
+Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -32,6 +32,7 @@ The application is considered working once these basics are functional:
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
+- `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -293,3 +293,9 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 - **Roadblocks**: None.
 - **Next Steps**: Add sorting parameters and update the frontend list.
 
+
+## Completed
+
+### Docker Compose Helper Script
+- **Summary**: Added `scripts/start_containers.sh` to automatically build the frontend and start the Docker Compose stack.
+- **Motivation**: Simplifies setup by launching the API, worker, broker and database with one command.

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Install and build the frontend if needed
+if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
+    echo "Installing frontend dependencies..."
+    (cd "$ROOT_DIR/frontend" && npm install)
+fi
+
+if [ ! -d "$ROOT_DIR/frontend/dist" ]; then
+    echo "Building frontend..."
+    (cd "$ROOT_DIR/frontend" && npm run build)
+fi
+
+# Ensure persistent directories exist
+mkdir -p "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
+
+if [ ! -d "$ROOT_DIR/models" ]; then
+    echo "Models directory $ROOT_DIR/models is missing. Place Whisper model files here before running." >&2
+    exit 1
+fi
+
+echo "Starting containers with docker compose..."
+docker compose -f "$ROOT_DIR/docker-compose.yml" up --build -d api worker broker db
+
+echo "Containers are starting. Use 'docker compose ps' to check status."


### PR DESCRIPTION
## Summary
- add `scripts/start_containers.sh` script for building frontend and starting the compose stack
- document the new script in README and design scope
- note the script in `future_updates.md`

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `coverage run -m pytest` *(fails: coverage: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605beade4c8325a20585b994862daa