### PR TITLE
Consolidate docker helper functions

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -41,21 +41,6 @@ OFFLINE=false
 
 
 
-# Return 0 if docker compose build supports --secret
-supports_secret() {
-    docker compose build --help 2>/dev/null | grep -q -- "--secret"
-}
-
-# Return 0 only if the API and worker images exist after the build
-verify_built_images() {
-    local images=(whisper-transcriber-api:latest whisper-transcriber-worker:latest)
-    for img in "${images[@]}"; do
-        if ! docker image inspect "$img" >/dev/null 2>&1; then
-            echo "Missing Docker image $img" >&2
-            return 1
-        fi
-    done
-}
 
 
 usage() {

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -294,3 +294,22 @@ verify_offline_assets() {
     fi
 }
 
+# Return 0 if docker compose build supports --secret
+supports_secret() {
+    docker compose build --help 2>/dev/null | grep -q -- "--secret"
+}
+
+# Verify the given Docker images exist
+verify_built_images() {
+    local images=("$@")
+    if [ ${#images[@]} -eq 0 ]; then
+        images=(whisper-transcriber-api:latest whisper-transcriber-worker:latest)
+    fi
+    for img in "${images[@]}"; do
+        if ! docker image inspect "$img" >/dev/null 2>&1; then
+            echo "Missing Docker image $img" >&2
+            return 1
+        fi
+    done
+}
+

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -103,21 +103,6 @@ ensure_env_file
 log_step "BUILD"
 printf '%s' "$SECRET_KEY" > "$secret_file"
 
-# Return 0 if docker compose build supports --secret
-supports_secret() {
-    docker compose build --help 2>/dev/null | grep -q -- "--secret"
-}
-
-# Verify the given Docker images exist
-verify_built_images() {
-    local images=("$@")
-    for img in "${images[@]}"; do
-        if ! docker image inspect "$img" >/dev/null 2>&1; then
-            echo "Missing Docker image $img" >&2
-            return 1
-        fi
-    done
-}
 
 services=(api worker)
 build_targets=()

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -79,21 +79,6 @@ fi
 # Verify required offline assets after downloads complete
 verify_offline_assets
 
-# Return 0 if docker compose build supports --secret
-supports_secret() {
-    docker compose build --help 2>/dev/null | grep -q -- "--secret"
-}
-
-# Verify the given Docker images exist
-verify_built_images() {
-    local images=("$@")
-    for img in "${images[@]}"; do
-        if ! docker image inspect "$img" >/dev/null 2>&1; then
-            echo "Missing Docker image $img" >&2
-            return 1
-        fi
-    done
-}
 
 # Load SECRET_KEY from .env
 ensure_env_file


### PR DESCRIPTION
## Summary
- move `supports_secret` and `verify_built_images` into `shared_checks.sh`
- remove duplicate implementations across scripts
- reference the shared helpers from build/start scripts

## Testing
- `black . --check`
- `shellcheck scripts/shared_checks.sh scripts/docker_build.sh scripts/update_images.sh scripts/start_containers.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883c408dcc48325b6f43dccd833638a