### PR TITLE
Improve worker file diagnosis

### DIFF
--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -38,6 +38,10 @@ for svc in $services; do
             echo "worker.py present in worker image"
         else
             echo "worker.py missing in worker image"
+            if ! docker compose -f "$COMPOSE_FILE" run --rm --no-deps --entrypoint "" worker test -f /app/worker.py >/dev/null; then
+                echo "ERROR: /app/worker.py not found in worker image" >&2
+                exit 1
+            fi
         fi
     fi
 done


### PR DESCRIPTION
## Summary
- ensure `diagnose_containers.sh` fails when `/app/worker.py` is missing

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` within `frontend`
- `black .`
- `scripts/docker_build.sh --force` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ee1dafda483259074aef52ac14b30