### PR TITLE
Make SECRET_KEY required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd frontend
 
 ## Optional Environment Variables
 
-`api/settings.py` reads the following environment variables at startup:
+`api/settings.py` reads the following environment variables at startup. `SECRET_KEY` has no default and must be set:
 
 - `DB_URL` – SQLAlchemy connection string for the required PostgreSQL
   database. The default `postgresql+psycopg2://whisper:whisper@db:5432/whisper`
@@ -45,7 +45,8 @@ cd frontend
   startup (defaults to `10`).
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
-- `SECRET_KEY` – secret used to sign JWT tokens.
+ - `SECRET_KEY` – **required** secret used to sign JWT tokens. The application
+   exits on startup when this variable is missing.
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – token lifetime in minutes.
 - `MAX_CONCURRENT_JOBS` – number of worker threads when using the built-in job
   queue. Defaults to `2`. The value can also be changed at runtime via

--- a/api/config.py
+++ b/api/config.py
@@ -6,6 +6,8 @@ variables the old way so legacy imports keep working. New code should import
 """
 
 import os
+import logging
+import sys
 from dotenv import load_dotenv
 
 # Load environment variables from a .env file if present
@@ -41,6 +43,9 @@ STORAGE_BACKEND = os.getenv("STORAGE_BACKEND", "local")
 AUTH_USERNAME = os.getenv("AUTH_USERNAME", "admin")
 AUTH_PASSWORD = os.getenv("AUTH_PASSWORD", "admin")
 
-SECRET_KEY = os.getenv("SECRET_KEY", "change-me")
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    logging.critical("SECRET_KEY environment variable not set")
+    sys.exit(1)
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))

--- a/api/main.py
+++ b/api/main.py
@@ -45,9 +45,7 @@ ROOT = Path(__file__).parent
 # Read API host from environment with a default for local development.
 API_HOST = settings.vite_api_host
 if "VITE_API_HOST" not in os.environ:
-    system_log.warning(
-        "VITE_API_HOST not set, defaulting to http://localhost:8000"
-    )
+    system_log.warning("VITE_API_HOST not set, defaulting to http://localhost:8000")
 
 
 # ─── Lifespan Hook ───
@@ -119,9 +117,7 @@ def rehydrate_incomplete_jobs():
             .all()
         )
         for job in jobs:
-            backend_log.info(
-                f"Rehydrating job {job.id} with model '{job.model}'"
-            )
+            backend_log.info(f"Rehydrating job {job.id} with model '{job.model}'")
             try:
                 upload_path = storage.get_upload_path(job.saved_filename)
                 job_dir = storage.get_transcript_dir(job.id)

--- a/api/settings.py
+++ b/api/settings.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     allow_registration: bool = Field(True, env="ALLOW_REGISTRATION")
     auth_username: str = Field("admin", env="AUTH_USERNAME")
     auth_password: str = Field("admin", env="AUTH_PASSWORD")
-    secret_key: str = Field("change-me", env="SECRET_KEY")
+    secret_key: str = Field(..., env="SECRET_KEY")
     access_token_expire_minutes: int = Field(60, env="ACCESS_TOKEN_EXPIRE_MINUTES")
     max_concurrent_jobs: int = Field(2, env="MAX_CONCURRENT_JOBS")
     job_queue_backend: str = Field("thread", env="JOB_QUEUE_BACKEND")
@@ -58,4 +58,15 @@ class Settings(BaseSettings):
         env_file_encoding = "utf-8"
 
 
-settings = Settings()
+import logging
+import sys
+from pydantic import ValidationError
+
+try:
+    settings = Settings()
+except ValidationError as exc:
+    if any(err["loc"][0] == "secret_key" for err in exc.errors()):
+        logging.critical("SECRET_KEY environment variable not set")
+    else:
+        logging.critical("Invalid configuration: %s", exc)
+    sys.exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,9 @@ import os
 import importlib
 import wave
 
+# Ensure required settings exist before importing the application
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7,6 +7,7 @@ from api import models, orm_bootstrap
 
 def create_test_app(postgresql, tmp_path):
     os.environ["DB_URL"] = postgresql.url()
+    os.environ.setdefault("SECRET_KEY", "test-secret")
     import api.settings as settings
 
     importlib.reload(settings)


### PR DESCRIPTION
## Summary
- require SECRET_KEY in settings and config
- fail fast when missing by logging a critical message
- mention requirement in README
- update tests to provide SECRET_KEY

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862b0a16a4483259dbc5cddcc789286