### PR TITLE
Add vitest setup and sample Spinner test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",
@@ -16,7 +17,10 @@
 },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.5.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.0"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/frontend/src/__tests__/Spinner.test.jsx
+++ b/frontend/src/__tests__/Spinner.test.jsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import Spinner from '../Spinner.jsx';
+import '@testing-library/jest-dom';
+
+test('renders Spinner component', () => {
+  const { container } = render(<Spinner />);
+  expect(container.firstChild).toBeInTheDocument();
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- update `frontend/package.json` with vitest and testing libraries
- configure jsdom test environment
- add a simple Spinner component test

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3922bda88325af215499885ff3a9