### PR TITLE
Add startup configuration validation

### DIFF
--- a/api/config_validator.py
+++ b/api/config_validator.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+
+from api.settings import settings
+from api.utils.logger import get_system_logger
+
+log = get_system_logger()
+
+
+def validate_config() -> None:
+    """Validate required environment variables on startup."""
+    issues: list[str] = []
+
+    if not settings.secret_key:
+        issues.append("SECRET_KEY environment variable not set")
+
+    if not settings.db_url:
+        issues.append("DB_URL environment variable not set")
+
+    if settings.storage_backend == "cloud" and not settings.s3_bucket:
+        issues.append("S3_BUCKET must be set when STORAGE_BACKEND=cloud")
+
+    if issues:
+        log.critical("Invalid configuration detected:")
+        for item in issues:
+            log.critical(" - %s", item)
+        sys.exit(1)
+
+    log.debug("Configuration validated")

--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,7 @@ from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
 from api.models import JobStatusEnum
 from api.utils.logger import get_system_logger
+from api.config_validator import validate_config
 from api.utils.model_validation import validate_models_dir
 from api.router_setup import register_routes
 from api.middlewares.access_log import access_logger
@@ -26,6 +27,7 @@ from api.app_state import (
 
 # ─── Logging ───
 system_log = get_system_logger()
+validate_config()
 
 
 def log_startup_settings() -> None:

--- a/api/services/celery_app.py
+++ b/api/services/celery_app.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from celery import Celery
 
 from api.settings import settings
+from api.config_validator import validate_config
+
+validate_config()
 
 celery_app = Celery(
     "whisper_transcriber",


### PR DESCRIPTION
## Summary
- implement `api.config_validator` to fail fast when required env vars are missing
- run validator at API and Celery worker startup

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864772947c48325a9e97481b19b62b3