### PR TITLE
Fix uvicorn log level

### DIFF
--- a/scripts/server_entry.py
+++ b/scripts/server_entry.py
@@ -11,5 +11,5 @@ if __name__ == "__main__":
         host="0.0.0.0",
         port=port,
         log_config=None,
-        log_level=settings.log_level,
+        log_level=settings.log_level.lower(),
     )


### PR DESCRIPTION
## Summary
- ensure uvicorn gets lowercase log level

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `SECRET_KEY=dummy timeout 3 python scripts/server_entry.py` *(fails: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_686b0bda36408325a9e6ed3699ef09d9