### PR TITLE
Revise celery connection loop

### DIFF
--- a/api/app_state.py
+++ b/api/app_state.py
@@ -353,19 +353,21 @@ async def check_celery_connection() -> None:
     from api.services.celery_app import celery_app
 
     log = get_system_logger()
-    attempts = settings.broker_connect_attempts
-    for attempt in range(1, attempts + 1):
+    attempt = 1
+    while True:
         try:
             result = celery_app.control.ping(timeout=1)
             if result:
                 return
             log.warning(
-                "Celery ping returned no workers (attempt %s/%s)", attempt, attempts
+                "Celery ping returned no workers (attempt %s)",
+                attempt,
             )
         except Exception as exc:
             log.warning(
-                "Celery ping failed (attempt %s/%s): %s", attempt, attempts, exc
+                "Celery ping failed (attempt %s): %s",
+                attempt,
+                exc,
             )
         await asyncio.sleep(attempt)
-    log.critical("Celery broker unreachable after %s attempts", attempts)
-    raise InitError(f"Celery broker unreachable after {attempts} attempts")
+        attempt += 1

--- a/tests/test_celery_startup.py
+++ b/tests/test_celery_startup.py
@@ -1,0 +1,29 @@
+import importlib
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_check_celery_connection_retries(monkeypatch):
+    monkeypatch.setenv("JOB_QUEUE_BACKEND", "broker")
+    import api.app_state as app_state
+
+    importlib.reload(app_state)
+
+    attempts = []
+
+    def fake_ping(timeout=1):
+        attempts.append("ping")
+        if len(attempts) < 3:
+            return []
+        return ["pong"]
+
+    async def fake_sleep(_):
+        attempts.append("sleep")
+
+    celery_app_module = importlib.import_module("api.services.celery_app")
+    monkeypatch.setattr(celery_app_module.celery_app.control, "ping", fake_ping)
+    monkeypatch.setattr(app_state.asyncio, "sleep", fake_sleep)
+
+    await app_state.check_celery_connection()
+
+    assert attempts.count("ping") == 3


### PR DESCRIPTION
## Summary
- loop indefinitely when checking Celery connectivity
- add test confirming retries until a worker responds

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686beaef001883259fd324c07e3cc60c