### PR TITLE
Remove audit_environment reference

### DIFF
--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -49,7 +49,7 @@ step that loads application settings:
 docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app .
 ```
 
-Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image. The older `audit_environment.py` helper script is optional and may be removed.
+Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- remove outdated helper script note in design docs

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686be8c0a4748325a745fb50973eb66a