### PR TITLE
Expose DB retry attempts in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ cd frontend
 - `LOG_MAX_BYTES` – maximum size of each log file before rotation (defaults to
   `10000000`).
 - `LOG_BACKUP_COUNT` – how many rotated log files to keep (defaults to `3`).
+- `DB_CONNECT_ATTEMPTS` – how many times to retry connecting to the database on
+  startup (defaults to `10`).
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
 - `SECRET_KEY` – secret used to sign JWT tokens.
@@ -92,6 +94,9 @@ uvicorn api.main:app
 
 PostgreSQL must be available. The default `DB_URL` targets the `db` service
 (based on the `postgres:15-alpine` image) from `docker-compose.yml`.
+
+If startup fails, set `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` for verbose
+logs before launching the API.
 
 When `JOB_QUEUE_BACKEND` is set to `broker` a Celery worker must also be
 started:

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import os
+import time
 from pathlib import Path
 
 from sqlalchemy import inspect, create_engine
@@ -20,15 +21,27 @@ log = get_logger("orm")
 def validate_or_initialize_database():
     log.info("Bootstrapping database...")
 
-    # ── Step 1: Check database connection ──
-    try:
-        with engine.connect():
-            pass
-    except OperationalError:
-        log.critical(
-            "Database unreachable. Ensure a PostgreSQL service is running and DB_URL is correct."
-        )
-        sys.exit(1)
+    # ── Step 1: Check database connection with retries ──
+    max_attempts = settings.db_connect_attempts
+    for attempt in range(1, max_attempts + 1):
+        try:
+            with engine.connect():
+                break
+        except OperationalError:
+            if attempt == max_attempts:
+                log.critical(
+                    "Database unreachable after %s attempts. Ensure a PostgreSQL service is running and DB_URL is correct.",
+                    max_attempts,
+                )
+                sys.exit(1)
+            wait_time = attempt
+            log.warning(
+                "Database connection failed (attempt %s/%s). Retrying in %s second(s)...",
+                attempt,
+                max_attempts,
+                wait_time,
+            )
+            time.sleep(wait_time)
 
     # ── Step 2: Run Alembic migrations ──
     log.info("Running Alembic migrations to ensure schema is current...")

--- a/api/settings.py
+++ b/api/settings.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     log_to_stdout: bool = Field(False, env="LOG_TO_STDOUT")
     log_max_bytes: int = Field(10_000_000, env="LOG_MAX_BYTES")
     log_backup_count: int = Field(3, env="LOG_BACKUP_COUNT")
+    db_connect_attempts: int = Field(10, env="DB_CONNECT_ATTEMPTS")
     allow_registration: bool = Field(True, env="ALLOW_REGISTRATION")
     auth_username: str = Field("admin", env="AUTH_USERNAME")
     auth_password: str = Field("admin", env="AUTH_PASSWORD")

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -61,6 +61,8 @@ object used throughout the code base. Available variables are:
 - `LOG_MAX_BYTES` – maximum size of log files before rotation (defaults to
   `10000000`).
 - `LOG_BACKUP_COUNT` – number of rotated files to keep (defaults to `3`).
+- `DB_CONNECT_ATTEMPTS` – how many times to retry connecting to the database on
+  startup (defaults to `10`).
 - `AUTH_USERNAME` / `AUTH_PASSWORD` – *(deprecated)* old static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint.
 - `SECRET_KEY` – secret for JWT signing.


### PR DESCRIPTION
## Summary
- allow configuring database connect retries via `DB_CONNECT_ATTEMPTS`
- document the new setting in `README.md` and `docs/design_scope.md`
- refer users to `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` for troubleshooting
- reference the new setting from database bootstrap logic

## Testing
- `black . --quiet`
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686159d5a3908325ac18b4a57f88b384