### PR TITLE
Update docs for Celery install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This project provides a FastAPI backend with a React frontend for running OpenAI
    ```
    The `bcrypt` dependency is pinned to `<4` for compatibility with
    `passlib`. If installing packages manually ensure this version
-   constraint is respected.
+   constraint is respected. Celery is also installed from this file
+   and is used when the broker-based queue is enabled.
 2. Install system dependencies. `ffmpeg` (providing `ffprobe`) must be present
    for audio processing features. On Linux you can install it with:
    ```bash
@@ -27,11 +28,10 @@ cd frontend
    Copy `frontend/.env.example` to `frontend/.env` to configure `VITE_API_HOST`,
    `VITE_DEV_HOST` and `VITE_DEV_PORT`.
    # install Redux packages for global state and toasts
-4. Install Celery if you plan to set `JOB_QUEUE_BACKEND=broker` or use Docker
-   Compose:
-   ```bash
-   pip install celery
-   ```
+
+Celery is included in `requirements.txt` and is required when
+`JOB_QUEUE_BACKEND=broker` or using Docker Compose, so no extra installation step is
+needed.
 
 ## Optional Environment Variables
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -80,8 +80,8 @@ release. Available variables are:
 - `ACCESS_TOKEN_EXPIRE_MINUTES` – JWT lifetime.
 - `MAX_CONCURRENT_JOBS` – worker thread count for the internal queue. This value can be changed at runtime via `/admin/concurrency`.
 - `JOB_QUEUE_BACKEND` – queue implementation (`thread` by default).
-- Celery must be installed when `JOB_QUEUE_BACKEND=broker` or using Docker
-  Compose.
+- Celery is installed from `requirements.txt` and used when
+  `JOB_QUEUE_BACKEND=broker` or running Docker Compose.
 - `STORAGE_BACKEND` – where uploads and transcripts are stored.
 - `LOCAL_STORAGE_DIR` – base directory for the local storage backend. Defaults
   to the repository root.


### PR DESCRIPTION
## Summary
- remove manual Celery install step from README
- clarify Celery comes from requirements.txt in README and docs

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686b25bd7a9c832599e190752080073a