### PR TITLE
Fix failed filter

### DIFF
--- a/api/services/jobs.py
+++ b/api/services/jobs.py
@@ -55,7 +55,10 @@ def list_jobs(search: Optional[str] = None, status: Optional[str] = None) -> Lis
             conditions = []
             for s in statuses:
                 if s == "failed":
-                    conditions.append(Job.status.ilike("failed%"))
+                    fail_statuses = [
+                        st for st in JobStatusEnum if st.value.startswith("failed")
+                    ]
+                    conditions.append(Job.status.in_(fail_statuses))
                     continue
                 try:
                     enum_val = JobStatusEnum(s)


### PR DESCRIPTION
## Summary
- handle `failed` status filtering using enum values

## Testing
- `black .`
- `pip install -r requirements-dev.txt` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686a78867e8c83259637ab1e7600f8c7