### PR TITLE
Handle broker ping timeout in worker entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ needed.
   `Celery broker unreachable after 20 attempts. Is the broker running?` (seen in
   the `scripts/docker_build.sh` output), increase this value or confirm the
   worker is healthy.
+- `BROKER_PING_TIMEOUT` – how many seconds the worker entrypoint waits for
+  RabbitMQ to respond before exiting (defaults to `60`).
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
  - `SECRET_KEY` – **required** secret used to sign JWT tokens. The application
@@ -466,7 +468,7 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
-The worker container runs `python worker.py` to process jobs from RabbitMQ. An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. After starting the containers it waits for the `api` service to report a healthy status (controlled by the `API_HEALTH_TIMEOUT` environment variable which defaults to 120 seconds) and exits with an error if it never becomes healthy. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. These scripts source `scripts/shared_checks.sh` which ensures Whisper models are present, `.env` contains a valid `SECRET_KEY`, and the `uploads`, `transcripts` and `logs` directories exist. Once running, access the API at `http://localhost:8000`.
+The worker container runs `python worker.py` to process jobs from RabbitMQ. Its entrypoint pings the broker until it responds, printing `waiting...` while attempts fail and exiting if no response arrives within `BROKER_PING_TIMEOUT` seconds (60 by default). An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. After starting the containers it waits for the `api` service to report a healthy status (controlled by the `API_HEALTH_TIMEOUT` environment variable which defaults to 120 seconds) and exits with an error if it never becomes healthy. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. These scripts source `scripts/shared_checks.sh` which ensures Whisper models are present, `.env` contains a valid `SECRET_KEY`, and the `uploads`, `transcripts` and `logs` directories exist. Once running, access the API at `http://localhost:8000`.
 
 ## Updating the Application
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,9 +6,17 @@ chown -R 1000:1000 /app/uploads /app/transcripts /app/logs
 # If this container is running a worker, wait for the broker to be ready
 if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
     broker_host="${CELERY_BROKER_HOST:-broker}"
+    max_wait=${BROKER_PING_TIMEOUT:-60}
+    start_time=$(date +%s)
     echo "Waiting for RabbitMQ at ${broker_host}..."
     while ! rabbitmq-diagnostics -q ping -n "rabbit@${broker_host}" >/dev/null 2>&1; do
+        echo "waiting..."
         sleep 1
+        elapsed=$(( $(date +%s) - start_time ))
+        if [ $elapsed -ge $max_wait ]; then
+            echo "Broker unreachable after ${max_wait}s" >&2
+            exit 1
+        fi
     done
     echo "Broker is available. Starting worker."
 fi


### PR DESCRIPTION
## Summary
- show a waiting message when pinging RabbitMQ from the entrypoint
- exit the entrypoint after a configurable timeout
- document `BROKER_PING_TIMEOUT` and worker startup behavior in the README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest tests/test_celery_startup.py::test_check_celery_connection_retries -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_687bb2431b508325b7ee8382b89c07e9