### PR TITLE
Document secret handling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,15 +335,15 @@ cd frontend
 npm run build
 cd ..
 ```
-Build the image with a secret key:
+Build the image with a secret key (using BuildKit secrets is preferred):
 ```bash
 SECRET_KEY=$(python -c "import secrets; print(secrets.token_hex(32))")
 printf "%s" "$SECRET_KEY" > secret_key.txt
 docker build --secret id=secret_key,src=secret_key.txt -t whisper-app .
 rm secret_key.txt
 ```
-You can also pass the key via build argument when BuildKit secrets are not
-available:
+If your Docker installation does not support `--secret`, pass the key via build
+argument instead:
 ```bash
 docker build --build-arg SECRET_KEY=$SECRET_KEY -t whisper-app .
 ```
@@ -405,11 +405,18 @@ manually, copy `.env.example` to `.env` and replace `CHANGE_ME` with your
 key. Include valid database credentials or a `DB_URL` override so the containers
 can connect to PostgreSQL.
 When building with Docker Compose, write the key to a temporary file and pass it
-using Docker's BuildKit secrets feature:
+using Docker's BuildKit secrets feature (recommended). The helper script
+`scripts/start_containers.sh` now creates `secret_key.txt` automatically so you
+only need to supply the key when invoking it manually:
 ```bash
 printf "%s" "$SECRET_KEY" > secret_key.txt
 docker compose build --secret id=secret_key,src=secret_key.txt api worker
 rm secret_key.txt
+```
+If `docker compose build` does not support `--secret`, use a build argument
+instead:
+```bash
+docker compose build --build-arg SECRET_KEY=$SECRET_KEY api worker
 ```
 
 Build and start all services with:

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -47,11 +47,13 @@ npm run build
 cd ..
 ```
 Create a file containing your SECRET_KEY and pass it to BuildKit so the
-validation step can load application settings:
+validation step can load application settings. BuildKit secrets are the
+preferred mechanism:
 ```bash
 docker build --secret id=secret_key,src=<file> -t whisper-app .
 ```
-Alternatively pass the key as a build argument:
+If `docker build` does not support `--secret`, pass the key as a build
+argument instead:
 ```bash
 docker build --build-arg SECRET_KEY=<key> -t whisper-app .
 ```

--- a/docs/future_updates.md
+++ b/docs/future_updates.md
@@ -305,10 +305,14 @@ This document organizes upcoming features for Whisper Transcriber. Items are gro
 - **Motivation**: Speeds up development by avoiding full image pruning when only code changes.
 
 ### Build Argument for SECRET_KEY
-- **Summary**: Dockerfile now accepts a `SECRET_KEY` build argument and falls back to it when `/run/secrets/secret_key` is not provided during build.
-- **Motivation**: `validate_models_dir()` loads settings which require a secret key. Supporting both BuildKit secrets and a build argument keeps the build compatible with older Docker Compose versions.
+- **Summary**: Dockerfile accepts a `SECRET_KEY` build argument as a fallback when `/run/secrets/secret_key` is not provided during build. BuildKit secrets remain the preferred approach.
+- **Motivation**: `validate_models_dir()` loads settings which require a secret key. Supporting `--build-arg SECRET_KEY=<key>` keeps the build compatible when `docker compose build --secret` is unavailable.
 
 ### Prerequisite Checks in start_containers.sh
 - **Summary**: start_containers.sh now verifies Whisper models exist and ensures a valid SECRET_KEY in .env. Missing prerequisites abort the build.
 - **Motivation**: Prevent confusing runtime errors by validating setup before docker-compose builds the images.
+
+### Automatic secret_key.txt Creation
+- **Summary**: start_containers.sh now writes `secret_key.txt` automatically so BuildKit can consume the key without manual steps.
+- **Motivation**: Simplifies container startup by handling temporary secret file creation.
 


### PR DESCRIPTION
## Summary
- clarify the use of BuildKit secrets with fall back to `--build-arg`
- note that `start_containers.sh` now writes `secret_key.txt` automatically

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68709d12cf10832581837ce4735e4d68