### PR TITLE
Add SECRET_KEY build arg to Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ and generate a key automatically when needed. If you start the stack
 manually, copy `.env.example` to `.env` and replace `CHANGE_ME` with your
 key. Include valid database credentials or a `DB_URL` override so the containers
 can connect to PostgreSQL.
+When building with Docker Compose, `SECRET_KEY` must be set in the environment so
+Compose can forward it as a build argument.
 
 Build and start all services with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   api:
-    build: .
+    build:
+      context: .
+      args:
+        SECRET_KEY: ${SECRET_KEY}
     restart: on-failure
     ports:
       - "8000:8000"
@@ -62,7 +65,10 @@ services:
       retries: 5
 
   worker:
-    build: .
+    build:
+      context: .
+      args:
+        SECRET_KEY: ${SECRET_KEY}
     command: celery -A api.services.celery_app worker
     restart: on-failure
     environment:


### PR DESCRIPTION
## Summary
- allow docker-compose to pass SECRET_KEY at build time
- note SECRET_KEY must be set before running compose

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686dbc0493c48325b67fbabd9a87b6a3