### PR TITLE
Add ffmpeg checks to scripts

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -66,6 +66,7 @@ pip install -r "$ROOT_DIR/requirements.txt"
 (cd "$ROOT_DIR/frontend" && npm install && npm run build)
 
 check_whisper_models
+check_ffmpeg
 ensure_env_file
 
 secret_file_runtime="$ROOT_DIR/secret_key.txt"

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -19,6 +19,14 @@ check_whisper_models() {
     done
 }
 
+# Verify ffmpeg is installed and on PATH
+check_ffmpeg() {
+    if ! command -v ffmpeg >/dev/null 2>&1; then
+        echo "ffmpeg executable not found. Please install ffmpeg and ensure it is in your PATH." >&2
+        return 1
+    fi
+}
+
 # Ensure .env exists and SECRET_KEY is populated
 ensure_env_file() {
     local env_file="$ROOT_DIR/.env"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -35,6 +35,7 @@ fi
 
 setup_persistent_dirs
 check_whisper_models
+check_ffmpeg
 ensure_env_file
 
 secret_file="$ROOT_DIR/secret_key.txt"


### PR DESCRIPTION
## Summary
- add a `check_ffmpeg` helper in `shared_checks.sh`
- ensure `docker_build.sh` and `start_containers.sh` validate ffmpeg availability

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_68716715d3808325b818f8cb65185833