### PR TITLE
Update RabbitMQ readiness check

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,9 +6,8 @@ chown -R 1000:1000 /app/uploads /app/transcripts /app/logs
 # If this container is running a worker, wait for the broker to be ready
 if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
     broker_host="${CELERY_BROKER_HOST:-broker}"
-    broker_port="${CELERY_BROKER_PORT:-5672}"
-    echo "Waiting for broker at ${broker_host}:${broker_port}..."
-    while ! (echo > /dev/tcp/${broker_host}/${broker_port}) >/dev/null 2>&1; do
+    echo "Waiting for RabbitMQ at ${broker_host}..."
+    while ! rabbitmq-diagnostics -q ping -n "rabbit@${broker_host}" >/dev/null 2>&1; do
         sleep 1
     done
     echo "Broker is available. Starting worker."


### PR DESCRIPTION
## Summary
- make worker startup wait for RabbitMQ

## Testing
- `black . --check`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686b5b91b6108325beeb41c7fca88d5e