### PR TITLE
Add script for running tests after container build

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Install Python dependencies
+pip install -r "$ROOT_DIR/requirements.txt"
+
+# Install development dependencies for running tests
+pip install -r "$ROOT_DIR/requirements-dev.txt"
+
+# Install Node dependencies for the frontend
+(cd "$ROOT_DIR/frontend" && npm install)
+
+# Build images and start containers
+"$SCRIPT_DIR/update_images.sh"
+
+# Run the Python test suite
+pytest


### PR DESCRIPTION
## Summary
- add `scripts/run_tests.sh` to rebuild images and run backend tests

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686bed3e173c8325972f0424da48e218