### PR TITLE
Use available_models for model validation

### DIFF
--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -7,6 +7,7 @@ import shutil
 import uuid
 
 from api.utils.logger import get_system_logger
+from api.utils.model_validation import available_models
 
 log = get_system_logger()
 from api.app_state import backend_log
@@ -36,9 +37,6 @@ from api.services.analysis import analyze_text
 
 router = APIRouter()
 
-# Allowed Whisper model names derived from validate_models_dir
-ALLOWED_MODELS = {"base", "small", "medium", "large-v3", "tiny"}
-
 
 @router.post(
     "/jobs", status_code=status.HTTP_202_ACCEPTED, response_model=JobCreatedOut
@@ -46,7 +44,7 @@ ALLOWED_MODELS = {"base", "small", "medium", "large-v3", "tiny"}
 async def submit_job(
     file: UploadFile = File(...), model: str = Form("base")
 ) -> JobCreatedOut:
-    if model not in ALLOWED_MODELS:
+    if model not in available_models():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid model"
         )

--- a/api/utils/model_validation.py
+++ b/api/utils/model_validation.py
@@ -34,3 +34,15 @@ def validate_models_dir():
             f"Required model files missing from {MODEL_DIR.resolve()}: "
             f"{', '.join(missing)}."
         )
+
+
+def available_models() -> set[str]:
+    """Return model names discovered in ``MODEL_DIR``.
+
+    Model files are expected to have a ``.pt`` extension. The returned names
+    exclude the extension. Missing ``MODEL_DIR`` simply results in an empty
+    set.
+    """
+    if not MODEL_DIR.exists():
+        return set()
+    return {p.stem for p in MODEL_DIR.glob("*.pt") if p.is_file()}


### PR DESCRIPTION
## Summary
- list Whisper models dynamically in `available_models`
- use `available_models` when validating job submissions

## Testing
- `black .`
- `pytest tests/test_jobs.py::test_submit_invalid_model -q --import-mode=importlib` *(fails: ExecutableMissingException)*

------
https://chatgpt.com/codex/tasks/task_e_687b128ccd50832586ed42050b6788aa