### PR TITLE
Pin bcrypt and mention in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
    # required for running tests
    pip install -r requirements-dev.txt
    ```
+   The `bcrypt` dependency is pinned to `<4` for compatibility with
+   `passlib`. If installing packages manually ensure this version
+   constraint is respected.
 2. Install system dependencies. `ffmpeg` (providing `ffprobe`) must be present
    for audio processing features. On Linux you can install it with:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ psycopg2-binary>=2.9
 
 # --- Auth / security (future-proofing) ---
 passlib[bcrypt]>=1.7.4
+bcrypt<4
 python-jose[cryptography]>=3.3.0
 
 # --- Speech-to-text ---


### PR DESCRIPTION
## Summary
- add `bcrypt<4` pin below passlib in requirements
- note bcrypt pin in README install steps
- run black formatting

## Testing
- `coverage run -m pytest` *(fails: command not found)*
- `coverage report` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686963aa95808325a06813cbc27b685b