### PR TITLE
Add prerequisite checks to start_containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ the database and broker to become available. The `db` service runs PostgreSQL
 for the API while RabbitMQ provides a broker for Celery when using the `broker`
 job queue backend.
 
-Prepare `models/` with `base.pt`, `small.pt`, `medium.pt`, `large-v3.pt` and `tiny.pt` and build the frontend before running compose:
+Prepare `models/` with `base.pt`, `small.pt`, `medium.pt`, `large-v3.pt` and `tiny.pt` and build the frontend before running compose. The helper script will verify these files exist:
 
 ```bash
 cd frontend
@@ -391,10 +391,12 @@ npm run build
 cd ..
 ```
 
-Copy `.env.example` to `.env`, replacing `CHANGE_ME` with the generated
-`SECRET_KEY`. Compose picks up this file automatically. Ensure this file also
-contains valid database credentials or a `DB_URL` override so the containers can
-connect to PostgreSQL.
+Ensure `.env` exists with a valid `SECRET_KEY`. The helper
+`scripts/start_containers.sh` will create this file from `.env.example`
+and generate a key automatically when needed. If you start the stack
+manually, copy `.env.example` to `.env` and replace `CHANGE_ME` with your
+key. Include valid database credentials or a `DB_URL` override so the containers
+can connect to PostgreSQL.
 
 Build and start all services with:
 
@@ -438,7 +440,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed and launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/post_build_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/post_build_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -32,7 +32,7 @@ The application is considered working once these basics are functional:
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
-- `start_containers.sh` – helper script that builds the frontend if needed and launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
+ - `start_containers.sh` – helper script that builds the frontend if needed, verifies required models and `.env`, then launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
  - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Tests are no longer run automatically; invoke `run_all_tests.sh` separately if desired.
 - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
 - `run_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -307,3 +307,8 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 ### Build Argument for SECRET_KEY
 - **Summary**: Dockerfile now expects a `SECRET_KEY` build argument so model validation can run during image creation.
 - **Motivation**: `validate_models_dir()` loads settings which require a secret key. Passing it via build argument keeps the build compatible with older Docker Compose versions.
+
+### Prerequisite Checks in start_containers.sh
+- **Summary**: start_containers.sh now verifies Whisper models exist and ensures a valid SECRET_KEY in .env. Missing prerequisites abort the build.
+- **Motivation**: Prevent confusing runtime errors by validating setup before docker-compose builds the images.
+


### PR DESCRIPTION
## Summary
- verify Whisper model files and SECRET_KEY in `start_containers.sh`
- generate `.env` automatically when missing
- document new checks in README and design docs

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_686d6c05e2a08325916fda19993f238f