### PR TITLE
Add offline pip upgrade support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY requirements.txt .
 COPY requirements-dev.txt .
 COPY alembic.ini .
 COPY cache/pip ./wheels
-RUN pip install --no-cache-dir --upgrade pip && \
+RUN pip install --no-cache-dir --no-index --find-links ./wheels --upgrade pip && \
     pip install --no-index --find-links ./wheels -r requirements.txt && \
     if [ "$INSTALL_DEV" = "true" ]; then \
         pip install --no-index --find-links ./wheels -r requirements-dev.txt; \

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -40,6 +40,7 @@ done
 
 echo "Downloading Python packages..."
 pip download -d "$CACHE_DIR/pip" \
+    pip \
     -r "$ROOT_DIR/requirements.txt" \
     -r "$ROOT_DIR/requirements-dev.txt"
 


### PR DESCRIPTION
## Summary
- ensure `prestage_dependencies.sh` grabs pip wheel for offline use
- upgrade pip from local wheels during Docker build

## Testing
- `black .`
- `npm install` *(partial output shown)*
- `pip install -r requirements.txt` *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68812fadd1608325802a5d57bf35d974