### PR TITLE
Respect broker connect attempts

### DIFF
--- a/tests/test_celery_startup.py
+++ b/tests/test_celery_startup.py
@@ -5,6 +5,7 @@ import pytest
 @pytest.mark.asyncio
 async def test_check_celery_connection_retries(monkeypatch):
     monkeypatch.setenv("JOB_QUEUE_BACKEND", "broker")
+    monkeypatch.setenv("BROKER_CONNECT_ATTEMPTS", "3")
     import api.app_state as app_state
 
     importlib.reload(app_state)
@@ -27,3 +28,30 @@ async def test_check_celery_connection_retries(monkeypatch):
     await app_state.check_celery_connection()
 
     assert attempts.count("ping") == 3
+
+
+@pytest.mark.asyncio
+async def test_check_celery_connection_max_attempts_exceeded(monkeypatch):
+    monkeypatch.setenv("JOB_QUEUE_BACKEND", "broker")
+    monkeypatch.setenv("BROKER_CONNECT_ATTEMPTS", "2")
+    import api.app_state as app_state
+
+    importlib.reload(app_state)
+
+    attempts = []
+
+    def fake_ping(timeout=1):
+        attempts.append("ping")
+        return []
+
+    async def fake_sleep(_):
+        attempts.append("sleep")
+
+    celery_app_module = importlib.import_module("api.services.celery_app")
+    monkeypatch.setattr(celery_app_module.celery_app.control, "ping", fake_ping)
+    monkeypatch.setattr(app_state.asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(app_state.InitError):
+        await app_state.check_celery_connection()
+
+    assert attempts.count("ping") == 2


### PR DESCRIPTION
## Summary
- stop looping forever in `check_celery_connection`
- add retry limit using `BROKER_CONNECT_ATTEMPTS`
- test Celery connection failure when the limit is exceeded

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement httpx)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6870851175d0832598def4960844f13c