### PR TITLE
Fix unbound variable in start script

### DIFF
--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -16,7 +16,7 @@ and logs directories.
 EOF
 }
 
-if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
     exit 0
 fi


### PR DESCRIPTION
## Summary
- guard command argument in `start_containers.sh`

## Testing
- `bash scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db04dc0408325adc1bb1cd1989dde