### PR TITLE
Display app name on all pages

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -16,17 +16,22 @@ export default function Layout({ children }) {
     <div
       style={{
         display: "flex",
+        flexDirection: "column",
         minHeight: "100vh",
         backgroundColor: "#18181b",
         color: "white",
       }}
     >
       <ToastContainer />
-      <aside className="side-nav">
-        <nav style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-          <Link to={ROUTES.UPLOAD} style={linkStyle}>
-            Upload
-          </Link>
+      <header className="app-header">
+        <h1 style={{ margin: 0 }}>Whisper Transcriber</h1>
+      </header>
+      <div style={{ display: "flex", flex: 1 }}>
+        <aside className="side-nav">
+          <nav style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+            <Link to={ROUTES.UPLOAD} style={linkStyle}>
+              Upload
+            </Link>
           <Link to={ROUTES.ACTIVE} style={linkStyle}>
             Active Jobs
           </Link>
@@ -57,10 +62,11 @@ export default function Layout({ children }) {
             </Link>
           )}
         </nav>
-      </aside>
-      <main className="page-content" style={{ flex: 1 }}>
-        {children}
-      </main>
+        </aside>
+        <main className="page-content" style={{ flex: 1 }}>
+          {children}
+        </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,6 +38,13 @@ nav {
   border-right: 1px solid #3f3f46;
 }
 
+.app-header {
+  background-color: #27272a;
+  border-bottom: 1px solid #3f3f46;
+  text-align: center;
+  padding: 1rem;
+}
+
 @media (max-width: 600px) {
   table {
     display: block;


### PR DESCRIPTION
## Summary
- add top header to layout
- style the header in global CSS

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68692ae881048325b1ed58fb5c348919