### PR TITLE
Add offline apt package support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ ARG INSTALL_DEV=false
 # Secret used for model validation during build
 ARG SECRET_KEY
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      ffmpeg git curl gosu && \
-      apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY cache/apt /tmp/apt
+RUN dpkg -i /tmp/apt/*.deb && rm -rf /tmp/apt
 
 # Create a non-root user to run Celery workers
 RUN groupadd -g 1000 appuser && \

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -6,7 +6,8 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CACHE_DIR="$ROOT_DIR/cache"
 IMAGES_DIR="$CACHE_DIR/images"
 
-mkdir -p "$IMAGES_DIR" "$CACHE_DIR/pip" "$CACHE_DIR/npm"
+APT_DIR="$CACHE_DIR/apt"
+mkdir -p "$IMAGES_DIR" "$CACHE_DIR/pip" "$CACHE_DIR/npm" "$APT_DIR"
 
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 
@@ -35,6 +36,10 @@ pip download -d "$CACHE_DIR/pip" \
 echo "Caching Node modules..."
 npm install --prefix "$ROOT_DIR/frontend"
 npm ci --prefix "$ROOT_DIR/frontend" --cache "$CACHE_DIR/npm"
+
+echo "Downloading APT packages..."
+apt-get update
+apt-get -o Dir::Cache::archives="$APT_DIR" --yes --download-only --reinstall install ffmpeg git curl gosu
 
 echo "Dependencies staged under $CACHE_DIR"
 


### PR DESCRIPTION
## Summary
- cache ffmpeg, git, curl and gosu deb packages in `prestage_dependencies.sh`
- install those debs in the Docker image with `dpkg -i`
- verify apt packages in `verify_offline_assets`
- ensure cache/apt directory is expected

## Testing
- `black .`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` in `frontend`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68811806dfa48325a6e6f430eeb3d274