### PR TITLE
Handle access log write errors

### DIFF
--- a/api/middlewares/access_log.py
+++ b/api/middlewares/access_log.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import time
 from fastapi import Request
 
-from api.app_state import LOCAL_TZ, ACCESS_LOG
+from api.app_state import LOCAL_TZ, ACCESS_LOG, backend_log
 
 
 async def access_logger(request: Request, call_next):
@@ -11,10 +11,13 @@ async def access_logger(request: Request, call_next):
     response = await call_next(request)
     duration = time.time() - start
     host = getattr(request.client, "host", "localtest")
-    with ACCESS_LOG.open("a", encoding="utf-8") as fh:
-        fh.write(
-            f"[{datetime.now(LOCAL_TZ).isoformat()}] {host} "
-            f"{request.method} {request.url.path} -> "
-            f"{response.status_code} in {duration:.2f}s\n"
-        )
+    try:
+        with ACCESS_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(
+                f"[{datetime.now(LOCAL_TZ).isoformat()}] {host} "
+                f"{request.method} {request.url.path} -> "
+                f"{response.status_code} in {duration:.2f}s\n"
+            )
+    except OSError as exc:  # pragma: no cover - log failures shouldn't break response
+        backend_log.warning(f"Failed to write access log: {exc}")
     return response

--- a/tests/test_access_log.py
+++ b/tests/test_access_log.py
@@ -1,0 +1,35 @@
+import importlib
+from pathlib import Path
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.middlewares.access_log as access_log
+
+
+def test_log_write_error(monkeypatch):
+    importlib.reload(access_log)
+
+    orig_open = Path.open
+
+    def fail_open(self, *args, **kwargs):
+        if self == access_log.ACCESS_LOG:
+            raise OSError("disk full")
+        return orig_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fail_open)
+    warnings = []
+    monkeypatch.setattr(
+        access_log.backend_log, "warning", lambda msg: warnings.append(msg)
+    )
+
+    app = FastAPI()
+    app.middleware("http")(access_log.access_logger)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert warnings, "logger.warning should be called"


### PR DESCRIPTION
## Summary
- catch `OSError` when writing access logs
- warn via `backend_log` if log write fails
- test that failing log writes don't impact the response

## Testing
- `black api/middlewares/access_log.py tests/test_access_log.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68696d7e7bb88325a988afc5d480b400