### PR TITLE
Improve compose docs and container setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,14 @@ docker compose up --build
 The compose file mounts the `uploads`, `transcripts`, `logs` and `models`
 directories so data and models persist between runs. These directories must
 exist on the host and be writable by UID `1000` because the containers run as a
-non-root `appuser`. The Dockerfile now creates `uploads/` and `transcripts/`
+non-root `appuser`. Create them and adjust ownership with:
+
+```bash
+mkdir -p uploads transcripts logs
+sudo chown -R 1000:1000 uploads transcripts logs
+```
+
+The Dockerfile now creates `uploads/` and `transcripts/`
 during the build so the API can write to them, but when they are mounted from
 the host this step is bypassed, making correct permissions on `logs/`,
 `uploads/` and `transcripts/` essential. The compose file defines a `db` service
@@ -391,7 +398,7 @@ docker compose up --build api worker broker db
 ```
 
 The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
-An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. The script now fixes permissions on `uploads`, `transcripts` and `logs` so the API and worker can create log files. Use `docker compose down` to stop all services.
+An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. The script now fixes permissions on `uploads`, `transcripts` and `logs`, using `sudo` automatically when required, so the API and worker can create log files. Use `docker compose down` to stop all services.
 Once running, access the API at `http://localhost:8000`.
 
 ## Testing

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -4,6 +4,16 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Re-run the script with sudo if not already root so ownership can be adjusted
+if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null; then
+        exec sudo "$0" "$@"
+    else
+        echo "sudo is required to set directory ownership" >&2
+        exit 1
+    fi
+fi
+
 # Install and build the frontend if needed
 if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
     echo "Installing frontend dependencies..."


### PR DESCRIPTION
## Summary
- clarify how to create Docker volumes with correct ownership
- automatically use `sudo` in `start_containers.sh` when needed

## Testing
- `black --check .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `coverage run -m pytest` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68652b76ee288325b92349726093c523