### PR TITLE
Add compose secret fallback

### DIFF
--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -6,13 +6,28 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"
 
+# Return 0 if docker compose build supports --secret
+supports_secret() {
+    docker compose build --help 2>/dev/null | grep -q -- "--secret"
+}
+
 # Load SECRET_KEY from .env
 ensure_env_file
 
 # Rebuild frontend assets
+
 (cd "$ROOT_DIR/frontend" && npm run build)
 
 # Rebuild API and worker images using Docker cache
-docker compose -f "$COMPOSE_FILE" build --build-arg SECRET_KEY="$SECRET_KEY" api worker
+if supports_secret; then
+    secret_file=$(mktemp)
+    printf '%s' "$SECRET_KEY" > "$secret_file"
+    docker compose -f "$COMPOSE_FILE" build \
+        --secret id=secret_key,src="$secret_file" api worker
+    rm -f "$secret_file"
+else
+    docker compose -f "$COMPOSE_FILE" build \
+        --build-arg SECRET_KEY="$SECRET_KEY" api worker
+fi
 
 docker compose -f "$COMPOSE_FILE" up -d api worker


### PR DESCRIPTION
## Summary
- detect if `docker compose build` supports `--secret`
- build docker images with `--secret` when available or use `--build-arg`

## Testing
- `black .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.111.0)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@reduxjs%2ftoolkit)*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68709a5e8aa08325a0ce255133bcdafe