### PR TITLE
Catch missing Alembic

### DIFF
--- a/api/orm_bootstrap.py
+++ b/api/orm_bootstrap.py
@@ -74,6 +74,11 @@ def validate_or_initialize_database():
         if e.stderr:
             log.critical("Alembic STDERR:\n%s", e.stderr)
         raise RuntimeError("Alembic migrations failed") from e
+    except FileNotFoundError as e:
+        log.critical(
+            "Alembic command not found. Ensure Alembic is installed and on PATH."
+        )
+        raise RuntimeError("Alembic not installed") from e
 
     # ── Step 3: Validate expected tables exist ──
     inspector = inspect(engine)

--- a/tests/test_orm_bootstrap.py
+++ b/tests/test_orm_bootstrap.py
@@ -1,0 +1,13 @@
+import pytest
+
+from api import orm_bootstrap
+
+
+def test_missing_alembic_raises_runtime_error(temp_db, monkeypatch):
+    def raise_fn(*a, **k):
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(orm_bootstrap.subprocess, "run", raise_fn)
+
+    with pytest.raises(RuntimeError, match="Alembic not installed"):
+        orm_bootstrap.validate_or_initialize_database()


### PR DESCRIPTION
## Summary
- handle missing Alembic binary in `validate_or_initialize_database`
- test runtime error when Alembic is unavailable

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686968f1c3a883258cb8f0b5f421929b