### PR TITLE
Rename test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/run_all_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. These scripts source `scripts/shared_checks.sh` which ensures Whisper models are present, `.env` contains a valid `SECRET_KEY`, and the `uploads`, `transcripts` and `logs` directories exist. Once running, access the API at `http://localhost:8000`.
+The worker container runs `celery -A api.services.celery_app worker` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch; optionally run `scripts/run_tests.sh` afterward to execute the tests. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. These scripts source `scripts/shared_checks.sh` which ensures Whisper models are present, `.env` contains a valid `SECRET_KEY`, and the `uploads`, `transcripts` and `logs` directories exist. Once running, access the API at `http://localhost:8000`.
 
 ## Testing
 
@@ -456,14 +456,14 @@ Start the containers with `scripts/start_containers.sh` or `docker compose
 up --build` and run the full suite with:
 
 ```bash
-./scripts/run_all_tests.sh
+./scripts/run_tests.sh
 ```
 
 This script runs the backend tests and integration checks, then executes the
 frontend unit tests and Cypress end‑to‑end tests. Output is saved to
 `logs/full_test.log`.
 
-Both `scripts/run_all_tests.sh` and `scripts/run_tests.sh` check that the `api`
+Both `scripts/run_tests.sh` and `scripts/run_backend_tests.sh` check that the `api`
 container is running before executing. If it isn't, they exit with the message
 ```
 API container is not running. Start the stack with scripts/start_containers.sh

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -33,10 +33,10 @@ The application is considered working once these basics are functional:
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
  - `start_containers.sh` – helper script that builds the frontend if needed, verifies required models and `.env`, then launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
- - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Tests are no longer run automatically; invoke `run_all_tests.sh` separately if desired.
+ - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Tests are no longer run automatically; invoke `run_backend_tests.sh` separately if desired.
 - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
-- `run_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
-- `run_all_tests.sh` – preferred wrapper that additionally executes frontend unit
+- `run_backend_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
+- `run_tests.sh` – preferred wrapper that additionally executes frontend unit
   tests and Cypress end-to-end tests, saving results to `logs/full_test.log`.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -10,7 +10,7 @@ usage() {
 Usage: $(basename "$0")
 
 Prunes Docker resources, rebuilds images and starts the compose stack from scratch.
-Run scripts/run_all_tests.sh afterward to execute the test suite.
+Run scripts/run_tests.sh afterward to execute the test suite.
 EOF
 }
 
@@ -44,5 +44,5 @@ docker compose -f "$ROOT_DIR/docker-compose.yml" build \
   --build-arg SECRET_KEY="$SECRET_KEY" api worker
 docker compose -f "$ROOT_DIR/docker-compose.yml" up -d api worker broker db
 
-echo "Images built and containers started. Run scripts/run_all_tests.sh separately to execute the test suite."
+echo "Images built and containers started. Run scripts/run_tests.sh separately to execute the test suite."
 

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 LOG_DIR="$ROOT_DIR/logs"
-LOG_FILE="$LOG_DIR/full_test.log"
+LOG_FILE="$LOG_DIR/test.log"
 
 mkdir -p "$LOG_DIR"
 
@@ -16,9 +16,9 @@ if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
 fi
 
 {
-    "$SCRIPT_DIR/run_tests.sh"
-    npm test --prefix "$ROOT_DIR/frontend"
-    npm run e2e --prefix "$ROOT_DIR/frontend"
+    docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
+    docker compose -f "$COMPOSE_FILE" exec -T api coverage report
+    "$SCRIPT_DIR/integration_tests.sh"
 } | tee "$LOG_FILE"
 
-echo "Full test log saved to $LOG_FILE"
+echo "Test log saved to $LOG_FILE"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 LOG_DIR="$ROOT_DIR/logs"
-LOG_FILE="$LOG_DIR/test.log"
+LOG_FILE="$LOG_DIR/full_test.log"
 
 mkdir -p "$LOG_DIR"
 
@@ -16,9 +16,9 @@ if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
 fi
 
 {
-    docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
-    docker compose -f "$COMPOSE_FILE" exec -T api coverage report
-    "$SCRIPT_DIR/integration_tests.sh"
+    "$SCRIPT_DIR/run_backend_tests.sh"
+    npm test --prefix "$ROOT_DIR/frontend"
+    npm run e2e --prefix "$ROOT_DIR/frontend"
 } | tee "$LOG_FILE"
 
-echo "Test log saved to $LOG_FILE"
+echo "Full test log saved to $LOG_FILE"


### PR DESCRIPTION
## Summary
- rename backend/overall test scripts
- update Docker instructions and docs for new script names

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d7d1c2da483259e1f79cb547adfbc