### PR TITLE
Validate job model names

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -68,3 +68,17 @@ def test_submit_and_fetch_job(postgresql, tmp_path, sample_wav):
     assert data["original_filename"] == "test.wav"
     assert data["model"] == "base"
     assert data["status"] == "queued"
+
+
+def test_submit_invalid_model(postgresql, tmp_path, sample_wav):
+    app = create_test_app(postgresql, tmp_path)
+    client = TestClient(app)
+
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/jobs",
+            data={"model": "bogus"},
+            files={"file": ("test.wav", f, "audio/wav")},
+        )
+
+    assert resp.status_code == 400

--- a/tests/test_jobs_api.py
+++ b/tests/test_jobs_api.py
@@ -45,6 +45,16 @@ def test_job_lifecycle(client, sample_wav):
         assert db.query(Job).get(job_id) is None
 
 
+def test_submit_invalid_model_api(client, sample_wav):
+    with sample_wav.open("rb") as f:
+        resp = client.post(
+            "/jobs",
+            data={"model": "bogus"},
+            files={"file": ("bad.wav", f, "audio/wav")},
+        )
+    assert resp.status_code == 400
+
+
 def test_list_jobs_search_filter(client, sample_wav):
     with sample_wav.open("rb") as f:
         resp = client.post(


### PR DESCRIPTION
## Summary
- restrict allowed models for job creation
- error if model param is invalid
- test invalid model handling via API and direct app

## Testing
- `black api/routes/jobs.py tests/test_jobs.py tests/test_jobs_api.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865c79abbd883259a2b10ccf8824c1f