### PR TITLE
Remove SECRET_KEY build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ COPY scripts/server_entry.py ./scripts/server_entry.py
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-ARG SECRET_KEY
 COPY api         ./api
 COPY models      ./models
-RUN SECRET_KEY=${SECRET_KEY:-temp-secret} \
+RUN --mount=type=secret,id=secret_key \
+    SECRET_KEY=$(cat /run/secrets/secret_key) \
     python -c "from api.utils.model_validation import validate_models_dir; validate_models_dir()"
 RUN mkdir -p uploads transcripts logs \
     && chown -R appuser:appuser /app

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ cd ..
 Build the image with a secret key:
 ```bash
 SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
-docker build --build-arg SECRET_KEY=$SECRET_KEY -t whisper-app .
+docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app .
 ```
 If you use a prebuilt image, mount the models directory at runtime.
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -42,10 +42,10 @@ cd frontend
 npm run build
 cd ..
 ```
-Provide a `SECRET_KEY` as a build argument since the image runs a validation
+Provide a `SECRET_KEY` as a BuildKit secret so the image can run the validation
 step that loads application settings:
 ```bash
-docker build --build-arg SECRET_KEY=<your_key> -t whisper-app .
+docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app .
 ```
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -300,6 +300,6 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 - **Summary**: Added `scripts/start_containers.sh` to automatically build the frontend and start the Docker Compose stack.
 - **Motivation**: Simplifies setup by launching the API, worker, broker and database with one command.
 
-### Build Argument for SECRET_KEY
-- **Summary**: Dockerfile accepts a `SECRET_KEY` build argument so model validation can run during image creation.
-- **Motivation**: `validate_models_dir()` loads settings which require a secret key, so the build would fail without one.
+### BuildKit Secret for SECRET_KEY
+- **Summary**: Dockerfile now expects a BuildKit secret named `secret_key` so model validation can run during image creation.
+- **Motivation**: `validate_models_dir()` loads settings which require a secret key, so the build would fail without one. Using a BuildKit secret avoids leaking the key in image layers.

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -39,8 +39,8 @@ if [ -z "$SECRET_KEY" ] || [ "$SECRET_KEY" = "CHANGE_ME" ]; then
     echo "Generated SECRET_KEY saved in .env"
 fi
 
-# Build the Docker image using the secret key
-docker build --build-arg SECRET_KEY="$SECRET_KEY" -t whisper-app "$ROOT_DIR"
+# Build the Docker image using a BuildKit secret
+docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app "$ROOT_DIR"
 
 # Start the compose stack
 docker compose -f "$ROOT_DIR/docker-compose.yml" up --build api worker broker db


### PR DESCRIPTION
## Summary
- use BuildKit secret for SECRET_KEY during Docker build
- update docker build script to use the secret
- document secret build usage in README and design docs
- note BuildKit change in future updates

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869abb8de90832598f5fbdc3c822cac