### PR TITLE
Use secret for BuildKit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   api:
     build:
       context: .
-      args:
-        SECRET_KEY: ${SECRET_KEY}
+      secrets:
+        - secret_key
     restart: on-failure
     ports:
       - "8000:8000"
@@ -16,6 +16,8 @@ services:
       - CELERY_BACKEND_URL=rpc://
       - DB_URL=postgresql+psycopg2://whisper:whisper@db:5432/whisper
       - SECRET_KEY=${SECRET_KEY}
+    secrets:
+      - secret_key
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts
@@ -67,8 +69,8 @@ services:
   worker:
     build:
       context: .
-      args:
-        SECRET_KEY: ${SECRET_KEY}
+      secrets:
+        - secret_key
     command: celery -A api.services.celery_app worker
     restart: on-failure
     environment:
@@ -79,6 +81,8 @@ services:
       - CELERY_BACKEND_URL=rpc://
       - DB_URL=postgresql+psycopg2://whisper:whisper@db:5432/whisper
       - SECRET_KEY=${SECRET_KEY}
+    secrets:
+      - secret_key
     volumes:
       - ./uploads:/app/uploads
       - ./transcripts:/app/transcripts
@@ -97,3 +101,7 @@ services:
 volumes:
   db_data:
   rabbitmq_data:
+
+secrets:
+  secret_key:
+    file: ./secret_key.txt

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -46,10 +46,10 @@ cd frontend
 npm run build
 cd ..
 ```
-Provide a `SECRET_KEY` build argument so the image can run the validation
-step that loads application settings:
+Create a file containing your SECRET_KEY and pass it to BuildKit so the
+validation step can load application settings:
 ```bash
-docker build --build-arg SECRET_KEY=<your_key> -t whisper-app .
+docker build --secret id=secret_key,src=<file> -t whisper-app .
 ```
 
 Key environment files include `pyproject.toml`, `requirements.txt`, and the `Dockerfile` used to build a runnable image.


### PR DESCRIPTION
## Summary
- inject `secret_key` secret during compose builds
- mention BuildKit secret usage in design docs

## Testing
- `black .`
- `scripts/run_backend_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68708d77b2f883258dcc8f36013d0e5e