### PR TITLE
Add PORT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY scripts/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh
+COPY scripts/server_entry.py ./scripts/server_entry.py
 
 COPY api         ./api
 COPY models      ./models
@@ -35,4 +36,4 @@ USER appuser
 ENV VITE_API_HOST=http://localhost:8000
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD /usr/local/bin/healthcheck.sh
-CMD ["uvicorn","api.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["python", "scripts/server_entry.py"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ cd frontend
   points to the `db` service (running the `postgres:15-alpine` image) defined in
   `docker-compose.yml`.
 - `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
+- `PORT` – TCP port used by the Uvicorn server (defaults to `8000`).
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
 - `LOG_FORMAT` – set to `json` for structured logs or `plain` for text (defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "8000:8000"
     environment:
       - SERVICE_TYPE=api
+      - PORT=8000 # change to run the API on a different port
       - VITE_API_HOST=http://localhost:8000
       - JOB_QUEUE_BACKEND=broker
       - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//

--- a/scripts/server_entry.py
+++ b/scripts/server_entry.py
@@ -1,4 +1,6 @@
+import os
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("api.main:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- allow overriding port via PORT env var in server_entry
- call server_entry in Dockerfile
- show PORT in docker-compose example
- document new variable in README

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `coverage run -m pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e6591d6c83258bf53fe3ca43e8bc