### PR TITLE
Clarify helper scripts usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,9 +470,15 @@ The worker container runs `celery -A api.services.celery_app worker` to process 
 
 ## Updating the Application
 
-Use `scripts/docker_build.sh --force` for a clean rebuild after pulling the latest code. This script fetches updates with `git fetch` and `git pull`, prunes Docker resources, installs dependencies and rebuilds all images from scratch. Run it when dependencies, the Dockerfile or compose configuration change, or whenever the environment falls out of sync.
+Before rebuilding containers, update the repository:
+```bash
+git fetch
+git pull
+```
 
-For routine code updates, run `scripts/update_images.sh` once your repository is up to date. It uses Docker's cache to rebuild only the API and worker images and then restarts those services.
+Use `scripts/docker_build.sh --force` for a clean rebuild when dependencies, the Dockerfile or compose configuration change or if the environment is out of sync. It prunes Docker resources, installs dependencies and rebuilds all images from scratch.
+
+Run `scripts/update_images.sh` after pulling the latest code for routine updates. It reuses Docker's cache to rebuild only the API and worker images and then restarts those services.
 
 After using either script, execute `scripts/run_tests.sh` to verify the new build.
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -33,8 +33,8 @@ The application is considered working once these basics are functional:
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
  - `start_containers.sh` – helper script that builds the frontend if needed, verifies required models and `.env`, then launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
- - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. After rebuilding, run `scripts/run_tests.sh` to verify everything works. Use `scripts/run_backend_tests.sh` if you only need the backend tests.
-- `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources.
+ - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Run it after `git fetch` and `git pull` when dependencies, the Dockerfile or compose configuration change, or if the environment is out of sync. After rebuilding, run `scripts/run_tests.sh` to verify everything works. Use `scripts/run_backend_tests.sh` if you only need the backend tests.
+- `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources. Run it after `git fetch` and `git pull` for routine code updates.
 - `run_backend_tests.sh` – runs backend tests and integration checks, logging output to `logs/test.log`.
 - `run_tests.sh` – preferred wrapper that additionally executes frontend unit
   tests and Cypress end-to-end tests, saving results to `logs/full_test.log`.


### PR DESCRIPTION
## Summary
- clarify when to run `docker_build.sh` vs `update_images.sh`
- mention running `git fetch` and `git pull` before either script

## Testing
- `black .`
- `pip install -r requirements-dev.txt`
- `./scripts/run_backend_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae7d3a1d083258721d15c273bdf21