### PR TITLE
Add build arg for SECRET_KEY and update docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,11 @@ COPY scripts/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh
 COPY scripts/server_entry.py ./scripts/server_entry.py
 
+ARG SECRET_KEY
 COPY api         ./api
 COPY models      ./models
-RUN python -c "from api.utils.model_validation import validate_models_dir; validate_models_dir()"
+RUN SECRET_KEY=${SECRET_KEY:-temp-secret} \
+    python -c "from api.utils.model_validation import validate_models_dir; validate_models_dir()"
 RUN mkdir -p uploads transcripts
 COPY frontend/dist ./api/static
 

--- a/README.md
+++ b/README.md
@@ -309,9 +309,10 @@ cd frontend
 npm run build
 cd ..
 ```
-Build the image with:
+Build the image with a secret key:
 ```bash
-docker build -t whisper-app .
+SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
+docker build --build-arg SECRET_KEY=$SECRET_KEY -t whisper-app .
 ```
 If you use a prebuilt image, mount the models directory at runtime.
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -41,6 +41,11 @@ cd frontend
 npm run build
 cd ..
 ```
+Provide a `SECRET_KEY` as a build argument since the image runs a validation
+step that loads application settings:
+```bash
+docker build --build-arg SECRET_KEY=<your_key> -t whisper-app .
+```
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.
 

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -299,3 +299,7 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 ### Docker Compose Helper Script
 - **Summary**: Added `scripts/start_containers.sh` to automatically build the frontend and start the Docker Compose stack.
 - **Motivation**: Simplifies setup by launching the API, worker, broker and database with one command.
+
+### Build Argument for SECRET_KEY
+- **Summary**: Dockerfile accepts a `SECRET_KEY` build argument so model validation can run during image creation.
+- **Motivation**: `validate_models_dir()` loads settings which require a secret key, so the build would fail without one.


### PR DESCRIPTION
## Summary
- allow providing SECRET_KEY during Docker builds
- document required build argument in README and design docs
- note completed update in future_updates

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6863152c23e083259ade8025b29b5c47