### PR TITLE
Handle Docker registry errors gracefully

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -6,10 +6,10 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"
 
 # Verify Docker Hub access before proceeding
-if ! check_docker_registry; then
+check_docker_registry || {
     echo "Docker Hub is unreachable. Configure your proxy or network settings before building." >&2
     exit 1
-fi
+}
 
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/docker_build.log"

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -66,7 +66,7 @@ check_docker_registry() {
     echo "Checking Docker Hub connectivity..." >&2
     if ! docker pull --quiet docker/dockerfile:1.4 >/dev/null 2>&1; then
         echo "Unable to reach registry-1.docker.io. Configure network or proxy settings before building." >&2
-        exit 1
+        return 1
     fi
 }
 


### PR DESCRIPTION
## Summary
- update `check_docker_registry` to return non-zero rather than exit
- stop `docker_build.sh` when registry check fails

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `PYTHONPATH=. pytest -q` *(fails: Directory '/workspace/whisper-transcriber/api/static' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687eec626edc83258358113591ff65b2