### PR TITLE
Move verify_offline_assets after staging dependencies

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -23,8 +23,9 @@ log_step "STAGING"
 # Verify Docker and cache directories are ready
 check_docker_running
 check_cache_dirs
+stage_build_dependencies
 
-# Ensure required offline assets are present
+# Verify required offline assets after downloads complete
 verify_offline_assets
 
 # Return 0 if docker compose build supports --secret
@@ -108,7 +109,6 @@ fi
 # Update the repo
 (git -C "$ROOT_DIR" fetch && git -C "$ROOT_DIR" pull)
 echo "Checking network connectivity and installing dependencies..."
-stage_build_dependencies
 (cd "$ROOT_DIR/frontend" && npm run build)
 
 log_step "VERIFICATION"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -23,8 +23,10 @@ log_step "STAGING"
 # Verify Docker and cache directories are ready
 check_docker_running
 check_cache_dirs
+echo "Checking network connectivity and installing dependencies..."
+stage_build_dependencies
 
-# Ensure required offline assets are present
+# Verify required offline assets after downloads complete
 verify_offline_assets
 
 usage() {
@@ -41,8 +43,6 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
     exit 0
 fi
-
-stage_build_dependencies
 
 log_step "VERIFICATION"
 setup_persistent_dirs

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -22,8 +22,10 @@ log_step "STAGING"
 # Verify Docker and cache directories are ready
 check_docker_running
 check_cache_dirs
+echo "Checking network connectivity and installing dependencies..."
+stage_build_dependencies
 
-# Ensure required offline assets are present
+# Verify required offline assets after downloads complete
 verify_offline_assets
 
 # Return 0 if docker compose build supports --secret
@@ -44,8 +46,6 @@ verify_built_images() {
 
 # Load SECRET_KEY from .env
 ensure_env_file
-echo "Checking network connectivity and installing dependencies..."
-stage_build_dependencies
 
 log_step "VERIFICATION"
 echo "Verifying Whisper models and ffmpeg..."


### PR DESCRIPTION
## Summary
- stage build dependencies before verifying offline assets
- update docker, update and start scripts accordingly

## Testing
- `black .`
- `pip install -r requirements.txt`
- `npm install` *(failed to fetch Cypress because `download.cypress.io` was blocked)*
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68811b69bb948325bcc3429f42ab02cc