### PR TITLE
Ignore cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 *.log
 *.tmp
 .cache/
+cache/
 pip-log.txt
 pip-delete-this-directory.txt
 


### PR DESCRIPTION
## Summary
- prevent accidentally committing cached packages and images by adding `cache/` to `.gitignore`

## Testing
- `black . --check`


------
https://chatgpt.com/codex/tasks/task_e_6883c7c853cc8325acff0b027152533a