### PR TITLE
Improve docker helper scripts

### DIFF
--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 
 usage() {
     cat <<EOF
@@ -41,6 +42,6 @@ if [ ! -d "$ROOT_DIR/models" ]; then
 fi
 
 echo "Starting containers with docker compose..."
-docker compose -f "$ROOT_DIR/docker-compose.yml" up --build -d api worker broker db
+docker compose -f "$COMPOSE_FILE" up --build -d api worker broker db
 
 echo "Containers are starting. Use 'docker compose ps' to check status."

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 
 # Rebuild frontend assets
 (cd "$ROOT_DIR/frontend" && npm run build)
 
 # Rebuild API and worker images using Docker cache
-docker compose -f "$ROOT_DIR/docker-compose.yml" build api worker
+docker compose -f "$COMPOSE_FILE" build api worker
 
-docker compose -f "$ROOT_DIR/docker-compose.yml" up -d api worker
+docker compose -f "$COMPOSE_FILE" up -d api worker


### PR DESCRIPTION
## Summary
- enforce strict error handling in `update_images.sh` and `start_containers.sh`
- standardize `ROOT_DIR` resolution and use a `COMPOSE_FILE` variable

## Testing
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_686d6a80882883259def364d48c5d938