### PR TITLE
Improve text analysis fallback

### DIFF
--- a/api/services/analysis.py
+++ b/api/services/analysis.py
@@ -4,6 +4,18 @@ from collections import Counter
 from typing import Tuple, List
 
 try:
+    from nltk.corpus import stopwords as nltk_stopwords
+except Exception:  # nltk not installed or data missing
+    nltk_stopwords = None
+
+try:
+    from sumy.nlp.tokenizers import Tokenizer
+    from sumy.parsers.plaintext import PlaintextParser
+    from sumy.summarizers.text_rank import TextRankSummarizer
+except Exception:  # sumy not installed
+    TextRankSummarizer = None
+
+try:
     import openai
 except Exception:  # openai not installed
     openai = None
@@ -33,13 +45,45 @@ STOPWORDS = {
     "an",
 }
 
+if nltk_stopwords:
+    try:
+        STOPWORDS.update(nltk_stopwords.words("english"))
+    except Exception:
+        pass
+
 
 def _local_analyze(text: str) -> Tuple[str, List[str]]:
-    """Fallback summarization and keyword extraction."""
+    """Fallback summarization and keyword extraction.
+
+    Attempts to use ``sumy``'s TextRank summarizer when available. If ``sumy``
+    is not installed, a simple frequency based ranking is used as a fallback.
+    """
+
     sentences = re.split(r"(?<=[.!?]) +", text.strip())
-    summary = " ".join(sentences[:3]).strip()
     words = re.findall(r"\b\w+\b", text.lower())
-    counts = Counter(w for w in words if w not in STOPWORDS)
+    filtered_words = [w for w in words if w not in STOPWORDS]
+    counts = Counter(filtered_words)
+
+    if TextRankSummarizer is not None:
+        try:
+            parser = PlaintextParser.from_string(text, Tokenizer("english"))
+            summarizer = TextRankSummarizer()
+            sum_sents = summarizer(parser.document, min(3, len(sentences)))
+            summary = " ".join(str(s) for s in sum_sents).strip()
+        except Exception:
+            summary = ""
+    else:
+        scores = []
+        for s in sentences:
+            s_words = re.findall(r"\b\w+\b", s.lower())
+            score = sum(counts.get(w, 0) for w in s_words)
+            scores.append((score, s))
+        scores.sort(key=lambda x: x[0], reverse=True)
+        summary = " ".join(s for _, s in scores[:3]).strip()
+
+    if not summary:
+        summary = " ".join(sentences[:3]).strip()
+
     keywords = [w for w, _ in counts.most_common(5)]
     return summary, keywords
 


### PR DESCRIPTION
## Summary
- improve `_local_analyze` with optional TextRank and sentence ranking
- extend stopword handling using NLTK when available

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68697034dac08325bd199b41a599c20e