### PR TITLE
Fix apt cache variable

### DIFF
--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -202,8 +202,8 @@ stage_build_dependencies() {
 verify_offline_assets() {
     local pip_cache="${CACHE_DIR:-$ROOT_DIR/cache}/pip"
     local npm_cache="${CACHE_DIR:-$ROOT_DIR/cache}/npm"
-    local image_cache="${CACHE_DIR:-$ROOT_DIR/cache}/images"
     local apt_cache="${CACHE_DIR:-$ROOT_DIR/cache}/apt"
+    local image_cache="${CACHE_DIR:-$ROOT_DIR/cache}/images"
 
     local missing=0
 


### PR DESCRIPTION
## Summary
- update `verify_offline_assets` to define `apt_cache` right after npm cache

## Testing
- `bash scripts/docker_build.sh` *(fails: Docker daemon is not running)*
- `bash scripts/update_images.sh` *(fails: Docker daemon is not running)*
- `bash scripts/start_containers.sh` *(fails: Docker daemon is not running)*
- `bash scripts/prestage_dependencies.sh` *(fails: Docker daemon is not running)*

------
https://chatgpt.com/codex/tasks/task_e_68812bd76ef08325aa980d9fb7db9ee5