### PR TITLE
Set RabbitMQ nodename in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     ports:
       - "15672:15672"
       - "5672:5672"
+    environment:
+      - RABBITMQ_NODENAME=rabbit@broker
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
       - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro


### PR DESCRIPTION
## Summary
- ensure RabbitMQ has predictable nodename

## Testing
- `black .`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb09b9a308325888044b396da564d