### PR TITLE
Improve model validation messages

### DIFF
--- a/api/utils/model_validation.py
+++ b/api/utils/model_validation.py
@@ -8,11 +8,10 @@ system_log = get_system_logger()
 def validate_models_dir():
     """Ensure MODEL_DIR contains all required Whisper model files."""
     if not MODEL_DIR.exists():
-        system_log.critical(
-            "Missing models directory. Populate models/ before running."
-        )
+        system_log.critical("Missing models directory: %s", MODEL_DIR.resolve())
         raise RuntimeError(
-            "Whisper models directory missing. Ensure models/ contains the required files."
+            f"Whisper models directory {MODEL_DIR.resolve()} is missing."
+            " Populate it with the required files before running."
         )
 
     required_models = [
@@ -28,9 +27,10 @@ def validate_models_dir():
     if missing:
         system_log.critical(
             "Missing model files in %s: %s",
-            MODEL_DIR,
+            MODEL_DIR.resolve(),
             ", ".join(missing),
         )
         raise RuntimeError(
-            f"Required model files missing: {', '.join(missing)}. Add them to models/."
+            f"Required model files missing from {MODEL_DIR.resolve()}: "
+            f"{', '.join(missing)}."
         )


### PR DESCRIPTION
## Summary
- mention the absolute model directory path in log messages and RuntimeErrors
- format file with `black`

## Testing
- `black api/utils/model_validation.py`
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686338eea5ac8325b4555433a0b447d6