### PR TITLE
Add startup check for Celery broker

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -21,6 +21,7 @@ from api.app_state import (
     LOCAL_TZ,
     backend_log,
     start_cleanup_thread,
+    check_celery_connection,
 )
 
 # ─── Logging ───
@@ -54,6 +55,7 @@ async def lifespan(app: FastAPI):
     system_log.info("App startup — lifespan entering.")
     validate_or_initialize_database()
     validate_models_dir()
+    check_celery_connection()
     rehydrate_incomplete_jobs()
     if settings.cleanup_enabled:
         start_cleanup_thread()


### PR DESCRIPTION
## Summary
- check Celery broker connection during startup
- exit process if ping fails

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6862ec3e21c883258f36e39898159fcd