### PR TITLE
Filter secret from env output

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -156,7 +156,7 @@ check_ffmpeg
 ensure_env_file
 
 echo "Environment variables:" >&2
-env | sort >&2
+env | sort | grep -v '^SECRET_KEY=' >&2
 
 secret_file_runtime="$ROOT_DIR/secret_key.txt"
 printf '%s' "$SECRET_KEY" > "$secret_file_runtime"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -155,7 +155,7 @@ fi
 
 log_step "STARTUP"
 echo "Environment variables:" >&2
-env | sort >&2
+env | sort | grep -v '^SECRET_KEY=' >&2
 
 echo "Starting containers with docker compose..."
 docker compose -f "$COMPOSE_FILE" up -d api worker broker db

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -98,7 +98,7 @@ check_whisper_models
 check_ffmpeg
 
 echo "Environment variables:" >&2
-env | sort >&2
+env | sort | grep -v '^SECRET_KEY=' >&2
 
 log_step "BUILD"
 # Determine which services require a rebuild


### PR DESCRIPTION
## Summary
- filter SECRET_KEY from environment printouts in shell scripts

## Testing
- `black . --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6883bc7542e08325b1a179fd34f0cbd3