### PR TITLE
Fix compose build options

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -99,13 +99,11 @@ if supports_secret; then
     secret_file=$(mktemp)
     printf '%s' "$SECRET_KEY" > "$secret_file"
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
-      --network=host \
       --secret id=secret_key,src="$secret_file" \
       --build-arg INSTALL_DEV=true api worker
     rm -f "$secret_file"
 else
     docker compose -f "$ROOT_DIR/docker-compose.yml" build \
-      --network=host \
       --build-arg SECRET_KEY="$SECRET_KEY" \
       --build-arg INSTALL_DEV=true api worker
 fi


### PR DESCRIPTION
## Summary
- drop `--network=host` from compose build commands in `docker_build.sh`

## Testing
- `black scripts/docker_build.sh` *(fails: Cannot parse for target version Python 3.13)*
- `scripts/docker_build.sh` *(fails: Docker Hub unreachable)*
- `scripts/run_tests.sh` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f11b730b08325a25ed489856486cf