### PR TITLE
Use session.get for user retrieval

### DIFF
--- a/api/services/users.py
+++ b/api/services/users.py
@@ -57,7 +57,7 @@ def update_user_role(user_id: int, role: str) -> Optional[User]:
     """Update a user's role and return the updated user or None."""
     with db_lock:
         with SessionLocal() as db:
-            user = db.query(User).get(user_id)
+            user = db.get(User, user_id)
             if not user:
                 return None
             user.role = role
@@ -71,7 +71,7 @@ def update_user_password(user_id: int, password: str) -> Optional[User]:
     hashed = pwd_context.hash(password)
     with db_lock:
         with SessionLocal() as db:
-            user = db.query(User).get(user_id)
+            user = db.get(User, user_id)
             if not user:
                 return None
             user.hashed_password = hashed


### PR DESCRIPTION
## Summary
- refactor user services to use `db.get` for user ID lookups

## Testing
- `black api/services/users.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687072b4251c8325b7c79ce385c9fe63