### PR TITLE
Add Cypress E2E setup

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,7 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:8000'
+  }
+});

--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -1,0 +1,8 @@
+describe('Home page', () => {
+  it('shows login form', () => {
+    cy.visit('/');
+    cy.contains('h2', 'Login').should('be.visible');
+    cy.get('input[placeholder="Username"]').should('be.visible');
+    cy.get('input[placeholder="Password"]').should('be.visible');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "cypress run"
   },
   "keywords": [],
   "author": "",
@@ -20,7 +21,8 @@
     "vite": "^6.3.5",
     "vitest": "^1.5.0",
     "@testing-library/react": "^14.2.1",
-    "@testing-library/jest-dom": "^6.4.0"
+    "@testing-library/jest-dom": "^6.4.0",
+    "cypress": "^13.7.3"
   },
   "dependencies": {
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- add Cypress as dev dependency
- add `e2e` NPM script
- configure Cypress to test the built site
- write a basic test checking the login form

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c3a16ee748325a54e379982ab421d