### PR TITLE
Add auth tests for log endpoints

### DIFF
--- a/tests/test_logs_api.py
+++ b/tests/test_logs_api.py
@@ -15,3 +15,27 @@ def test_log_event_invalid_json(client):
 def test_log_path_traversal_blocked(client):
     resp = client.get("/logs/%2e%2e%2Fsecret.txt")
     assert resp.status_code == 404
+
+
+def test_job_log_requires_auth(client):
+    overrides = client.app.dependency_overrides.copy()
+    client.app.dependency_overrides.clear()
+    resp = client.get("/log/someid")
+    assert resp.status_code == 401
+    client.app.dependency_overrides.update(overrides)
+
+
+def test_access_log_requires_auth(client):
+    overrides = client.app.dependency_overrides.copy()
+    client.app.dependency_overrides.clear()
+    resp = client.get("/logs/access")
+    assert resp.status_code == 401
+    client.app.dependency_overrides.update(overrides)
+
+
+def test_log_file_requires_auth(client):
+    overrides = client.app.dependency_overrides.copy()
+    client.app.dependency_overrides.clear()
+    resp = client.get("/logs/valid.log")
+    assert resp.status_code == 401
+    client.app.dependency_overrides.update(overrides)


### PR DESCRIPTION
## Summary
- validate auth is required for log endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686bdaf02c688325bcd72d9f2055e202