### PR TITLE
Add worker dependency and faster health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
         condition: service_healthy
       broker:
         condition: service_healthy
+      worker:
+        condition: service_started
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
       interval: 30s
@@ -80,7 +82,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
-      interval: 5m
+      interval: 10s
       timeout: 10s
       retries: 3
 


### PR DESCRIPTION
## Summary
- make API wait for worker startup before launching
- shrink Celery worker healthcheck interval for rapid readiness

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686be97d6a4483258b5ad0987edc0e04