### PR TITLE
Update docker instructions for secret key

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ PostgreSQL instance; the compose file defaults to the `db` service
 ```bash
 docker run -p 8000:8000 \
   -e VITE_API_HOST=http://localhost:8000 \
+  -e SECRET_KEY=<your key> \
   -v $(pwd)/uploads:/app/uploads \
   -v $(pwd)/transcripts:/app/transcripts \
   -v $(pwd)/logs:/app/logs \
@@ -332,6 +333,14 @@ docker run -p 8000:8000 \
   -e LOG_TO_STDOUT=true \
   whisper-app
 ```
+
+Generate `SECRET_KEY` with:
+
+```bash
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+Alternatively copy `.env.example` to `.env` and set a secure value there before launching the container.
 
 Setting `LOG_TO_STDOUT=true` and `LOG_LEVEL=DEBUG` surfaces detailed logs, which
 helps diagnose bootstrapping failures when running inside Docker.


### PR DESCRIPTION
## Summary
- update `docker run` snippet to set `SECRET_KEY`
- show how to generate the key or use `.env.example`

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686468de50688325a23979d9ab115d46