### PR TITLE
Fix worker container path for worker.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 COPY api         ./api
 COPY models      ./models
+COPY worker.py   ./worker.py
 # Use BuildKit secrets when available, otherwise rely on the build argument
 RUN --mount=type=secret,id=secret_key \
     bash -c 'if [ -f /run/secrets/secret_key ]; then export SECRET_KEY="$(cat /run/secrets/secret_key)"; fi; \ 


### PR DESCRIPTION
## Summary
- copy `worker.py` into the Docker image so the worker container can start

## Testing
- `black . --check`
- `docker compose build worker` *(fails: command not found)*
- `scripts/docker_build.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d6efe42fc832588f910371bb1fa0b