### PR TITLE
Update start script permissions and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ docker compose up --build api worker broker db
 ```
 
 The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
-An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. Use `docker compose down` to stop all services.
+An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. The script now fixes permissions on `uploads`, `transcripts` and `logs` so the API and worker can create log files. Use `docker compose down` to stop all services.
 Once running, access the API at `http://localhost:8000`.
 
 ## Testing

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -17,6 +17,8 @@ fi
 
 # Ensure persistent directories exist
 mkdir -p "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
+# Fix permissions in case they were created as root
+chown -R 1000:1000 "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
 
 if [ ! -d "$ROOT_DIR/models" ]; then
     echo "Models directory $ROOT_DIR/models is missing. Place Whisper model files here before running." >&2


### PR DESCRIPTION
## Summary
- ensure uploads, transcripts and logs are owned by UID 1000 in `start_containers.sh`
- note in README that the helper script now sets the correct permissions
- run `black .`

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864bc0a1ee0832582706b01ae08ce02