### PR TITLE
Fix Celery banner noise

### DIFF
--- a/api/services/celery_app.py
+++ b/api/services/celery_app.py
@@ -13,6 +13,13 @@ celery_app = Celery(
     backend=settings.celery_backend_url,
 )
 
+# Avoid Celery printing duplicate banners when the worker starts or
+# stops by disabling the root logger hijack and stdout redirection.
+celery_app.conf.update(
+    worker_hijack_root_logger=False,
+    worker_redirect_stdouts=False,
+)
+
 
 @celery_app.task(name="run_callable")
 def run_callable(pickled_func: bytes) -> None:


### PR DESCRIPTION
## Summary
- update Celery configuration so the worker doesn't hijack the logger or redirect stdout

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686b01f0fc84832598256c775dd3560a