### PR TITLE
Add offline asset verification and cache-based installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,12 @@ ENV PYTHONPATH=/app
 COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY alembic.ini .
+COPY cache/pip ./wheels
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt --retries 5 --resume-retries 3 --timeout 60 && \
+    pip install --no-index --find-links ./wheels -r requirements.txt && \
     if [ "$INSTALL_DEV" = "true" ]; then \
-        pip install --no-cache-dir -r requirements-dev.txt --retries 5 --resume-retries 3 --timeout 60; \
-    fi
+        pip install --no-index --find-links ./wheels -r requirements-dev.txt; \
+    fi && rm -rf ./wheels
 
 COPY scripts/healthcheck.sh /usr/local/bin/healthcheck.sh
 RUN chmod +x /usr/local/bin/healthcheck.sh

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -11,6 +11,9 @@ LOG_FILE="$LOG_DIR/docker_build.log"
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Ensure required offline assets are present
+verify_offline_assets
+
 # Return 0 if docker compose build supports --secret
 supports_secret() {
     docker compose build --help 2>/dev/null | grep -q -- "--secret"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -13,6 +13,9 @@ mkdir -p "$LOG_DIR"
 # Mirror all output to a startup log for troubleshooting
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Ensure required offline assets are present
+verify_offline_assets
+
 usage() {
     cat <<EOF
 Usage: $(basename "$0")

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -12,6 +12,9 @@ LOG_FILE="$LOG_DIR/update_images.log"
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Ensure required offline assets are present
+verify_offline_assets
+
 # Return 0 if docker compose build supports --secret
 supports_secret() {
     docker compose build --help 2>/dev/null | grep -q -- "--secret"


### PR DESCRIPTION
## Summary
- install Python deps from cached wheels in Dockerfile
- add `verify_offline_assets` helper and use it in build scripts
- check cached assets before building or starting containers

## Testing
- `black . --quiet`
- `pytest tests/test_health.py::test_health_db_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_688107ecb15c8325b74bffecbce2c3b7