### PR TITLE
Fix auth import path

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -12,8 +12,8 @@ from fastapi import (
 from fastapi.security import (
     OAuth2PasswordBearer,
     OAuth2PasswordRequestForm,
-    get_authorization_scheme_param,
 )
+from fastapi.security.utils import get_authorization_scheme_param
 from jose import JWTError, jwt
 
 from api.settings import settings


### PR DESCRIPTION
## Summary
- patch auth route to import `get_authorization_scheme_param` from `fastapi.security.utils`

## Testing
- `black api/routes/auth.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686b15a398f083259ad1d8ee958ad47b