### PR TITLE
Add default admin account and password change workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ creates regular users. Set `ALLOW_REGISTRATION=false` in production to disable
 this endpoint. Obtain a token from `/token` using the same credentials. JWT
 payloads now include the user role so clients can inspect their privileges.
 
+The application ships with a built-in `admin` account using the password
+`admin`. Logging in with these credentials returns a token with
+`must_change_password=true`. Call `/change-password` with the new password and
+the token to update it before continuing.
+
 ### User Management
 
 Admins can manage accounts via two endpoints:

--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,7 @@ except (ConfigurationError, InitError) as exc:  # pragma: no cover - startup fai
 from api.orm_bootstrap import SessionLocal, validate_or_initialize_database
 from api.models import Job
 from api.models import JobStatusEnum
+from api.services.users import ensure_default_admin
 from api.utils.model_validation import validate_models_dir
 from api.router_setup import register_routes
 from api.middlewares.access_log import access_logger
@@ -64,6 +65,7 @@ if "VITE_API_HOST" not in os.environ:
 async def lifespan(app: FastAPI):
     system_log.info("App startup — lifespan entering.")
     validate_or_initialize_database()
+    ensure_default_admin(settings.auth_username, settings.auth_password)
     validate_models_dir()
     system_log.info(
         "Startup complete: DB connected, storage backend %s ready, job queue %s, timezone %s",

--- a/api/migrations/versions/b8b3752f3e16_add_must_change_password_column.py
+++ b/api/migrations/versions/b8b3752f3e16_add_must_change_password_column.py
@@ -1,0 +1,33 @@
+"""add must_change_password column to users
+
+Revision ID: b8b3752f3e16
+Revises: f9f3e87495ad
+Create Date: 2025-07-05
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b8b3752f3e16"
+down_revision: Union[str, None] = "f9f3e87495ad"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "must_change_password",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.alter_column("users", "must_change_password", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "must_change_password")

--- a/api/models.py
+++ b/api/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum as PyEnum
 from typing import Optional
 
-from sqlalchemy import DateTime, Enum, Integer, String, Text, Float
+from sqlalchemy import DateTime, Enum, Integer, String, Text, Float, Boolean
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy import ForeignKey
 
@@ -20,6 +20,9 @@ class User(Base):
     username: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     hashed_password: Mapped[str] = mapped_column(String, nullable=False)
     role: Mapped[str] = mapped_column(String, nullable=False, default="user")
+    must_change_password: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False
     )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -75,6 +75,14 @@ class TokenOut(BaseModel):
     token_type: str
 
 
+class TokenLoginOut(TokenOut):
+    must_change_password: bool | None = None
+
+
+class PasswordChangeIn(BaseModel):
+    password: str
+
+
 class CleanupConfigOut(BaseModel):
     cleanup_enabled: bool
     cleanup_days: int

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import JobStatusPage from "./pages/JobStatusPage";
 import FailedJobsPage from "./pages/FailedJobsPage";
 import JobProgressPage from "./pages/JobProgressPage";
 import LoginPage from "./pages/LoginPage";
+import ChangePasswordPage from "./pages/ChangePasswordPage";
 import FileBrowserPage from "./pages/FileBrowserPage";
 import { AuthContext } from "./context/AuthContext";
 import { useApi } from "./api";
@@ -39,6 +40,7 @@ export default function App() {
           <Route path={ROUTES.ADMIN} element={isAuthenticated ? <AdminPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.FILE_BROWSER} element={isAuthenticated ? <FileBrowserPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.SETTINGS} element={isAuthenticated && role === "admin" ? <SettingsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
+          <Route path={ROUTES.CHANGE_PASSWORD} element={isAuthenticated ? <ChangePasswordPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.TRANSCRIPT_VIEW} element={isAuthenticated ? <TranscriptViewPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.STATUS} element={isAuthenticated ? <JobStatusPage /> : <Navigate to={ROUTES.LOGIN} replace />} />
           <Route path={ROUTES.FAILED} element={isAuthenticated ? <FailedJobsPage /> : <Navigate to={ROUTES.LOGIN} replace />} />

--- a/frontend/src/pages/ChangePasswordPage.jsx
+++ b/frontend/src/pages/ChangePasswordPage.jsx
@@ -1,0 +1,51 @@
+import { useState, useContext } from "react";
+import { useApi } from "../api";
+import { AuthContext } from "../context/AuthContext";
+import { ROUTES } from "../routes";
+
+export default function ChangePasswordPage() {
+  const api = useApi();
+  const { logout } = useContext(AuthContext);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await api.post("/change-password", { password });
+      window.location.href = ROUTES.UPLOAD;
+    } catch (err) {
+      setError(err.message || "Failed to change password");
+    }
+  };
+
+  const handleLogout = () => {
+    logout();
+    window.location.href = ROUTES.LOGIN;
+  };
+
+  return (
+    <div className="page-content" style={{ maxWidth: "400px", margin: "0 auto" }}>
+      <h2>Change Password</h2>
+      <form onSubmit={handleSubmit} style={{ marginTop: "1rem" }}>
+        <div style={{ marginBottom: "0.5rem" }}>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="New Password"
+            style={{ padding: "0.5rem", width: "100%" }}
+          />
+        </div>
+        <button type="submit" style={{ padding: "0.5rem 1rem" }}>
+          Save Password
+        </button>
+      </form>
+      <button onClick={handleLogout} style={{ marginTop: "1rem" }}>
+        Cancel
+      </button>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -21,14 +21,19 @@ export default function LoginPage() {
         { headers: { "Content-Type": "application/x-www-form-urlencoded" } }
       );
       login(data.access_token);
-      window.location.href = ROUTES.UPLOAD;
-    } catch {
-      setError("Network error");
+      if (data.must_change_password) {
+        window.location.href = ROUTES.CHANGE_PASSWORD;
+      } else {
+        window.location.href = ROUTES.UPLOAD;
+      }
+    } catch (err) {
+      setError(err.message || "Login failed");
     }
   };
 
   return (
     <div className="page-content" style={{ maxWidth: "400px", margin: "0 auto" }}>
+      <h1 style={{ textAlign: "center" }}>Whisper Transcriber</h1>
       <h2>Login</h2>
       <form onSubmit={handleSubmit} style={{ marginTop: "1rem" }}>
         <div style={{ marginBottom: "0.5rem" }}>

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -10,6 +10,7 @@ export const ROUTES = {
   STATUS: "/status/:jobId",
   PROGRESS: "/progress/:jobId",
   FILE_BROWSER: "/admin/files",
+  CHANGE_PASSWORD: "/change-password",
   API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
 };
 


### PR DESCRIPTION
## Summary
- create `must_change_password` flag for User model
- ensure default admin user exists at startup
- return flag from login endpoint and add password change route
- add ChangePasswordPage and login banner
- document default credentials
- migration for new column

## Testing
- `npm run build --silent`
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68693133353483258642e18337b5605a