### PR TITLE
Add docker_build.sh script with Docker cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ the container logs in the console.
 
 The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ.
 An optional helper script `scripts/start_containers.sh` automates these steps. Run it from the repository root to build the frontend if needed and launch the compose stack in detached mode. The script uses sudo only to adjust ownership of the `uploads`, `transcripts` and `logs` directories. Use `docker compose down` to stop all services.
+Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch.
 Once running, access the API at `http://localhost:8000`.
 
 ## Testing

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -33,6 +33,7 @@ The application is considered working once these basics are functional:
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
 - `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
+- `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove existing containers, images and volumes to start fresh
+docker compose down -v --remove-orphans || true
+docker system prune -af --volumes
+
+# Update the repo
+git fetch
+git pull
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Install and build the frontend
+cd frontend
+npm install
+npm run build
+cd ..
+
+# Verify Whisper model files exist
+MODELS=(base.pt small.pt medium.pt large-v3.pt tiny.pt)
+for m in "${MODELS[@]}"; do
+    if [ ! -f "models/$m" ]; then
+        echo "Missing models/$m. Populate the models/ directory before building." >&2
+        exit 1
+    fi
+done
+
+# Ensure .env with SECRET_KEY
+if [ ! -f ".env" ]; then
+    cp .env.example .env
+fi
+
+SECRET_KEY=$(grep -E '^SECRET_KEY=' .env | cut -d= -f2-)
+if [ -z "$SECRET_KEY" ] || [ "$SECRET_KEY" = "CHANGE_ME" ]; then
+    SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
+    sed -i "s/^SECRET_KEY=.*/SECRET_KEY=$SECRET_KEY/" .env
+    echo "Generated SECRET_KEY saved in .env"
+fi
+
+# Build the Docker image using the secret key
+docker build --build-arg SECRET_KEY="$SECRET_KEY" -t whisper-app .
+
+# Start the compose stack
+docker compose up --build api worker broker db
+


### PR DESCRIPTION
## Summary
- add `scripts/docker_build.sh` to rebuild from a clean Docker state
- document the new script in README and design docs

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686706c52a9483259b427d70fe20e59e