### PR TITLE
Update container scripts to handle secret key file

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -68,6 +68,9 @@ pip install -r "$ROOT_DIR/requirements.txt"
 check_whisper_models
 ensure_env_file
 
+secret_file_runtime="$ROOT_DIR/secret_key.txt"
+printf '%s' "$SECRET_KEY" > "$secret_file_runtime"
+
 # Build the standalone image used for production deployments
 if supports_secret; then
     secret_file=$(mktemp)
@@ -117,4 +120,5 @@ while true; do
 done
 
 echo "Images built and containers started. Run scripts/run_tests.sh separately to execute the test suite."
+rm -f "$secret_file_runtime"
 

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -37,6 +37,9 @@ setup_persistent_dirs
 check_whisper_models
 ensure_env_file
 
+secret_file="$ROOT_DIR/secret_key.txt"
+printf '%s' "$SECRET_KEY" > "$secret_file"
+
 echo "Starting containers with docker compose..."
 docker compose -f "$COMPOSE_FILE" up --build -d api worker broker db
 
@@ -64,3 +67,4 @@ while true; do
 done
 
 echo "Containers are ready. Use 'docker compose ps' to check status."
+rm -f "$secret_file"


### PR DESCRIPTION
## Summary
- write the SECRET_KEY from `.env` into `secret_key.txt` in `start_containers.sh`
- create and later remove `secret_key.txt` during the Docker build workflow

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_68709c124be4832597fc249381a759ae