### PR TITLE
Document Celery requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
 3. Install frontend dependencies from the `frontend` directory. The build
    requires **Node.js 18** or newer:
    ```bash
- cd frontend
+cd frontend
   npm install
   ```
    # install Redux packages for global state and toasts
+4. Install Celery if you plan to set `JOB_QUEUE_BACKEND=broker` or use Docker
+   Compose:
+   ```bash
+   pip install celery
+   ```
 
 ## Optional Environment Variables
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -67,6 +67,8 @@ object used throughout the code base. Available variables are:
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – JWT lifetime.
 - `MAX_CONCURRENT_JOBS` – worker thread count for the internal queue. This value can be changed at runtime via `/admin/concurrency`.
 - `JOB_QUEUE_BACKEND` – queue implementation (`thread` by default).
+- Celery must be installed when `JOB_QUEUE_BACKEND=broker` or using Docker
+  Compose.
 - `STORAGE_BACKEND` – where uploads and transcripts are stored.
 - `LOCAL_STORAGE_DIR` – base directory for the local storage backend. Defaults
   to the repository root.


### PR DESCRIPTION
## Summary
- note that Celery must be installed for broker queue usage
- sync design scope documentation

## Testing
- `black . --check`


------
https://chatgpt.com/codex/tasks/task_e_68609b28a1cc8325b07be5b409a37994