### PR TITLE
Improve API host fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ needed.
   `docker-compose.yml` because it references the `db` service. Override it for
   a local instance, for example
   `DB_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/whisper`.
-- `VITE_API_HOST` – base URL used by the frontend to reach the API (defaults to `http://localhost:8000`).
+- `VITE_API_HOST` – base URL used by the frontend to reach the API. Leave blank to use the site's origin and set a URL when the API is hosted remotely.
 - `PORT` – TCP port used by the Uvicorn server (defaults to `8000`).
 - `VITE_DEFAULT_TRANSCRIPT_FORMAT` – default download format used by the web UI (defaults to `txt`).
 - `LOG_LEVEL` – logging level for job/system logs (`DEBUG` by default).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,6 @@
-# Base API URL used by the frontend to reach the backend
-VITE_API_HOST=http://localhost:8000
+# Base API URL used by the frontend to reach the backend.
+# Leave blank to use the site's origin or set a URL when the API runs remotely.
+VITE_API_HOST=
 
 # Hostname used when running `npm run dev`
 VITE_DEV_HOST=localhost

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,7 +11,7 @@ export const ROUTES = {
   PROGRESS: "/progress/:jobId",
   FILE_BROWSER: "/admin/files",
   CHANGE_PASSWORD: "/change-password",
-  API: import.meta.env.VITE_API_HOST || "http://localhost:8000"
+  API: import.meta.env.VITE_API_HOST || window.location.origin
 };
 
 export const DEFAULT_DOWNLOAD_FORMAT =


### PR DESCRIPTION
## Summary
- make frontend API URL use the page origin when VITE_API_HOST is unset
- document the remote-access configuration in frontend/.env.example
- clarify README about VITE_API_HOST default behaviour

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686c69a28c488325aa4e42717a34689b