### PR TITLE
Add offline docker build flag

### DIFF
--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -96,10 +96,12 @@ else
         printf '%s' "$SECRET_KEY" > "$secret_file"
         docker compose -f "$COMPOSE_FILE" build \
             --secret id=secret_key,src="$secret_file" \
+            --network=none \
             --build-arg INSTALL_DEV=true "${build_targets[@]}"
         rm -f "$secret_file"
     else
         docker compose -f "$COMPOSE_FILE" build \
+            --network=none \
             --build-arg SECRET_KEY="$SECRET_KEY" \
             --build-arg INSTALL_DEV=true "${build_targets[@]}"
     fi


### PR DESCRIPTION
## Summary
- add `--network=none` to update_images.sh builds
- build API and worker images with `--network=none` in start_containers.sh

## Testing
- `black .`
- `pip install -r requirements.txt`
- `npm install` in frontend
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError: Directory '/workspace/whisper-transcriber/api/static' does not exist)*
- `bash scripts/update_images.sh` *(fails: Docker daemon is not running)*
- `bash scripts/start_containers.sh` *(fails: Docker daemon is not running)*

------
https://chatgpt.com/codex/tasks/task_e_68813c9c321883258205f794b56a4b89