### PR TITLE
Add API diagnostics to backend test script

### DIFF
--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -12,6 +12,8 @@ mkdir -p "$LOG_DIR"
 # Ensure the API container is running before executing tests
 if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
     echo "API container is not running. Start the stack with scripts/start_containers.sh" >&2
+    echo "Last API container logs:" >&2
+    docker compose -f "$COMPOSE_FILE" logs api | tail -n 20 >&2 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- show last API logs if the container failed to start

## Testing
- `black . --quiet`


------
https://chatgpt.com/codex/tasks/task_e_686dba00933c8325bd1d626ca2e8fbad