### PR TITLE
Add host networking for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ fails with errors like `failed to resolve source metadata` or `lookup
 http.docker.internal ... i/o timeout`, your network is blocking access to the
 Docker Hub registry. Check any proxy or firewall configuration and ensure the
 host can pull images before retrying the build.
+The helper script `scripts/docker_build.sh` passes `--network=host` to both
+`docker build` and `docker compose build`, which uses the host's networking
+directly and bypasses Docker's proxy settings such as `http.docker.internal`.
 If you use a prebuilt image, mount the models directory at runtime.
 
 Run the container with the application directories mounted so that

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -88,10 +88,10 @@ printf '%s' "$SECRET_KEY" > "$secret_file_runtime"
 if supports_secret; then
     secret_file=$(mktemp)
     printf '%s' "$SECRET_KEY" > "$secret_file"
-    docker build --secret id=secret_key,src="$secret_file" -t whisper-app "$ROOT_DIR"
+    docker build --network=host --secret id=secret_key,src="$secret_file" -t whisper-app "$ROOT_DIR"
     rm -f "$secret_file"
 else
-    docker build --build-arg SECRET_KEY="$SECRET_KEY" -t whisper-app "$ROOT_DIR"
+    docker build --network=host --build-arg SECRET_KEY="$SECRET_KEY" -t whisper-app "$ROOT_DIR"
 fi
 
 # Build images for the compose stack and start the services
@@ -99,11 +99,13 @@ if supports_secret; then
     secret_file=$(mktemp)
     printf '%s' "$SECRET_KEY" > "$secret_file"
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
+      --network=host \
       --secret id=secret_key,src="$secret_file" \
       --build-arg INSTALL_DEV=true api worker
     rm -f "$secret_file"
 else
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
+      --network=host \
       --build-arg SECRET_KEY="$SECRET_KEY" \
       --build-arg INSTALL_DEV=true api worker
 fi


### PR DESCRIPTION
## Summary
- use `--network=host` when building Docker images
- document the new behavior in the Docker build instructions

## Testing
- `pip install -r requirements-dev.txt`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_687ee95b287c8325a7f1f75ea7b35a01