### PR TITLE
Improve worker health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ ENV SERVICE_TYPE=api
 
 ENV VITE_API_HOST=http://localhost:8000
 EXPOSE 8000
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=5m --timeout=10s --retries=3 CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python", "scripts/server_entry.py"]

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ displayed all files at once.
 - The Admin page shows the system log via `/ws/logs/system`.
 - Toast notifications show the result of actions across all pages.
 - Admins can manage user roles from the Settings page.
+- The worker container's health check uses `pgrep` to ensure a Celery process is running and now runs every 5 minutes.
 - A left-side navigation bar lists each section, including a **Download Desktop App** tab linking to `/download-app`.
 - The Completed Jobs page provides a search box that filters results using the
   `search` query parameter on `/jobs`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
-      interval: 30s
+      interval: 5m
       timeout: 10s
       retries: 3
 

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -2,7 +2,8 @@
 set -eu
 
 if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
-    celery -A api.services.celery_app inspect ping -d "celery@$(hostname)" >/dev/null || exit 1
+    # succeed only if the Celery worker process is running
+    pgrep -f "celery" >/dev/null || exit 1
 else
     curl -fs http://localhost:8000/health >/dev/null || exit 1
 fi


### PR DESCRIPTION
## Summary
- check worker health by verifying the Celery process exists
- extend the worker container healthcheck interval to 5 minutes
- note the new behaviour in README

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6869d65802548325b24fb41a34eda446