### PR TITLE
Fix login error message handling

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -22,8 +22,8 @@ export default function LoginPage() {
       );
       login(data.access_token);
       window.location.href = ROUTES.UPLOAD;
-    } catch {
-      setError("Network error");
+    } catch (err) {
+      setError(err.message || "Login failed");
     }
   };
 


### PR DESCRIPTION
## Summary
- bubble up backend error message on login failure
- rebuild front-end

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68693133353483258642e18337b5605a