### PR TITLE
Add Docker entrypoint for permission handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ffmpeg git curl && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+      ffmpeg git curl gosu && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user to run Celery workers
 RUN groupadd -g 1000 appuser && \
@@ -20,6 +20,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
 COPY scripts/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh
 COPY scripts/server_entry.py ./scripts/server_entry.py
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ARG SECRET_KEY
 COPY api         ./api
@@ -33,10 +35,9 @@ COPY frontend/dist ./api/static
 # Default service type for healthcheck script
 ENV SERVICE_TYPE=api
 
-# Switch to non-root user for running the application
-USER appuser
 
 ENV VITE_API_HOST=http://localhost:8000
 EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD /usr/local/bin/healthcheck.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python", "scripts/server_entry.py"]

--- a/README.md
+++ b/README.md
@@ -373,19 +373,10 @@ docker compose up --build
 ```
 
 The compose file mounts the `uploads`, `transcripts`, `logs` and `models`
-directories so data and models persist between runs. These directories must
-exist on the host and be writable by UID `1000` because the containers run as a
-non-root `appuser`. Create them and adjust ownership with:
-
-```bash
-mkdir -p uploads transcripts logs
-sudo chown -R 1000:1000 uploads transcripts logs
-```
-
-The Dockerfile now creates `uploads/` and `transcripts/`
-during the build so the API can write to them, but when they are mounted from
-the host this step is bypassed, making correct permissions on `logs/`,
-`uploads/` and `transcripts/` essential. The compose file defines a `db` service
+directories so data and models persist between runs. These directories will be
+created automatically inside the containers and ownership fixed to UID `1000`
+by the entrypoint script, so no manual `chown` step is required. The compose
+file defines a `db` service
 using the `postgres:15-alpine` image and sets `DB_URL` on the API and worker so
 they connect to it. It also configures
 Celery with RabbitMQ by setting `JOB_QUEUE_BACKEND=broker`,
@@ -398,7 +389,7 @@ docker compose up --build api worker broker db
 ```
 
 The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
-An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. The script now fixes permissions on `uploads`, `transcripts` and `logs`, using `sudo` automatically when required, so the API and worker can create log files. Use `docker compose down` to stop all services.
+An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. Because the containers fix permissions automatically, the script no longer needs to run with sudo. Use `docker compose down` to stop all services.
 Once running, access the API at `http://localhost:8000`.
 
 ## Testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,7 @@ services:
 
   worker:
     build: .
-    # Run Celery as a non-root user
-    # See https://docs.celeryq.dev/en/stable/userguide/workers.html#running-the-worker-as-a-daemon
-    command: celery -A api.services.celery_app worker --uid=1000 --gid=1000
+    command: celery -A api.services.celery_app worker
     environment:
       - SERVICE_TYPE=worker
       - VITE_API_HOST=http://localhost:8000

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+mkdir -p /app/uploads /app/transcripts /app/logs
+chown -R 1000:1000 /app/uploads /app/transcripts /app/logs
+exec gosu appuser "$@"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -4,15 +4,6 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
-# Re-run the script with sudo if not already root so ownership can be adjusted
-if [ "$(id -u)" -ne 0 ]; then
-    if command -v sudo >/dev/null; then
-        exec sudo "$0" "$@"
-    else
-        echo "sudo is required to set directory ownership" >&2
-        exit 1
-    fi
-fi
 
 # Install and build the frontend if needed
 if [ ! -d "$ROOT_DIR/frontend/node_modules" ]; then
@@ -27,8 +18,6 @@ fi
 
 # Ensure persistent directories exist
 mkdir -p "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
-# Fix permissions in case they were created as root
-chown -R 1000:1000 "$ROOT_DIR/uploads" "$ROOT_DIR/transcripts" "$ROOT_DIR/logs"
 
 if [ ! -d "$ROOT_DIR/models" ]; then
     echo "Models directory $ROOT_DIR/models is missing. Place Whisper model files here before running." >&2


### PR DESCRIPTION
## Summary
- add `scripts/docker-entrypoint.sh` that prepares dirs and drops to appuser
- install gosu in Dockerfile, copy entrypoint, and remove `USER` directive
- use entrypoint to start containers and simplify worker command
- remove chown logic from `start_containers.sh`
- document automatic permission handling

## Testing
- `black .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68655d3be33c83258ff9e1c953862923