### PR TITLE
Update update_images.sh to pass SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/post_build_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. Use `docker compose down` to stop all services. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/post_build_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. This script reads `SECRET_KEY` from `.env` and passes it to `docker compose build` using `--build-arg`. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -5,10 +5,22 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 
+# Load secret key from .env for Docker build
+if [ ! -f "$ROOT_DIR/.env" ]; then
+    echo "Missing .env file" >&2
+    exit 1
+fi
+
+SECRET_KEY=$(grep -E '^SECRET_KEY=' "$ROOT_DIR/.env" | cut -d= -f2-)
+if [ -z "$SECRET_KEY" ]; then
+    echo "SECRET_KEY not set in .env" >&2
+    exit 1
+fi
+
 # Rebuild frontend assets
 (cd "$ROOT_DIR/frontend" && npm run build)
 
 # Rebuild API and worker images using Docker cache
-docker compose -f "$COMPOSE_FILE" build api worker
+docker compose -f "$COMPOSE_FILE" build --build-arg SECRET_KEY="$SECRET_KEY" api worker
 
 docker compose -f "$COMPOSE_FILE" up -d api worker


### PR DESCRIPTION
## Summary
- use SECRET_KEY from `.env` when rebuilding API and worker images
- note this requirement in README

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements-dev.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686d6f4b6b808325b84ff7a7975cf14a