### PR TITLE
Improve logging in prestage script

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'echo "prestage_dependencies.sh failed near line $LINENO" >&2' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOG_FILE="$ROOT_DIR/logs/prestage_dependencies.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 CACHE_DIR="$ROOT_DIR/cache"
 IMAGES_DIR="$CACHE_DIR/images"
 


### PR DESCRIPTION
## Summary
- log script output to `logs/prestage_dependencies.log`
- add error trap message for easier debugging

## Testing
- `black . --check`
- `pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(failed: operation cancelled due to huge downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68811f705a5c83258343ef97870028ee