### PR TITLE
Wrap debug logs with log level checks

### DIFF
--- a/api/config_validator.py
+++ b/api/config_validator.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sys
 
+import logging
+
 from api.settings import settings
 from api.utils.logger import get_system_logger
 
@@ -27,4 +29,5 @@ def validate_config() -> None:
             log.critical(" - %s", item)
         sys.exit(1)
 
-    log.debug("Configuration validated")
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug("Configuration validated")

--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import os
 import time
+import logging
 from pathlib import Path
 
 from sqlalchemy import inspect, create_engine
@@ -42,7 +43,8 @@ def validate_or_initialize_database():
                 max_attempts,
                 wait_time,
             )
-            log.debug("Connection error: %s", exc)
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug("Connection error: %s", exc)
             time.sleep(wait_time)
 
     # ── Step 2: Run Alembic migrations ──

--- a/api/router_setup.py
+++ b/api/router_setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import logging
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
@@ -58,8 +59,9 @@ def register_routes(app: FastAPI) -> None:
             raise HTTPException(status_code=404, detail="Not Found")
         return FileResponse(static_dir / "index.html")
 
-    backend_log.debug("\nSTATIC ROUTE CHECK:")
-    for route in app.routes:
-        backend_log.debug(
-            f"Path: {getattr(route, 'path', 'n/a')}  →  Name: {getattr(route, 'name', 'n/a')}  →  Type: {type(route)}"
-        )
+    if backend_log.isEnabledFor(logging.DEBUG):
+        backend_log.debug("\nSTATIC ROUTE CHECK:")
+        for route in app.routes:
+            backend_log.debug(
+                f"Path: {getattr(route, 'path', 'n/a')}  →  Name: {getattr(route, 'name', 'n/a')}  →  Type: {type(route)}"
+            )


### PR DESCRIPTION
## Summary
- ensure debug logging only triggers when enabled
- guard router route dump with debug check

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865db7ae7848325812482f2c06d6e98