### PR TITLE
Check API container before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,12 @@ This script runs the backend tests and integration checks, then executes the
 frontend unit tests and Cypress end‑to‑end tests. Output is saved to
 `logs/full_test.log`.
 
+Both `scripts/run_all_tests.sh` and `scripts/run_tests.sh` check that the `api`
+container is running before executing. If it isn't, they exit with the message
+```
+API container is not running. Start the stack with scripts/start_containers.sh
+```
+
 To invoke just the backend tests manually use the same commands inside the
 running container:
 

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -3,10 +3,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/full_test.log"
 
 mkdir -p "$LOG_DIR"
+
+# Ensure the API container is running before executing tests
+if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
+    echo "API container is not running. Start the stack with scripts/start_containers.sh" >&2
+    exit 1
+fi
 
 {
     "$SCRIPT_DIR/run_tests.sh"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,6 +9,12 @@ LOG_FILE="$LOG_DIR/test.log"
 
 mkdir -p "$LOG_DIR"
 
+# Ensure the API container is running before executing tests
+if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
+    echo "API container is not running. Start the stack with scripts/start_containers.sh" >&2
+    exit 1
+fi
+
 {
     docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
     docker compose -f "$COMPOSE_FILE" exec -T api coverage report


### PR DESCRIPTION
## Summary
- ensure scripts abort if the API container isn't running
- mention new check in the README

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_686d7b3642f08325a87f45fb5907128c