### PR TITLE
Add post build tests script and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; run `scripts/run_all_tests.sh` separately if you wish to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/post_build_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/scripts/post_build_tests.sh
+++ b/scripts/post_build_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/run_all_tests.sh"


### PR DESCRIPTION
## Summary
- add `scripts/post_build_tests.sh` wrapper to run all tests
- document the new optional script in the Running section of README

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686d5940f6e48325b317bf232e4e0714