### PR TITLE
Add help doc with quick start

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -1,0 +1,50 @@
+# Quick Start Guide
+
+Follow these steps to install and run Whisper Transcriber.
+
+## Prerequisites
+- Python 3 and `pip`
+- Node.js 18 or newer
+- `ffmpeg` with `ffprobe`
+- Docker and Docker Compose *(optional)*
+
+## Install dependencies
+- Python packages:
+  ```bash
+  pip install -r requirements.txt
+  ```
+- Frontend packages from the `frontend` directory:
+  ```bash
+  cd frontend
+  npm install
+  cd ..
+  ```
+
+## Configure the application
+- Copy `.env.example` to `.env` and replace the placeholder value.
+- Generate a secret with:
+  ```bash
+  python -c "import secrets; print(secrets.token_hex(32))"
+  ```
+  Use this value for `SECRET_KEY` in `.env`.
+
+## Build and run
+- Build the frontend:
+  ```bash
+  npm run build
+  ```
+- Start locally with:
+  ```bash
+  uvicorn api.main:app
+  ```
+- Or launch the Docker Compose stack:
+  ```bash
+  sudo scripts/start_containers.sh
+  # or
+  docker compose up --build
+  ```
+
+## Testing and maintenance
+- Use `scripts/run_tests.sh` to run backend, frontend and Cypress tests.
+- `scripts/start_containers.sh` verifies prerequisites and starts the containers.
+


### PR DESCRIPTION
## Summary
- document install and run steps in `docs/help.md`

## Testing
- `black . --quiet`
- `./scripts/run_tests.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ca94b5108325847f1029e093e052