### PR TITLE
Improve build & startup logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
 The worker container runs `python worker.py` to process jobs from RabbitMQ. Its entrypoint uses Python's `socket` module to connect to the broker until it responds, printing `waiting...` while attempts fail and exiting if no response arrives within `BROKER_PING_TIMEOUT` seconds (60 by default). An optional helper script `scripts/start_containers.sh` builds the frontend if needed, verifies model files and `.env`, and then launches the compose stack in detached mode. After starting the containers it waits for the `api` service to report a healthy status (controlled by the `API_HEALTH_TIMEOUT` environment variable which defaults to 120 seconds) and exits with an error if it never becomes healthy. Another script `scripts/docker_build.sh` prunes Docker resources and then rebuilds the images and stack from scratch. Use `scripts/update_images.sh` to rebuild just the API and worker images using Docker's cache and restart those services when you make code changes. These scripts source `scripts/shared_checks.sh` which ensures Whisper models are present, `.env` contains a valid `SECRET_KEY`, and the `uploads`, `transcripts` and `logs` directories exist. Once running, access the API at `http://localhost:8000`.
+The build helper scripts mirror their output to log files for easier troubleshooting: `logs/start_containers.log`, `logs/docker_build.log`, and `logs/update_images.log`. The container entrypoint also writes to `logs/entrypoint.log` when each service starts.
 
 ## Updating the Application
 
@@ -481,7 +482,7 @@ git pull
 Use `scripts/docker_build.sh --force` for a clean rebuild when dependencies, the Dockerfile or compose configuration change or if the environment is out of sync. It prunes Docker resources, installs dependencies and rebuilds all images from scratch.
 
 Run `scripts/update_images.sh` after pulling the latest code for routine updates. It reuses Docker's cache to rebuild only the API and worker images and then restarts those services.
-If containers fail to start, run `scripts/diagnose_containers.sh` to check their status, exit codes, restart counts and health information. The script also prints the `SERVICE_TYPE` and `CELERY_BROKER_URL` environment variables for each service and shows the last 20 log lines by default.
+If containers fail to start, run `scripts/diagnose_containers.sh` to check their status, exit codes, restart counts and health information. The script also prints the `SERVICE_TYPE` and `CELERY_BROKER_URL` environment variables for each service, shows the last 20 log lines from each container by default, and prints the full contents of any build log files in `logs/`.
 
 After using either script, execute `scripts/run_tests.sh` to verify the new build.
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -32,9 +32,9 @@ The application is considered working once these basics are functional:
 - `frontend/` – React app built into `frontend/dist/` and copied by the Dockerfile
   to `api/static/` for the UI.
 - `scripts/` – packaging helpers that generate `dist/whisper-transcriber.exe` and `dist/whisper-transcriber.rpm`.
- - `start_containers.sh` – helper script that builds the frontend if needed, verifies required models and `.env`, then launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`).
- - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Run it after `git fetch` and `git pull` when dependencies, the Dockerfile or compose configuration change, or if the environment is out of sync. After rebuilding, run `scripts/run_tests.sh` to verify everything works. Use `scripts/run_backend_tests.sh` if you only need the backend tests.
-- `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources. Run it after `git fetch` and `git pull` for routine code updates.
+ - `start_containers.sh` – helper script that builds the frontend if needed, verifies required models and `.env`, then launches the Docker Compose stack (`api`, `worker`, `broker`, and `db`). All output is mirrored to `logs/start_containers.log` for troubleshooting.
+ - `docker_build.sh` – wipes old Docker resources and rebuilds the compose stack from scratch. Run it after `git fetch` and `git pull` when dependencies, the Dockerfile or compose configuration change, or if the environment is out of sync. Output is saved to `logs/docker_build.log`. After rebuilding, run `scripts/run_tests.sh` to verify everything works. Use `scripts/run_backend_tests.sh` if you only need the backend tests.
+ - `update_images.sh` – rebuilds the API and worker images using Docker's cache and restarts those services without pruning existing resources. Its log is written to `logs/update_images.log`. Run it after `git fetch` and `git pull` for routine code updates.
 - `run_backend_tests.sh` – runs backend tests and verifies the `/health` and `/version` endpoints, logging output to `logs/test.log`.
 - `run_tests.sh` – preferred wrapper that additionally executes frontend unit
   tests and Cypress end-to-end tests, saving results to `logs/full_test.log`.

--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -56,3 +56,16 @@ if [ -z "$api_id" ]; then
         fi
     done
 fi
+
+echo
+echo "===== Build logs ====="
+for log in docker_build.log start_containers.log update_images.log entrypoint.log; do
+    log_path="$ROOT_DIR/logs/$log"
+    echo
+    echo "----- ${log} -----"
+    if [ -f "$log_path" ]; then
+        cat "$log_path"
+    else
+        echo "Log file $log_path not found"
+    fi
+done

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+LOG_FILE="/app/logs/entrypoint.log"
 mkdir -p /app/uploads /app/transcripts /app/logs
+# Mirror output to a log file for troubleshooting
+exec > >(tee -a "$LOG_FILE") 2>&1
 chown -R 1000:1000 /app/uploads /app/transcripts /app/logs
+
+echo "Container entrypoint starting with environment:" >&2
+env | sort >&2
 
 # If this container is running a worker, wait for the broker to be ready
 if [ "${SERVICE_TYPE:-api}" = "worker" ]; then
@@ -30,4 +37,5 @@ while True:
 print("Broker is available. Starting worker.")
 PY
 fi
+echo "Executing: $@" >&2
 exec gosu appuser "$@"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"
 
+LOG_DIR="$ROOT_DIR/logs"
+LOG_FILE="$LOG_DIR/docker_build.log"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 # Return 0 if docker compose build supports --secret
 supports_secret() {
     docker compose build --help 2>/dev/null | grep -q -- "--secret"
@@ -69,6 +74,9 @@ pip install -r "$ROOT_DIR/requirements.txt"
 check_whisper_models
 check_ffmpeg
 ensure_env_file
+
+echo "Environment variables:" >&2
+env | sort >&2
 
 secret_file_runtime="$ROOT_DIR/secret_key.txt"
 printf '%s' "$SECRET_KEY" > "$secret_file_runtime"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -6,6 +6,12 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"
 
+LOG_DIR="$ROOT_DIR/logs"
+LOG_FILE="$LOG_DIR/start_containers.log"
+mkdir -p "$LOG_DIR"
+# Mirror all output to a startup log for troubleshooting
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 usage() {
     cat <<EOF
 Usage: $(basename "$0")
@@ -40,6 +46,9 @@ ensure_env_file
 
 secret_file="$ROOT_DIR/secret_key.txt"
 printf '%s' "$SECRET_KEY" > "$secret_file"
+
+echo "Environment variables:" >&2
+env | sort >&2
 
 echo "Starting containers with docker compose..."
 docker compose -f "$COMPOSE_FILE" up --build -d api worker broker db

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -6,6 +6,11 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"
 
+LOG_DIR="$ROOT_DIR/logs"
+LOG_FILE="$LOG_DIR/update_images.log"
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 # Return 0 if docker compose build supports --secret
 supports_secret() {
     docker compose build --help 2>/dev/null | grep -q -- "--secret"
@@ -13,6 +18,9 @@ supports_secret() {
 
 # Load SECRET_KEY from .env
 ensure_env_file
+
+echo "Environment variables:" >&2
+env | sort >&2
 
 # Rebuild frontend assets
 


### PR DESCRIPTION
## Summary
- log start_containers.sh activity to logs/start_containers.log
- log docker_build.sh activity to logs/docker_build.log
- log update_images.sh activity to logs/update_images.log
- make container entrypoint log to logs/entrypoint.log
- document new log locations in docs
- add build logs to diagnose_containers.sh output
- print entire build logs in diagnose_containers.sh

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: api)*

------
https://chatgpt.com/codex/tasks/task_e_687cf1c9edd883259ce16a099ade1037