### PR TITLE
Document config module removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ cd frontend
 
 ## Optional Environment Variables
 
-`api/settings.py` reads the following environment variables at startup. `SECRET_KEY` has no default and must be set. When using Docker Compose, variables in a `.env` file at the project root are automatically loaded. Create this file by copying `.env.example` and replacing the placeholder with a unique value:
+`api/settings.py` reads the following environment variables at startup. `SECRET_KEY` has no default and must be set. When using Docker Compose, variables in a `.env` file at the project root are automatically loaded. Create this file by copying `.env.example` and replacing the placeholder with a unique value.
+
+The old `api/config.py` module is kept only for backward compatibility and will be removed in a future release. New code should import settings from `api.settings`.
 
 - `DB_URL` – SQLAlchemy connection string for the required PostgreSQL database in the form
   `postgresql+psycopg2://user:password@host:port/database`. The default

--- a/api/config.py
+++ b/api/config.py
@@ -1,3 +1,4 @@
+# NOTE: This module is unused and will be removed in a future release.
 """Deprecated module kept for backward compatibility.
 
 Use :mod:`api.settings` instead. This file now simply loads environment

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -53,7 +53,9 @@ Key environment files include `pyproject.toml`, `requirements.txt`, and the `Doc
 
 Application settings come from `api/settings.py`. It reads environment
 variables once using `pydantic_settings.BaseSettings` and exposes a `settings`
-object used throughout the code base. Available variables are:
+object used throughout the code base. The legacy `api/config.py` module is
+retained only for backward compatibility and will be removed in a future
+release. Available variables are:
 
 - `DB_URL` – SQLAlchemy connection string for the required PostgreSQL
   database. The default


### PR DESCRIPTION
## Summary
- document that `api/config.py` is unused
- emphasize `api.settings` in docs

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `npm install` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68647583fe648325befa6fae4e3f3707