### PR TITLE
Add restart policies for Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ Alternatively copy `.env.example` to `.env` and replace `CHANGE_ME` with a uniqu
 Setting `LOG_TO_STDOUT=true` and `LOG_LEVEL=DEBUG` surfaces detailed logs, which
 helps diagnose bootstrapping failures when running inside Docker.
 
+The compose file configures the `api` and `worker` services with `restart: on-failure`
+so they automatically restart if either container exits unexpectedly.
+
 ## Docker Compose
 
 A `docker-compose.yml` is included to start the API together with the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   api:
     build: .
+    restart: on-failure
     ports:
       - "8000:8000"
     environment:
@@ -63,6 +64,7 @@ services:
   worker:
     build: .
     command: celery -A api.services.celery_app worker
+    restart: on-failure
     environment:
       - SERVICE_TYPE=worker
       - VITE_API_HOST=http://192.168.1.52:8000


### PR DESCRIPTION
## Summary
- restart API and worker containers automatically on failure
- mention the restart policy in the Docker usage section

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686bea3410d88325adf795cdfc002e1d