### PR TITLE
Improve /health db check

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,10 @@ Available metrics:
 
 ### Health & Version
 
-Use `/health` to check server status. `/version` returns the current application version.
+`/health` now verifies the database connection by running a simple query. It returns
+`{"status": "ok"}` when the check succeeds or `{"status": "db_error"}` with details
+and a 500 status code if the query fails. `/version` returns the current
+application version.
 
 ### Progress WebSocket
 

--- a/api/main.py
+++ b/api/main.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
 from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
@@ -97,7 +99,15 @@ app.middleware("http")(access_logger)
 # ─── Static File Routes ───
 @app.get("/health")
 def health_check():
-    return {"status": "ok"}
+    try:
+        with SessionLocal() as db:
+            db.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as exc:
+        return JSONResponse(
+            status_code=500,
+            content={"status": "db_error", "detail": str(exc)},
+        )
 
 
 @app.get("/version")

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -131,6 +131,8 @@ This document summarizes the repository layout and how the core FastAPI service 
 
 ### Backend
 - REST endpoints handle job submission, progress checks, downloads and admin operations.
+- `/health` verifies the database connection and returns `{"status": "db_error"}`
+  with a 500 code when the query fails.
 - Whisper runs in a background thread writing transcripts to `transcripts/` and logs to `logs/`.
 - Metadata is extracted from each transcript and persisted to the database.
 - Jobs survive server restarts by being rehydrated on startup if processing was incomplete.

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,29 @@
+import importlib
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.main as main
+
+
+def test_health_db_failure(monkeypatch):
+    def bad_session():
+        class Dummy:
+            def __enter__(self):
+                raise Exception("boom")
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        return Dummy()
+
+    monkeypatch.setattr(main, "SessionLocal", bad_session)
+
+    app = FastAPI()
+    app.add_api_route("/health", main.health_check, methods=["GET"])
+
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data["status"] == "db_error"
+    assert "boom" in data["detail"]


### PR DESCRIPTION
## Summary
- check DB connection on `/health`
- add failing DB test for `/health`
- document new health-check behaviour in README and design docs

## Testing
- `pip install -r requirements.txt` *(fails: could not fetch packages)*
- `(cd frontend && npm install)` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865881077708325b40940318e65f3d6