### PR TITLE
Update broker retry setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ needed.
 - `DB_CONNECT_ATTEMPTS` – how many times to retry connecting to the database on
   startup (defaults to `10`).
 - `BROKER_CONNECT_ATTEMPTS` – how many times to retry pinging the Celery broker
-  on startup (defaults to `10`).
+  on startup (defaults to `20`).
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
  - `SECRET_KEY` – **required** secret used to sign JWT tokens. The application
@@ -124,7 +124,8 @@ PostgreSQL must be available. The default `DB_URL` targets the `db` service
 (based on the `postgres:15-alpine` image) from `docker-compose.yml`.
 
 If startup fails, set `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` for verbose
-logs before launching the API.
+logs before launching the API. Increase `BROKER_CONNECT_ATTEMPTS` if the API
+exits before the Celery worker is ready.
 
 When `JOB_QUEUE_BACKEND` is set to `broker` a Celery worker must also be
 started:

--- a/api/settings.py
+++ b/api/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     log_backup_count: int = Field(3, env="LOG_BACKUP_COUNT")
     max_upload_size: int = Field(2 * 1024**3, env="MAX_UPLOAD_SIZE")
     db_connect_attempts: int = Field(10, env="DB_CONNECT_ATTEMPTS")
-    broker_connect_attempts: int = Field(10, env="BROKER_CONNECT_ATTEMPTS")
+    broker_connect_attempts: int = Field(20, env="BROKER_CONNECT_ATTEMPTS")
     allow_registration: bool = Field(True, env="ALLOW_REGISTRATION")
     auth_username: str = Field("admin", env="AUTH_USERNAME")
     auth_password: str = Field("admin", env="AUTH_PASSWORD")

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -80,7 +80,7 @@ object used throughout the code base. Available variables are:
 - `DB_CONNECT_ATTEMPTS` – how many times to retry connecting to the database on
   startup (defaults to `10`).
 - `BROKER_CONNECT_ATTEMPTS` – how many times to retry pinging the Celery broker
-  on startup (defaults to `10`).
+  on startup (defaults to `20`).
 - `AUTH_USERNAME` / `AUTH_PASSWORD` – *(deprecated)* old static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint.
 - `SECRET_KEY` – secret for JWT signing.


### PR DESCRIPTION
## Summary
- bump `broker_connect_attempts` default from 10 to 20
- document the new default and mention how to use the variable when startup fails
- keep design docs in sync

## Testing
- `black .`
- `coverage run -m pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687196e0dc68832586cc833ae65ec081