### PR TITLE
Improve run_tests.sh service status

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -14,6 +14,7 @@ if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
     echo "API container is not running. Start the stack with scripts/start_containers.sh" >&2
     echo "Last API container logs:" >&2
     docker compose -f "$COMPOSE_FILE" logs api | tail -n 20 >&2 || true
+    docker compose -f "$COMPOSE_FILE" ps >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- show container status if API is not running in `run_tests.sh`
- format repository with `black`

## Testing
- `scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df845ae208325bc20fad7c220c69f