### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,9 +444,9 @@ Once running, access the API at `http://192.168.1.52:8000`.
 
 ## Testing
 
-Install the development requirements and run the test suite with coverage. The
-test suite requires the additional packages from `requirements-dev.txt` and
-uses `pytest-postgresql` to launch a temporary PostgreSQL instance:
+Install the development requirements and run the test suite with coverage.
+`requirements-dev.txt` includes `psycopg[binary]>=3.1` which `pytest-postgresql`
+uses to launch a temporary PostgreSQL instance:
 
 ```bash
 pip install -r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ black
 pytest-asyncio
 coverage
 pytest-postgresql
+
+psycopg[binary]>=3.1


### PR DESCRIPTION
## Summary
- document psycopg as a dev requirement for running tests
- include psycopg in requirements-dev.txt

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_686c103a0ff48325b103ca45b9979844