### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,18 +443,26 @@ The worker container runs `celery -A api.services.celery_app worker` to process 
 ## Testing
 
 Tests rely on Docker to provide the required services and on **Node.js 18** or
-newer to build the frontend. Start the containers with `scripts/start_containers.sh`
-or `docker compose up --build` and then run:
+newer. Install the frontend dev dependencies first:
 
 ```bash
-./scripts/run_tests.sh
+cd frontend
+npm install
 ```
 
-The script runs the backend test suite inside the `api` container and performs
-basic integration checks against the live API. Results are written to
-`logs/test.log` for review.
+Start the containers with `scripts/start_containers.sh` or `docker compose
+up --build` and run the full suite with:
 
-To run the tests manually use the same commands inside the running container:
+```bash
+./scripts/run_all_tests.sh
+```
+
+This script runs the backend tests and integration checks, then executes the
+frontend unit tests and Cypress end‑to‑end tests. Output is saved to
+`logs/full_test.log`.
+
+To invoke just the backend tests manually use the same commands inside the
+running container:
 
 ```bash
 docker compose exec api coverage run -m pytest

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -36,6 +36,8 @@ The application is considered working once these basics are functional:
 - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch.
 - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
 - `run_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
+- `run_all_tests.sh` – preferred wrapper that additionally executes frontend unit
+  tests and Cypress end-to-end tests, saving results to `logs/full_test.log`.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:


### PR DESCRIPTION
## Summary
- detail `run_all_tests.sh` in `docs/design_scope.md`
- expand README Testing section to cover front-end tests and full test script

## Testing
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_686c3c1cad1083259bd63216644962dd