### PR TITLE
Add optional dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.4
 FROM python:3.11-slim
 
+# Install dev requirements when building test images
+ARG INSTALL_DEV=false
+
 # Secret used for model validation during build
 ARG SECRET_KEY
 
@@ -21,7 +24,7 @@ COPY requirements-dev.txt .
 COPY alembic.ini .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir -r requirements-dev.txt
+    if [ "$INSTALL_DEV" = "true" ]; then pip install --no-cache-dir -r requirements-dev.txt; fi
 
 COPY scripts/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -87,11 +87,13 @@ if supports_secret; then
     secret_file=$(mktemp)
     printf '%s' "$SECRET_KEY" > "$secret_file"
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
-      --secret id=secret_key,src="$secret_file" api worker
+      --secret id=secret_key,src="$secret_file" \
+      --build-arg INSTALL_DEV=true api worker
     rm -f "$secret_file"
 else
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
-      --build-arg SECRET_KEY="$SECRET_KEY" api worker
+      --build-arg SECRET_KEY="$SECRET_KEY" \
+      --build-arg INSTALL_DEV=true api worker
 fi
 docker compose -f "$ROOT_DIR/docker-compose.yml" up -d api worker broker db
 

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -23,11 +23,13 @@ if supports_secret; then
     secret_file=$(mktemp)
     printf '%s' "$SECRET_KEY" > "$secret_file"
     docker compose -f "$COMPOSE_FILE" build \
-        --secret id=secret_key,src="$secret_file" api worker
+        --secret id=secret_key,src="$secret_file" \
+        --build-arg INSTALL_DEV=true api worker
     rm -f "$secret_file"
 else
     docker compose -f "$COMPOSE_FILE" build \
-        --build-arg SECRET_KEY="$SECRET_KEY" api worker
+        --build-arg SECRET_KEY="$SECRET_KEY" \
+        --build-arg INSTALL_DEV=true api worker
 fi
 
 docker compose -f "$COMPOSE_FILE" up -d api worker


### PR DESCRIPTION
## Summary
- install dev packages only when `INSTALL_DEV=true`
- pass `INSTALL_DEV=true` when helper scripts build API images

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687b14d3656c8325aa46e1075c4268f2