### PR TITLE
Run tests during docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. After the stack starts it automatically runs `scripts/run_all_tests.sh`, aborting the build when any test fails. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -42,6 +42,9 @@ fi
 # Build the Docker image using a BuildKit secret
 docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app "$ROOT_DIR"
 
-# Start the compose stack
-docker compose -f "$ROOT_DIR/docker-compose.yml" up --build api worker broker db
+# Start the compose stack in the background
+docker compose -f "$ROOT_DIR/docker-compose.yml" up --build -d api worker broker db
+
+# Run the full test suite; the build fails if any step exits non-zero
+"$SCRIPT_DIR/run_all_tests.sh"
 


### PR DESCRIPTION
## Summary
- run the full test suite after bringing up the compose stack in `docker_build.sh`
- document that the build script runs tests automatically

## Testing
- `black . --check`
- `bash scripts/run_tests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c3ea5a3a88325acbe2c508d20294c