### PR TITLE
Add thread safety for progress connections

### DIFF
--- a/api/routes/progress.py
+++ b/api/routes/progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from typing import Dict, Set
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -12,22 +13,29 @@ router = APIRouter()
 
 # Store active websocket connections per job id
 progress_connections: Dict[str, Set[WebSocket]] = {}
+progress_lock = threading.Lock()
 
 
 async def _broadcast(job_id: str, status: str) -> None:
     """Send a status update to all websockets for this job."""
-    websockets = progress_connections.get(job_id)
-    if not websockets:
-        return
+    with progress_lock:
+        websockets = progress_connections.get(job_id)
+        if not websockets:
+            return
+        targets = set(websockets)
     stale: Set[WebSocket] = set()
-    for ws in list(websockets):
+    for ws in list(targets):
         try:
             await ws.send_json({"status": status})
         except Exception:
             stale.add(ws)
-    websockets.difference_update(stale)
-    if not websockets:
-        progress_connections.pop(job_id, None)
+    if stale:
+        with progress_lock:
+            conns = progress_connections.get(job_id)
+            if conns:
+                conns.difference_update(stale)
+                if not conns:
+                    progress_connections.pop(job_id, None)
 
 
 def send_progress_update(job_id: str, status: str) -> None:
@@ -45,15 +53,17 @@ async def websocket_progress(
     websocket: WebSocket, job_id: str, user: User = Depends(get_current_user)
 ) -> None:
     await websocket.accept()
-    progress_connections.setdefault(job_id, set()).add(websocket)
+    with progress_lock:
+        progress_connections.setdefault(job_id, set()).add(websocket)
     try:
         while True:
             await asyncio.sleep(60)
     except WebSocketDisconnect:
         pass
     finally:
-        connections = progress_connections.get(job_id)
-        if connections:
-            connections.discard(websocket)
-            if not connections:
-                progress_connections.pop(job_id, None)
+        with progress_lock:
+            connections = progress_connections.get(job_id)
+            if connections:
+                connections.discard(websocket)
+                if not connections:
+                    progress_connections.pop(job_id, None)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,37 @@
+import threading
+import importlib
+
+from api.routes import progress
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.messages = []
+
+    async def send_json(self, data):
+        self.messages.append(data)
+
+
+def test_concurrent_progress_updates():
+    importlib.reload(progress)
+    job_id = "job1"
+    ws = DummyWebSocket()
+    with progress.progress_lock:
+        progress.progress_connections[job_id] = {ws}
+
+    errors = []
+
+    def worker():
+        try:
+            progress.send_progress_update(job_id, "processing")
+        except Exception as exc:  # pragma: no cover - ensure no exceptions
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert len(ws.messages) == 5


### PR DESCRIPTION
## Summary
- protect `progress_connections` with `progress_lock`
- test concurrent updates to ensure thread safety

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686968137124832598ab5bb3df4ce723