### PR TITLE
Add RabbitMQ config file and mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,16 @@ host with `psql -h localhost -p 5432 -U whisper`. It also configures Celery with
 RabbitMQ by setting `JOB_QUEUE_BACKEND=broker`,
 `CELERY_BROKER_URL` and `CELERY_BACKEND_URL` on the API and worker services.
 
+The broker service loads additional settings from `rabbitmq.conf` mounted at
+`/etc/rabbitmq/rabbitmq.conf`. This configuration enables collection of
+management metrics and other deprecated features required by Celery:
+
+```
+deprecated_features.permit.management_metrics_collection = true
+deprecated_features.permit.transient_nonexcl_queues = true
+deprecated_features.permit.global_qos = true
+```
+
 Start everything with:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - "5672:5672"
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,0 +1,3 @@
+deprecated_features.permit.management_metrics_collection = true
+deprecated_features.permit.transient_nonexcl_queues = true
+deprecated_features.permit.global_qos = true


### PR DESCRIPTION
## Summary
- add rabbitmq.conf enabling deprecated metrics features
- mount config file into the broker container
- document the new config in README

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `coverage run -m pytest` *(fails: command not found)*
- `coverage report` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b549af6e083258403455ee94c5e48