### PR TITLE
Add root check before apt installs

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 trap 'echo "prestage_dependencies.sh failed near line $LINENO" >&2' ERR
 
+# Ensure script is run with root privileges for apt operations
+if [[ $EUID -ne 0 ]]; then
+    echo "Run with sudo to download apt packages" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"


### PR DESCRIPTION
## Summary
- ensure `prestage_dependencies.sh` exits if not run with sudo

## Testing
- `black . --check`
- `./scripts/run_tests.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814c48b3c08325aaf6d0c619868996