### PR TITLE
Add wait for broker port in worker entrypoint

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,4 +2,15 @@
 set -e
 mkdir -p /app/uploads /app/transcripts /app/logs
 chown -R 1000:1000 /app/uploads /app/transcripts /app/logs
+
+# If this container is running a worker, wait for the broker to be ready
+if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
+    broker_host="${CELERY_BROKER_HOST:-broker}"
+    broker_port="${CELERY_BROKER_PORT:-5672}"
+    echo "Waiting for broker at ${broker_host}:${broker_port}..."
+    while ! (echo > /dev/tcp/${broker_host}/${broker_port}) >/dev/null 2>&1; do
+        sleep 1
+    done
+    echo "Broker is available. Starting worker."
+fi
 exec gosu appuser "$@"


### PR DESCRIPTION
## Summary
- add logic in `docker-entrypoint.sh` to wait until the RabbitMQ broker port is reachable before running Celery workers

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869ad102bcc83258bcbd94c9962e126