### PR TITLE
Improve docs for database usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,10 @@ Run the container with the application directories mounted so that
 uploads, transcripts and logs persist on the host. Set `VITE_API_HOST` to
 the URL where the backend is reachable. Ensure `DB_URL` points to your
 PostgreSQL instance; the compose file defaults to the `db` service
-(using the `postgres:15-alpine` image):
+(using the `postgres:15-alpine` image). When starting the container
+without compose you must provide your own PostgreSQL instance. Launch one
+manually or point `DB_URL` at an existing server to avoid the "could not
+translate host name \"db\"" error:
 
 ```bash
 docker run -p 8000:8000 \
@@ -304,6 +307,17 @@ docker run -p 8000:8000 \
   -v $(pwd)/transcripts:/app/transcripts \
   -v $(pwd)/logs:/app/logs \
   whisper-app
+```
+
+If you need a local database without using compose, run a PostgreSQL
+container separately and set `DB_URL` accordingly:
+
+```bash
+docker run -d --name whisper-db \
+  -e POSTGRES_USER=whisper \
+  -e POSTGRES_PASSWORD=whisper \
+  -e POSTGRES_DB=whisper \
+  -p 5432:5432 postgres:15-alpine
 ```
 
 ## Docker Compose
@@ -340,8 +354,9 @@ Start everything with:
 docker compose up --build api worker broker db
 ```
 
-The worker container runs `celery -A api.services.celery_app worker` to process
-jobs from RabbitMQ. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
+An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. Use `docker compose down` to stop all services.
+Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -10,11 +10,19 @@ from api.models import Base
 from api.utils.logger import get_logger
 from api.settings import settings
 
+log = get_logger("orm")
+
 DB_URL = settings.db_url
+if "DB_URL" not in os.environ:
+    log.warning(
+        "DB_URL environment variable not set; using default '%s'."
+        " If running without docker compose, set DB_URL to a reachable"
+        " PostgreSQL server.",
+        DB_URL,
+    )
+
 engine = create_engine(DB_URL)
 SessionLocal = sessionmaker(bind=engine)
-
-log = get_logger("orm")
 
 
 def validate_or_initialize_database():

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -32,6 +32,7 @@ The application is considered working once these basics are functional:
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
+- `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`). The compose file provides a PostgreSQL service named `db` which the API expects by default.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -293,3 +293,10 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 - **Roadblocks**: None.
 - **Next Steps**: Add sorting parameters and update the frontend list.
 
+
+## Completed
+
+### Docker Compose Helper Script
+- **Summary**: Added `scripts/start_containers.sh` to automatically build the frontend and start the Docker Compose stack.
+- **Motivation**: Simplifies setup by launching the API, worker, broker and database with one command.
+- **Notes**: The compose file starts a `db` container so the API can connect using the default `DB_URL` setting.

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Install and build the frontend if needed
+if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
+    echo "Installing frontend dependencies..."
+    (cd "$ROOT_DIR/frontend" && npm install)
+fi
+
+if [ ! -d "$ROOT_DIR/frontend/dist" ]; then
+    echo "Building frontend..."
+    (cd "$ROOT_DIR/frontend" && npm run build)
+fi
+
+# Ensure persistent directories exist
+mkdir -p "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
+
+if [ ! -d "$ROOT_DIR/models" ]; then
+    echo "Models directory $ROOT_DIR/models is missing. Place Whisper model files here before running." >&2
+    exit 1
+fi
+
+echo "Starting containers with docker compose..."
+docker compose -f "$ROOT_DIR/docker-compose.yml" up --build -d api worker broker db
+
+echo "Containers are starting. Use 'docker compose ps' to check status."


### PR DESCRIPTION
## Summary
- clarify how to run a PostgreSQL container when not using compose
- note in design overview that compose provides a `db` service
- add note in future updates entry about the `db` container
- add helper script to start containers
- warn if `DB_URL` is not explicitly set

## Testing
- `black . --line-length 88`
- `pip install -r requirements.txt` *(fails: could not fetch packages)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68605beade4c8325a20585b994862daa