### PR TITLE
Add docker compose cleanup after tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,10 @@ coverage run -m pytest
 coverage report
 ```
 
+The helper script `scripts/run_tests.sh` performs these steps in a Docker
+environment and automatically stops the compose stack with `docker compose down`
+even when tests fail.
+
 
 ## Contributing
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+
+# Ensure docker compose services are stopped on exit
+trap 'docker compose -f "$COMPOSE_FILE" down' EXIT
 
 # Install Python dependencies
 pip install -r "$ROOT_DIR/requirements.txt"


### PR DESCRIPTION
## Summary
- ensure `scripts/run_tests.sh` stops the compose stack after tests
- mention automatic cleanup in README

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686c124f3f4883259c008996ee98db06