### PR TITLE
Update docker_build.sh to skip automatic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. After the stack starts it automatically runs `scripts/run_all_tests.sh`, aborting the build when any test fails. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; run `scripts/run_all_tests.sh` separately if you wish to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -33,7 +33,7 @@ The application is considered working once these basics are functional:
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
 - `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
-- `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch.
+ - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Tests are no longer run automatically; invoke `run_all_tests.sh` separately if desired.
 - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
 - `run_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
 - `run_all_tests.sh` – preferred wrapper that additionally executes frontend unit

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -39,12 +39,13 @@ if [ -z "$SECRET_KEY" ] || [ "$SECRET_KEY" = "CHANGE_ME" ]; then
     echo "Generated SECRET_KEY saved in .env"
 fi
 
-# Build the Docker image using a BuildKit secret
+# Build the standalone image used for production deployments
 docker build --secret id=secret_key,env=SECRET_KEY -t whisper-app "$ROOT_DIR"
 
-# Start the compose stack in the background
-docker compose -f "$ROOT_DIR/docker-compose.yml" up --build -d api worker broker db
+# Build images for the compose stack and start the services
+docker compose -f "$ROOT_DIR/docker-compose.yml" build \
+  --secret id=secret_key,env=SECRET_KEY api worker
+docker compose -f "$ROOT_DIR/docker-compose.yml" up -d api worker broker db
 
-# Run the full test suite; the build fails if any step exits non-zero
-"$SCRIPT_DIR/run_all_tests.sh"
+echo "Images built and containers started. Run scripts/run_all_tests.sh separately to execute the test suite."
 


### PR DESCRIPTION
## Summary
- update `docker_build.sh` so production images build and compose stack starts without triggering tests
- mention running the test suite separately
- adjust documentation in `README.md` and `docs/design_scope.md`

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686c62a15df083258cf6bad9662e1bb6