### PR TITLE
Remove compose file version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   api:
     build: .


### PR DESCRIPTION
## Summary
- drop deprecated `version` line from docker-compose.yml

## Testing
- `black .`
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862076ab0208325b1b4d5e5127136c7