### PR TITLE
Improve container logs in run_tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -12,6 +12,8 @@ mkdir -p "$LOG_DIR"
 # Ensure the API container is running before executing tests
 if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
     echo "API container is not running. Start the stack with scripts/start_containers.sh" >&2
+    echo "Last API container logs:" >&2
+    docker compose -f "$COMPOSE_FILE" logs api | tail -n 20 >&2 || true
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- surface recent API logs when `scripts/run_tests.sh` detects the container isn't running
- keep exit code behavior the same
- run `black .`

## Testing
- `black . --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686df5ea333483259c597181b883dffb