### PR TITLE
Fix api depends_on condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       broker:
         condition: service_healthy
       worker:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
       interval: 30s


### PR DESCRIPTION
## Summary
- switch api/worker link to `service_healthy`

## Testing
- `bash scripts/start_containers.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687130f09960832594d17d6fb1021e98