### PR TITLE
Configure LAN access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY frontend/dist ./api/static
 ENV SERVICE_TYPE=api
 
 
-ENV VITE_API_HOST=http://localhost:8000
+ENV VITE_API_HOST=http://192.168.1.52:8000
 EXPOSE 8000
 HEALTHCHECK --interval=5m --timeout=10s --retries=3 CMD /usr/local/bin/healthcheck.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The old `api/config.py` module is kept only for backward compatibility and will 
   `docker-compose.yml` because it references the `db` service. Override it for
   a local instance, for example
   `DB_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/whisper`.
-- `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
+- `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://192.168.1.52:8000`).
 - `PORT` – TCP port used by the Uvicorn server (defaults to `8000`).
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).
@@ -346,7 +346,7 @@ PostgreSQL instance; the compose file defaults to the `db` service
 
 ```bash
 docker run -p 8000:8000 \
-  -e VITE_API_HOST=http://localhost:8000 \
+  -e VITE_API_HOST=http://192.168.1.52:8000 \
   -e SECRET_KEY=<your key> \
   -v $(pwd)/uploads:/app/uploads \
   -v $(pwd)/transcripts:/app/transcripts \
@@ -426,7 +426,7 @@ An optional helper script `scripts/start_containers.sh` automates these steps. R
 Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch.
 Use `scripts/update_images.sh` to rebuild just the API and worker images using
 Docker's cache and restart those services when you make code changes.
-Once running, access the API at `http://localhost:8000`.
+Once running, access the API at `http://192.168.1.52:8000`.
 
 ## Testing
 

--- a/api/config.py
+++ b/api/config.py
@@ -16,7 +16,7 @@ load_dotenv()
 
 # Raw environment variable for API host
 RAW_VITE_API_HOST = os.getenv("VITE_API_HOST")
-API_HOST = RAW_VITE_API_HOST or "http://localhost:8000"
+API_HOST = RAW_VITE_API_HOST or "http://192.168.1.52:8000"
 
 # PostgreSQL is required. Provide ``DB_URL`` with the connection string to your
 # PostgreSQL server. Using a different engine is only recommended for local

--- a/api/main.py
+++ b/api/main.py
@@ -60,7 +60,7 @@ ROOT = Path(__file__).parent
 # Read API host from environment with a default for local development.
 API_HOST = settings.vite_api_host
 if "VITE_API_HOST" not in os.environ:
-    system_log.warning("VITE_API_HOST not set, defaulting to http://localhost:8000")
+    system_log.warning("VITE_API_HOST not set, defaulting to http://192.168.1.52:8000")
 
 
 # ─── Lifespan Hook ───

--- a/api/settings.py
+++ b/api/settings.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     db_url: str = Field(
         "postgresql+psycopg2://whisper:whisper@db:5432/whisper", env="DB_URL"
     )
-    vite_api_host: str = Field("http://localhost:8000", env="VITE_API_HOST")
+    vite_api_host: str = Field("http://192.168.1.52:8000", env="VITE_API_HOST")
     log_level: str = Field("DEBUG", env="LOG_LEVEL")
     log_format: str = Field("plain", env="LOG_FORMAT")
     log_to_stdout: bool = Field(False, env="LOG_TO_STDOUT")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - SERVICE_TYPE=api
       - PORT=8000 # change to run the API on a different port
-      - VITE_API_HOST=http://localhost:8000
+      - VITE_API_HOST=http://192.168.1.52:8000
       - JOB_QUEUE_BACKEND=broker
       - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
       - CELERY_BACKEND_URL=rpc://
@@ -62,7 +62,7 @@ services:
     command: celery -A api.services.celery_app worker
     environment:
       - SERVICE_TYPE=worker
-      - VITE_API_HOST=http://localhost:8000
+      - VITE_API_HOST=http://192.168.1.52:8000
       - JOB_QUEUE_BACKEND=broker
       - CELERY_BROKER_URL=amqp://guest:guest@broker:5672//
       - CELERY_BACKEND_URL=rpc://

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_HOST=http://localhost:8000
+VITE_API_HOST=http://192.168.1.52:8000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # Base API URL used by the frontend to reach the backend
-VITE_API_HOST=http://localhost:8000
+VITE_API_HOST=http://192.168.1.52:8000
 
 # Hostname used when running `npm run dev`
 VITE_DEV_HOST=localhost

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,7 +10,7 @@
   </head>
   <body class="bg-zinc-900 text-white">
     <div id="log-warning" class="bg-yellow-500 text-black p-2 text-sm text-center hidden">
-      ⚠️ Logs will not appear unless the backend is running at http://localhost:8000
+      ⚠️ Logs will not appear unless the backend is running at http://192.168.1.52:8000
     </div>
 
     <noscript>

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,7 +11,7 @@ export const ROUTES = {
   PROGRESS: "/progress/:jobId",
   FILE_BROWSER: "/admin/files",
   CHANGE_PASSWORD: "/change-password",
-  API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
+  API: import.meta.env.VITE_API_HOST || "http://192.168.1.52:8000"
 };
 
 export const DEFAULT_DOWNLOAD_FORMAT =

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,14 +9,14 @@ export default defineConfig({
     host: process.env.VITE_DEV_HOST || "localhost",
     port: parseInt(process.env.VITE_DEV_PORT || "5173"),
     proxy: {
-      '/log_event': 'http://localhost:8000',
-      '/jobs': 'http://localhost:8000',
-      '/audio': 'http://localhost:8000',
-      '^/admin/(files|reset|download-all)$': 'http://localhost:8000',
-      '/admin/stats': 'http://localhost:8000',
-      '/logs': 'http://localhost:8000',
-      '/uploads': 'http://localhost:8000',
-      '/transcripts': 'http://localhost:8000'
+      '/log_event': 'http://192.168.1.52:8000',
+      '/jobs': 'http://192.168.1.52:8000',
+      '/audio': 'http://192.168.1.52:8000',
+      '^/admin/(files|reset|download-all)$': 'http://192.168.1.52:8000',
+      '/admin/stats': 'http://192.168.1.52:8000',
+      '/logs': 'http://192.168.1.52:8000',
+      '/uploads': 'http://192.168.1.52:8000',
+      '/transcripts': 'http://192.168.1.52:8000'
     }
   }
 });

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -5,5 +5,5 @@ if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
     # succeed only if the Celery worker process is running
     pgrep -f "celery" >/dev/null || exit 1
 else
-    curl -fs http://localhost:8000/health >/dev/null || exit 1
+    curl -fs http://192.168.1.52:8000/health >/dev/null || exit 1
 fi


### PR DESCRIPTION
## Summary
- set `VITE_API_HOST` to the LAN IP `192.168.1.52`
- update Dockerfile, docker-compose and frontend environment files
- adjust health check script and frontend configurations
- document LAN address in README

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest` *(fails: ModuleNotFoundError: httpx)*


------
https://chatgpt.com/codex/tasks/task_e_6869d2e250288325802012a697d62b1a