### PR TITLE
Add test selection options to run_tests.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,9 @@ endpoints, then executes the frontend unit tests and Cypress end‑to‑end test
 Output is saved to
 `logs/full_test.log`.
 
+Pass `--backend`, `--frontend`, or `--cypress` to execute only that portion
+of the suite.
+
 Both `scripts/run_tests.sh` and `scripts/run_backend_tests.sh` check that the `api`
 container is running before executing. If it isn't, they exit with the message
 ```
@@ -533,7 +536,7 @@ To invoke just the backend tests manually use the same commands inside the
 running container:
 
 ```bash
-docker compose exec api coverage run -m pytest
+docker compose exec api coverage run -m pytest -n auto
 docker compose exec api coverage report
 ```
 ## Contributing

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -39,8 +39,9 @@ The application is considered working once these basics are functional:
 - `prestage_dependencies.sh` – download Docker images and Python/Node packages into `cache/` for offline use. The build scripts automatically run this step, so invoke it manually only when you want a separate download pass.
 - `run_backend_tests.sh` – runs backend tests and verifies the `/health` and `/version` endpoints, logging output to `logs/test.log`.
 - `diagnose_containers.sh` – checks that Docker is running, verifies cache directories, and prints container and build logs for troubleshooting.
-- `run_tests.sh` – preferred wrapper that additionally executes frontend unit
-  tests and Cypress end-to-end tests, saving results to `logs/full_test.log`.
+ - `run_tests.sh` – preferred wrapper that runs backend, frontend and Cypress
+  tests by default. Pass `--backend`, `--frontend` or `--cypress` to run a
+  subset. Results are saved to `logs/full_test.log`.
 
 Both `models/` and `frontend/dist/` are listed in `.gitignore`. They must exist
 before running `docker build`:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ black
 pytest-asyncio
 coverage
 pytest-postgresql
+pytest-xdist
 
 psycopg[binary]>=3.1

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -37,7 +37,7 @@ check_endpoint() {
 
 {
     log_step "BACKEND TESTS"
-    docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest
+    docker compose -f "$COMPOSE_FILE" exec -T api coverage run -m pytest -n auto
     docker compose -f "$COMPOSE_FILE" exec -T api coverage report
     log_step "API ENDPOINTS"
     check_endpoint /health

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,6 +7,40 @@ COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/full_test.log"
 
+RUN_BACKEND=false
+RUN_FRONTEND=false
+RUN_CYPRESS=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --backend)
+            RUN_BACKEND=true
+            ;;
+        --frontend)
+            RUN_FRONTEND=true
+            ;;
+        --cypress)
+            RUN_CYPRESS=true
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--backend] [--frontend] [--cypress]" >&2
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# default to all when no options supplied
+if ! $RUN_BACKEND && ! $RUN_FRONTEND && ! $RUN_CYPRESS; then
+    RUN_BACKEND=true
+    RUN_FRONTEND=true
+    RUN_CYPRESS=true
+fi
+
 mkdir -p "$LOG_DIR"
 
 # Echo a marker for major milestones
@@ -24,12 +58,18 @@ if ! docker compose -f "$COMPOSE_FILE" ps api | grep -q "running"; then
 fi
 
 {
-    log_step "BACKEND TESTS"
-    "$SCRIPT_DIR/run_backend_tests.sh"
-    log_step "FRONTEND UNIT"
-    npm test --prefix "$ROOT_DIR/frontend"
-    log_step "E2E TESTS"
-    npm run e2e --prefix "$ROOT_DIR/frontend"
+    if $RUN_BACKEND; then
+        log_step "BACKEND TESTS"
+        "$SCRIPT_DIR/run_backend_tests.sh"
+    fi
+    if $RUN_FRONTEND; then
+        log_step "FRONTEND UNIT"
+        npm test --prefix "$ROOT_DIR/frontend"
+    fi
+    if $RUN_CYPRESS; then
+        log_step "E2E TESTS"
+        npm run e2e --prefix "$ROOT_DIR/frontend"
+    fi
 } | tee "$LOG_FILE"
 
 echo "Full test log saved to $LOG_FILE"


### PR DESCRIPTION
## Summary
- allow selecting backend, frontend, or Cypress tests
- enable pytest parallelization in backend tests
- document new options
- mention parallel pytest when running manually
- add pytest-xdist dev dependency

## Testing
- `pip install -r requirements-dev.txt`
- `npm install` *(fails: download.cypress.io blocked)*
- `./scripts/run_tests.sh --backend --frontend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a9bf933c83259cf483de4e183bf9