### PR TITLE
Add root checks to startup scripts

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure the script runs with root privileges for apt operations
+if [[ $EUID -ne 0 ]]; then
+    echo "Run with sudo to download apt packages" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CACHE_DIR="${CACHE_DIR:-$ROOT_DIR/cache}"

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure the script runs with root privileges for apt operations
+if [[ $EUID -ne 0 ]]; then
+    echo "Run with sudo to download apt packages" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CACHE_DIR="${CACHE_DIR:-$ROOT_DIR/cache}"

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure the script runs with root privileges for apt operations
+if [[ $EUID -ne 0 ]]; then
+    echo "Run with sudo to download apt packages" >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CACHE_DIR="${CACHE_DIR:-$ROOT_DIR/cache}"


### PR DESCRIPTION
## Summary
- ensure `docker_build.sh` is run as root
- ensure `update_images.sh` is run as root
- ensure `start_containers.sh` is run as root

## Testing
- `black .`
- `scripts/run_backend_tests.sh` *(fails: docker not found)*
- `pytest` *(fails: fastapi missing because deps install interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6883c2ac049c83259450273e647c16da