### PR TITLE
Add Celery dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings",
     "alembic",                # Keep for DB migration
     "psycopg2-binary",
+    "celery>=5.3",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,9 @@ torch>=2.2.2
 pydub>=0.25.1
 pyttsx3>=2.90
 
+# --- Background task queue ---
+celery>=5.3
+
 # --- .env file support ---
 python-dotenv>=1.1.0
 pydantic-settings>=2.2.1


### PR DESCRIPTION
## Summary
- add Celery to requirements
- include Celery under project dependencies for `pyproject.toml`
- run `black .` for formatting

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68609b2186648325b600e679906f1850