### PR TITLE
Add robust init helpers for timezone and storage

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from subprocess import Popen, PIPE
 from typing import Union
 from zoneinfo import ZoneInfo
+import sys
 
 from api.metadata_writer import run_metadata_writer
 from api.models import Job, JobStatusEnum
@@ -23,10 +24,20 @@ from api.paths import (
 # ─── Config ───
 from api.settings import settings
 
-LOCAL_TZ = ZoneInfo(settings.timezone)
-from api.services.job_queue import JobQueue, ThreadJobQueue, BrokerJobQueue
+from api.utils.logger import get_logger, get_system_logger
 
-from api.utils.logger import get_logger
+
+def init_timezone() -> ZoneInfo:
+    """Initialize timezone based on configuration."""
+    try:
+        return ZoneInfo(settings.timezone)
+    except Exception as exc:  # pragma: no cover - system exit
+        get_system_logger().critical(f"Invalid timezone '{settings.timezone}': {exc}")
+        sys.exit(1)
+
+
+LOCAL_TZ = init_timezone()
+from api.services.job_queue import JobQueue, ThreadJobQueue, BrokerJobQueue
 
 backend_log = get_logger("backend")
 ACCESS_LOG = LOG_DIR / "access.log"

--- a/api/paths.py
+++ b/api/paths.py
@@ -4,27 +4,33 @@ from pathlib import Path
 
 from api.settings import settings
 from api.services.storage import LocalStorage, CloudStorage, Storage
+from api.utils.logger import get_system_logger
+import sys
 
 ROOT = Path(__file__).parent
 BASE_DIR = ROOT.parent
 
 
-def _init_storage() -> Storage:
-    if settings.storage_backend == "local":
-        return LocalStorage(Path(settings.local_storage_dir))
-    elif settings.storage_backend == "cloud":
-        if not settings.s3_bucket:
-            raise ValueError("S3_BUCKET must be set for cloud storage")
-        return CloudStorage(
-            settings.s3_bucket,
-            aws_access_key_id=settings.aws_access_key_id,
-            aws_secret_access_key=settings.aws_secret_access_key,
-        )
-    else:
+def init_storage() -> Storage:
+    """Initialize the configured storage backend."""
+    try:
+        if settings.storage_backend == "local":
+            return LocalStorage(Path(settings.local_storage_dir))
+        if settings.storage_backend == "cloud":
+            if not settings.s3_bucket:
+                raise ValueError("S3_BUCKET must be set for cloud storage")
+            return CloudStorage(
+                settings.s3_bucket,
+                aws_access_key_id=settings.aws_access_key_id,
+                aws_secret_access_key=settings.aws_secret_access_key,
+            )
         raise ValueError(f"Unknown STORAGE_BACKEND: {settings.storage_backend}")
+    except Exception as exc:  # pragma: no cover - system exit
+        get_system_logger().critical(f"Storage initialization failed: {exc}")
+        sys.exit(1)
 
 
-storage = _init_storage()
+storage = init_storage()
 
 UPLOAD_DIR = storage.upload_dir
 TRANSCRIPTS_DIR = storage.transcripts_dir


### PR DESCRIPTION
## Summary
- create `init_timezone` for safe ZoneInfo startup
- add `init_storage` with logging and sys.exit on failure
- use helpers where previously direct assignments were used

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862eaad4b108325a72ddbfb109000f4