### PR TITLE
Specify worker uid to silence Celery warning

### DIFF
--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -22,7 +22,6 @@ def validate_or_initialize_database():
     log.info("Bootstrapping database...")
 
     # ── Step 1: Check database connection with retries ──
-codex/investigate-application-errors-and-propose-fixes
     max_attempts = settings.db_connect_attempts
     for attempt in range(1, max_attempts + 1):
         try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,9 @@ services:
 
   worker:
     build: .
-    command: celery -A api.services.celery_app worker
+    # Explicitly specify the user so Celery doesn't warn about running as root
+    # See https://docs.celeryq.dev/en/stable/userguide/workers.html#running-the-worker-as-a-daemon
+    command: celery -A api.services.celery_app worker --uid=0 --gid=0
     environment:
       - VITE_API_HOST=http://localhost:8000
       - JOB_QUEUE_BACKEND=broker


### PR DESCRIPTION
## Summary
- pass `--uid` and `--gid` to Celery worker command
- fix stray text in `orm_bootstrap.py`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `(cd frontend && npm install)` *(fails: 403 Forbidden)*
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `coverage run -m pytest` *(fails: coverage: command not found)*
- `docker compose build worker` *(fails: docker: command not found)*
- `docker compose up worker` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ec39c3c483259737753b05353ee6