### PR TITLE
Update get_token signature

### DIFF
--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -33,6 +33,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
 async def get_token(request: Request = None, websocket: WebSocket = None) -> str:
+    """Return the JWT bearer token from an HTTP request or WebSocket."""
     if request is not None:
         return await oauth2_scheme(request)
     token = websocket.query_params.get("token")


### PR DESCRIPTION
## Summary
- document the get_token helper

## Testing
- `python -m uvicorn api.main:app --port 8000 --host 127.0.0.1` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_686b3159bdc083259f06f21641cf7587