### PR TITLE
Check docker registry before building

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -5,6 +5,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"
 
+# Verify Docker Hub access before proceeding
+if ! check_docker_registry; then
+    echo "Docker Hub is unreachable. Configure your proxy or network settings before building." >&2
+    exit 1
+fi
+
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/docker_build.log"
 mkdir -p "$LOG_DIR"

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -66,7 +66,7 @@ check_docker_registry() {
     echo "Checking Docker Hub connectivity..." >&2
     if ! docker pull --quiet docker/dockerfile:1.4 >/dev/null 2>&1; then
         echo "Unable to reach registry-1.docker.io. Configure network or proxy settings before building." >&2
-        return 1
+        exit 1
     fi
 }
 


### PR DESCRIPTION
## Summary
- fail in `check_docker_registry` when the registry can't be reached
- abort `docker_build.sh` early if docker hub is inaccessible and give a hint

## Testing
- `black .`
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest tests/test_health.py -k test_health -vv` *(fails: Directory '/workspace/whisper-transcriber/api/static' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687ee385781083258ecb2219a6edb37c