### PR TITLE
Improve container diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ git pull
 Use `scripts/docker_build.sh --force` for a clean rebuild when dependencies, the Dockerfile or compose configuration change or if the environment is out of sync. It prunes Docker resources, installs dependencies and rebuilds all images from scratch.
 
 Run `scripts/update_images.sh` after pulling the latest code for routine updates. It reuses Docker's cache to rebuild only the API and worker images and then restarts those services.
-If containers fail to start, run `scripts/diagnose_containers.sh` to check their status and recent logs.
+If containers fail to start, run `scripts/diagnose_containers.sh` to check their status, recent logs and health information.
 
 After using either script, execute `scripts/run_tests.sh` to verify the new build.
 

--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+LOG_LINES="${LOG_LINES:-20}"
 
 echo "Container status:" 
 # Display container status including health information
@@ -14,6 +15,13 @@ services=$(docker compose -f "$COMPOSE_FILE" config --services)
 
 for svc in $services; do
     echo
-    echo "===== Last 20 log lines for $svc ====="
-    docker compose -f "$COMPOSE_FILE" logs --tail 20 "$svc" || true
+    echo "===== Inspecting $svc ====="
+    container_id=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
+    if [ -n "$container_id" ]; then
+        docker inspect --format 'Status: {{ .State.Status }} (Health: {{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }})  Restarts: {{ .RestartCount }}' "$container_id" || true
+    else
+        echo "Container not running"
+    fi
+    echo "===== Last ${LOG_LINES} log lines for $svc ====="
+    docker compose -f "$COMPOSE_FILE" logs --tail "$LOG_LINES" "$svc" || true
 done


### PR DESCRIPTION
## Summary
- add a configurable log line count and container health inspection in `diagnose_containers.sh`
- mention the new health info in README

## Testing
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_687c370fa8cc8325a82750c6d713427a