### PR TITLE
Add container diagnostic script

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ git pull
 Use `scripts/docker_build.sh --force` for a clean rebuild when dependencies, the Dockerfile or compose configuration change or if the environment is out of sync. It prunes Docker resources, installs dependencies and rebuilds all images from scratch.
 
 Run `scripts/update_images.sh` after pulling the latest code for routine updates. It reuses Docker's cache to rebuild only the API and worker images and then restarts those services.
+If containers fail to start, run `scripts/diagnose_containers.sh` to check their status and recent logs.
 
 After using either script, execute `scripts/run_tests.sh` to verify the new build.
 

--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+
+echo "Container status:" 
+# Display container status including health information
+docker compose -f "$COMPOSE_FILE" ps
+
+# Get list of services defined in the compose file
+services=$(docker compose -f "$COMPOSE_FILE" config --services)
+
+for svc in $services; do
+    echo
+    echo "===== Last 20 log lines for $svc ====="
+    docker compose -f "$COMPOSE_FILE" logs --tail 20 "$svc" || true
+done


### PR DESCRIPTION
## Summary
- add `diagnose_containers.sh` helper for printing container status and logs
- document the new diagnostic script in the README

## Testing
- `pip install -r requirements-dev.txt`
- `./scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb4518e488325a186233c64e500e1