### PR TITLE
Improve container diagnosis output

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,7 +481,7 @@ git pull
 Use `scripts/docker_build.sh --force` for a clean rebuild when dependencies, the Dockerfile or compose configuration change or if the environment is out of sync. It prunes Docker resources, installs dependencies and rebuilds all images from scratch.
 
 Run `scripts/update_images.sh` after pulling the latest code for routine updates. It reuses Docker's cache to rebuild only the API and worker images and then restarts those services.
-If containers fail to start, run `scripts/diagnose_containers.sh` to check their status, recent logs and health information.
+If containers fail to start, run `scripts/diagnose_containers.sh` to check their status, exit codes, restart counts and health information. The script also prints the `SERVICE_TYPE` and `CELERY_BROKER_URL` environment variables for each service and shows the last 20 log lines by default.
 
 After using either script, execute `scripts/run_tests.sh` to verify the new build.
 

--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -18,7 +18,9 @@ for svc in $services; do
     echo "===== Inspecting $svc ====="
     container_id=$(docker compose -f "$COMPOSE_FILE" ps -q "$svc" 2>/dev/null || true)
     if [ -n "$container_id" ]; then
-        docker inspect --format 'Status: {{ .State.Status }} (Health: {{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }})  Restarts: {{ .RestartCount }}' "$container_id" || true
+        docker inspect --format 'Status: {{ .State.Status }} (Health: {{ if .State.Health }}{{ .State.Health.Status }}{{ else }}none{{ end }})  Exit Code: {{ .State.ExitCode }}  Restarts: {{ .RestartCount }}' "$container_id" || true
+        echo "Environment variables:"
+        docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container_id" | grep -E '^(SERVICE_TYPE|CELERY_BROKER_URL)=' || true
     else
         echo "Container not running"
     fi


### PR DESCRIPTION
## Summary
- add exit code, restart count and selected env vars to `diagnose_containers.sh`
- document new script output in README

## Testing
- `black .`
- `scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3c739dc88325b0155fb39af8a6ed