### PR TITLE
Remove Node dependency from docs

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -4,7 +4,6 @@ Follow these steps to install and run Whisper Transcriber.
 
 ## Prerequisites
 - Python 3 and `pip`
-- Node.js 18 or newer
 - `ffmpeg` with `ffprobe`
 - Docker and Docker Compose *(optional)*
 
@@ -13,13 +12,6 @@ Follow these steps to install and run Whisper Transcriber.
   ```bash
   pip install -r requirements.txt
   ```
-- Frontend packages from the `frontend` directory:
-  ```bash
-  cd frontend
-  npm install
-  cd ..
-  ```
-
 ## Configure the application
 - Copy `.env.example` to `.env` and replace the placeholder value.
 - Generate a secret with:
@@ -29,10 +21,7 @@ Follow these steps to install and run Whisper Transcriber.
   Use this value for `SECRET_KEY` in `.env`.
 
 ## Build and run
-- Build the frontend:
-  ```bash
-  npm run build
-  ```
+The React frontend is precompiled, so no additional build step is required.
 - Start locally with:
   ```bash
   uvicorn api.main:app


### PR DESCRIPTION
## Summary
- docs: drop mention of Node.js setup
- docs: indicate React frontend is prebuilt

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6883ccbd50ec8325b6443918525addf2