### PR TITLE
Add docker readiness checks

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -11,6 +11,10 @@ LOG_FILE="$LOG_DIR/docker_build.log"
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Verify Docker and cache directories are ready
+check_docker_running
+check_cache_dirs
+
 # Ensure required offline assets are present
 verify_offline_assets
 

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -99,6 +99,26 @@ check_docker_compose() {
     fi
 }
 
+# Verify that the Docker daemon is running
+check_docker_running() {
+    if ! docker info >/dev/null 2>&1; then
+        echo "Docker daemon is not running. Start Docker and retry." >&2
+        return 1
+    fi
+}
+
+# Confirm cache directories exist under CACHE_DIR
+check_cache_dirs() {
+    local base="${CACHE_DIR:-$ROOT_DIR/cache}"
+    local dirs=("$base/images" "$base/pip" "$base/npm")
+    for d in "${dirs[@]}"; do
+        if [ ! -d "$d" ]; then
+            echo "Required cache directory $d missing" >&2
+            return 1
+        fi
+    done
+}
+
 # Ensure python packages and node modules are installed and docker images pulled
 stage_build_dependencies() {
     check_node_version

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -13,6 +13,10 @@ mkdir -p "$LOG_DIR"
 # Mirror all output to a startup log for troubleshooting
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Verify Docker and cache directories are ready
+check_docker_running
+check_cache_dirs
+
 # Ensure required offline assets are present
 verify_offline_assets
 

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -12,6 +12,10 @@ LOG_FILE="$LOG_DIR/update_images.log"
 mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
+# Verify Docker and cache directories are ready
+check_docker_running
+check_cache_dirs
+
 # Ensure required offline assets are present
 verify_offline_assets
 


### PR DESCRIPTION
## Summary
- verify Docker is running and required cache directories exist in `shared_checks.sh`
- run these new checks at the beginning of `docker_build.sh`, `update_images.sh` and `start_containers.sh`

## Testing
- `black .`
- `pip install -r requirements-dev.txt`
- `pytest tests/test_health.py::test_health -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68810df84de08325b8ae01823c46b668