### PR TITLE
Improve container diagnostic messaging

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -20,6 +20,7 @@ Prunes Docker resources, rebuilds images and starts the compose stack from scrat
 With no options, the script will prompt before removing Docker data.
   --force  Skip confirmation prompt and prune without asking.
 Run scripts/run_tests.sh afterward to execute the test suite.
+If startup fails, use scripts/diagnose_containers.sh to inspect the containers.
 EOF
 }
 
@@ -116,12 +117,15 @@ while true; do
         echo "API container failed to become healthy within ${max_wait}s." >&2
         echo "Last API container logs:" >&2
         docker compose -f "$ROOT_DIR/docker-compose.yml" logs api | tail -n 20 >&2 || true
+        echo "Run scripts/diagnose_containers.sh for a detailed status report." >&2
         exit 1
     fi
     printf "."
     sleep 5
 done
 
-echo "Images built and containers started. Run scripts/run_tests.sh separately to execute the test suite."
+echo "Images built and containers started."
+echo "Run scripts/run_tests.sh to execute the test suite." 
+echo "If containers encounter issues, use scripts/diagnose_containers.sh for troubleshooting." 
 rm -f "$secret_file_runtime"
 

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -61,6 +61,7 @@ while true; do
     if [ $elapsed -ge $max_wait ]; then
         echo ""
         echo "API service failed to become healthy within ${max_wait}s. Check 'docker compose logs api' for details." >&2
+        echo "Run scripts/diagnose_containers.sh for further troubleshooting." >&2
         exit 1
     fi
     printf "."
@@ -68,4 +69,5 @@ while true; do
 done
 
 echo "Containers are ready. Use 'docker compose ps' to check status."
+echo "Run scripts/run_tests.sh to execute the test suite." 
 rm -f "$secret_file"


### PR DESCRIPTION
## Summary
- add instructions about diagnosing containers in `docker_build.sh`
- mention troubleshooting and test commands in `start_containers.sh`

## Testing
- `black .`
- `./scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3fe196388325a8f1d775be635980