### PR TITLE
Add size limit check for cloud storage uploads

### DIFF
--- a/api/services/storage.py
+++ b/api/services/storage.py
@@ -129,6 +129,9 @@ class CloudStorage(Storage):
         dest = self._upload_dir / filename
         with dest.open("wb") as dst:
             shutil.copyfileobj(source, dst)
+        if dest.stat().st_size > settings.max_upload_size:
+            dest.unlink(missing_ok=True)
+            raise http_error(ErrorCode.FILE_TOO_LARGE)
         self.s3.upload_file(str(dest), self.bucket, f"uploads/{filename}")
         return dest
 

--- a/tests/test_upload_size.py
+++ b/tests/test_upload_size.py
@@ -1,7 +1,8 @@
 import io
 import pytest
+import tempfile
 
-from api.services.storage import LocalStorage
+from api.services.storage import LocalStorage, CloudStorage
 from api.errors import ErrorCode
 from api.settings import settings
 from fastapi import HTTPException
@@ -13,5 +14,23 @@ def test_save_upload_enforces_size_limit(tmp_path, monkeypatch):
     data = io.BytesIO(b"x" * 11)
     with pytest.raises(HTTPException) as exc:
         storage.save_upload(data, "big.bin")
+    assert exc.value.detail["code"] == ErrorCode.FILE_TOO_LARGE
+    assert not (storage.upload_dir / "big.bin").exists()
+
+
+class DummyS3:
+    def upload_file(self, *a, **k):
+        pass
+
+
+def test_cloud_save_upload_enforces_size_limit(tmp_path, monkeypatch):
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    storage = CloudStorage("bucket")
+    storage.s3 = DummyS3()
+    monkeypatch.setattr(settings, "max_upload_size", 10)
+    data = io.BytesIO(b"x" * 11)
+    with pytest.raises(HTTPException) as exc:
+        storage.save_upload(data, "big.bin")
+    assert exc.value.status_code == 413
     assert exc.value.detail["code"] == ErrorCode.FILE_TOO_LARGE
     assert not (storage.upload_dir / "big.bin").exists()


### PR DESCRIPTION
## Summary
- enforce `MAX_UPLOAD_SIZE` in `CloudStorage.save_upload`
- test oversize upload handling with the cloud backend

## Testing
- `pip install -r requirements.txt` *(fails: no internet)*
- `pip install -r requirements-dev.txt` *(fails: no internet)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686966ec11ac8325a6f87207ee67824b