### PR TITLE
Update health_check error handling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -104,10 +104,8 @@ def health_check():
             db.execute(text("SELECT 1"))
         return {"status": "ok"}
     except Exception as exc:
-        return JSONResponse(
-            status_code=500,
-            content={"status": "db_error", "detail": str(exc)},
-        )
+        system_log.error(f"Health check failed: {exc}")
+        return JSONResponse(status_code=500, content={"status": "db_error"})
 
 
 @app.get("/version")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -26,4 +26,3 @@ def test_health_db_failure(monkeypatch):
     assert resp.status_code == 500
     data = resp.json()
     assert data["status"] == "db_error"
-    assert "boom" in data["detail"]


### PR DESCRIPTION
## Summary
- log DB health check failures via `system_log.error`
- return a generic `{"status": "db_error"}` message
- update failing test expectation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865c61e8d108325a287b87674a63d21