### PR TITLE
Add integration test script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,9 @@ or `docker compose up --build` and then run:
 ./scripts/run_tests.sh
 ```
 
-The Docker image now includes the development requirements so the script simply
-executes the test suite with coverage inside the `api` container without
-destroying the compose stack.
+The script runs the backend test suite inside the `api` container and performs
+basic integration checks against the live API. Results are written to
+`logs/test.log` for review.
 
 To run the tests manually use the same commands inside the running container:
 
@@ -460,8 +460,6 @@ To run the tests manually use the same commands inside the running container:
 docker compose exec api coverage run -m pytest
 docker compose exec api coverage report
 ```
-
-
 ## Contributing
 
 Run `black .` before committing changes. When adding features or changing configuration, update both `docs/design_scope.md`, `docs/future_updates.md`, and `README.md` so the documentation stays consistent.

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -35,6 +35,7 @@ The application is considered working once these basics are functional:
 - `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
 - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch.
 - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
+- `run_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_HOST="${VITE_API_HOST:-http://localhost:8000}"
+API_HOST="${API_HOST%/}"
+
+check_endpoint() {
+    local path="$1"
+    if curl -fsS "$API_HOST$path" >/dev/null; then
+        echo "$path OK"
+    else
+        echo "$path FAILED"
+        return 1
+    fi
+}
+
+check_endpoint /health
+check_endpoint /version
+
+exit 0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+LOG_DIR="$ROOT_DIR/logs"
+LOG_FILE="$LOG_DIR/test.log"
 
-docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
-docker compose -f "$COMPOSE_FILE" exec -T api coverage report
+mkdir -p "$LOG_DIR"
+
+{
+    docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
+    docker compose -f "$COMPOSE_FILE" exec -T api coverage report
+    "$SCRIPT_DIR/integration_tests.sh"
+} | tee "$LOG_FILE"
+
+echo "Test log saved to $LOG_FILE"


### PR DESCRIPTION
## Summary
- add `integration_tests.sh` for simple endpoint checks
- update `run_tests.sh` to log all test output and invoke the integration tests
- document new test workflow in README and design scope

## Testing
- `black .`
- `./scripts/run_tests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c33372ea88325806eda6feb4cee17