### PR TITLE
Increase API health wait timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ needed.
   worker is healthy.
 - `BROKER_PING_TIMEOUT` – how many seconds the worker entrypoint waits for
   RabbitMQ to respond before exiting (defaults to `60`).
+- `API_HEALTH_TIMEOUT` – how many seconds `docker_build.sh` and
+  `start_containers.sh` wait for the API container to become healthy
+  (defaults to `300`).
 - `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
  - `SECRET_KEY` – **required** secret used to sign JWT tokens. The application

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -180,7 +180,7 @@ echo "Starting containers..."
 docker compose -f "$ROOT_DIR/docker-compose.yml" up -d api worker broker db
 
 # Wait for the API container to become healthy
-max_wait=${API_HEALTH_TIMEOUT:-120}
+max_wait=${API_HEALTH_TIMEOUT:-300}
 start_time=$(date +%s)
 printf "Waiting for api service to become healthy..."
 while true; do

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -150,7 +150,7 @@ echo "Starting containers with docker compose..."
 docker compose -f "$COMPOSE_FILE" up -d api worker broker db
 
 # Wait for the API service to become healthy
-max_wait=${API_HEALTH_TIMEOUT:-120}
+max_wait=${API_HEALTH_TIMEOUT:-300}
 start_time=$(date +%s)
 printf "Waiting for api service to become healthy..."
 while true; do


### PR DESCRIPTION
## Summary
- wait longer for API container to become healthy
- document `API_HEALTH_TIMEOUT` in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `black .`
- `scripts/run_backend_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815e16f2988325adac624080b3dd29