### PR TITLE
Extend offline apt package support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ARG INSTALL_DEV=false
 # Secret used for model validation during build
 ARG SECRET_KEY
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      ffmpeg git curl gosu && \
-      apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY cache/apt /tmp/apt
+RUN dpkg -i /tmp/apt/*.deb && \
+    rm -rf /tmp/apt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user to run Celery workers
 RUN groupadd -g 1000 appuser && \

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -47,5 +47,12 @@ echo "Caching Node modules..."
 npm install --prefix "$ROOT_DIR/frontend"
 npm ci --prefix "$ROOT_DIR/frontend" --cache "$CACHE_DIR/npm"
 
+echo "Downloading apt packages..."
+apt-get update
+apt-get install -y --download-only --no-install-recommends \
+    ffmpeg git curl gosu
+cp /var/cache/apt/archives/*.deb "$CACHE_DIR/apt/"
+apt-get clean && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 echo "Dependencies staged under $CACHE_DIR"
 

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -203,6 +203,7 @@ verify_offline_assets() {
     local pip_cache="${CACHE_DIR:-$ROOT_DIR/cache}/pip"
     local npm_cache="${CACHE_DIR:-$ROOT_DIR/cache}/npm"
     local image_cache="${CACHE_DIR:-$ROOT_DIR/cache}/images"
+    local apt_cache="${CACHE_DIR:-$ROOT_DIR/cache}/apt"
 
     local missing=0
 
@@ -233,9 +234,17 @@ verify_offline_assets() {
     fi
 
     echo "Verifying cached apt packages..." >&2
-    if [ -d "$apt_cache" ] && [ -z "$(ls -A "$apt_cache" 2>/dev/null)" ]; then
-        echo "Apt cache directory $apt_cache empty" >&2
+    if [ ! -d "$apt_cache" ]; then
+        echo "Apt cache directory $apt_cache missing" >&2
         missing=1
+    else
+        local debs=(ffmpeg git curl gosu)
+        for pkg in "${debs[@]}"; do
+            if ! ls "$apt_cache"/"$pkg"*.deb >/dev/null 2>&1; then
+                echo "Missing $pkg package in $apt_cache" >&2
+                missing=1
+            fi
+        done
     fi
 
     echo "Verifying cached Docker images..." >&2


### PR DESCRIPTION
## Summary
- download ffmpeg, git, curl and gosu `.deb` packages when staging dependencies
- install those packages from the cached directory in Docker builds
- verify cached apt packages exist

## Testing
- `black .`
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install`
- `npm run build`
- `pytest -q` *(fails: Directory `/workspace/whisper-transcriber/api/static` does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688127021de88325aa798e142c57a893