### PR TITLE
Implement timeout handling for whisper subprocess

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -155,7 +155,10 @@ def handle_whisper(
                     stdout_thread.start()
                     stderr_thread.start()
 
-                    proc.wait()
+                    wait_args = {}
+                    if settings.whisper_timeout_seconds > 0:
+                        wait_args["timeout"] = settings.whisper_timeout_seconds
+                    proc.wait(**wait_args)
                     stdout_thread.join()
                     stderr_thread.join()
                     logger.info(f"Whisper exited with code {proc.returncode}")

--- a/api/settings.py
+++ b/api/settings.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     )
     whisper_bin: str = Field("whisper", env="WHISPER_BIN")
     whisper_language: str = Field("en", env="WHISPER_LANGUAGE")
+    whisper_timeout_seconds: int = Field(0, env="WHISPER_TIMEOUT_SECONDS")
     model_dir: str = Field(
         default=str(Path(__file__).resolve().parent.parent / "models"),
         env="MODEL_DIR",

--- a/tests/test_handle_whisper_failure.py
+++ b/tests/test_handle_whisper_failure.py
@@ -1,6 +1,7 @@
 import importlib
 import io
 import shutil
+import subprocess
 from pathlib import Path
 
 from api import app_state, paths, orm_bootstrap
@@ -81,3 +82,57 @@ def test_transcript_dir_removed_on_metadata_failure(
     with orm_bootstrap.SessionLocal() as db:
         job = db.query(Job).get(job_id)
         assert job.status == JobStatusEnum.FAILED_UNKNOWN
+
+
+def test_whisper_timeout_sets_failed_status(temp_db, tmp_path, sample_wav, monkeypatch):
+    storage = setup_storage(tmp_path)
+    importlib.reload(app_state)
+    app_state.UPLOAD_DIR = paths.UPLOAD_DIR
+    app_state.TRANSCRIPTS_DIR = paths.TRANSCRIPTS_DIR
+    app_state.LOG_DIR = paths.LOG_DIR
+
+    class TimeoutPopen:
+        def __init__(self, cmd, stdout=None, stderr=None, text=True, bufsize=1):
+            self.cmd = cmd
+            self.stdout = io.StringIO()
+            self.stderr = io.StringIO()
+            self.returncode = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(self.cmd, timeout)
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(app_state, "Popen", TimeoutPopen)
+    monkeypatch.setattr(app_state.shutil, "which", lambda x: "/bin/echo")
+    monkeypatch.setattr(app_state.settings, "whisper_timeout_seconds", 1)
+
+    job_id = "job_timeout"
+    upload_path = storage.upload_dir / "file.wav"
+    shutil.copy(sample_wav, upload_path)
+    job_dir = storage.transcripts_dir / job_id
+
+    with orm_bootstrap.SessionLocal() as db:
+        db.add(
+            Job(
+                id=job_id,
+                original_filename="file.wav",
+                saved_filename="file.wav",
+                model="base",
+                status=JobStatusEnum.QUEUED,
+            )
+        )
+        db.commit()
+
+    app_state.handle_whisper(job_id, upload_path, job_dir, "base", start_thread=False)
+
+    with orm_bootstrap.SessionLocal() as db:
+        job = db.query(Job).get(job_id)
+        assert job.status == JobStatusEnum.FAILED_TIMEOUT


### PR DESCRIPTION
## Summary
- add configurable `whisper_timeout_seconds` setting
- support timeout when waiting for whisper subprocess
- test failed status when whisper times out

## Testing
- `pip install -r requirements.txt` *(fails: Could not find fastapi)*
- `(cd frontend && npm install)` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866b83a3b4083259e237d2e43c4d587