### PR TITLE
Add frontend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
    ```bash
 cd frontend
   npm install
-  ```
+   ```
+   Copy `frontend/.env.example` to `frontend/.env` to configure `VITE_API_HOST`,
+   `VITE_DEV_HOST` and `VITE_DEV_PORT`.
    # install Redux packages for global state and toasts
 4. Install Celery if you plan to set `JOB_QUEUE_BACKEND=broker` or use Docker
    Compose:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# Base API URL used by the frontend to reach the backend
+VITE_API_HOST=http://localhost:8000
+
+# Hostname used when running `npm run dev`
+VITE_DEV_HOST=localhost
+
+# Port used when running `npm run dev`
+VITE_DEV_PORT=5173


### PR DESCRIPTION
## Summary
- document frontend env vars in `.env.example`
- update setup instructions to copy the file

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `coverage run -m pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686474834acc8325bd3220a9cf77662b