### PR TITLE
Remove unused error codes

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -21,10 +21,7 @@ class ErrorCode(IntEnum):
     FILE_TOO_LARGE = 40002  # > 2 GB limit
     JOB_NOT_FOUND = 40401  # /jobs/{id} missing
     TRANSCRIPT_NOT_FOUND = 40402  # Transcript missing on disk
-    AUDIO_NOT_FOUND = 40403  # Original audio missing
     FILE_SAVE_FAILED = 40003  # File couldn't be written to disk
-    DUPLICATE_JOB = 40901  # Same audio already queued
-    JOB_BUSY = 40301  # Job is running; action blocked
 
     # 5xx – server
     WHISPER_RUNTIME = 50001  # Whisper process crashed
@@ -37,10 +34,7 @@ ERROR_MAP: dict[ErrorCode, str] = {
     ErrorCode.FILE_TOO_LARGE: "File exceeds 2 GB limit.",
     ErrorCode.JOB_NOT_FOUND: "Job no longer exists.",
     ErrorCode.TRANSCRIPT_NOT_FOUND: "Transcript not found.",
-    ErrorCode.AUDIO_NOT_FOUND: "Original audio not found.",
     ErrorCode.FILE_SAVE_FAILED: "Failed to save uploaded file.",
-    ErrorCode.DUPLICATE_JOB: "Audio already queued or completed.",
-    ErrorCode.JOB_BUSY: "Job is currently running—try later.",
     ErrorCode.WHISPER_RUNTIME: "Transcription failed—internal Whisper error.",
     ErrorCode.FILE_NOT_FOUND: "Expected output file missing—contact support.",
     ErrorCode.CLOUD_STORAGE_ERROR: "Cloud storage operation failed.",
@@ -51,10 +45,7 @@ _HTTP_STATUS = {
     ErrorCode.FILE_TOO_LARGE: 413,
     ErrorCode.JOB_NOT_FOUND: 404,
     ErrorCode.TRANSCRIPT_NOT_FOUND: 404,
-    ErrorCode.AUDIO_NOT_FOUND: 404,
     ErrorCode.FILE_SAVE_FAILED: 500,
-    ErrorCode.DUPLICATE_JOB: 409,
-    ErrorCode.JOB_BUSY: 403,
     ErrorCode.WHISPER_RUNTIME: 500,
     ErrorCode.FILE_NOT_FOUND: 500,
     ErrorCode.CLOUD_STORAGE_ERROR: 500,

--- a/api/models.py
+++ b/api/models.py
@@ -36,7 +36,6 @@ class JobStatusEnum(str, PyEnum):
     ENRICHING = "enriching"
     COMPLETED = "completed"
     FAILED = "failed"
-    STALLED = "stalled"
     FAILED_TIMEOUT = "failed_timeout"
     FAILED_LAUNCH_ERROR = "failed_launch_error"
     FAILED_WHISPER_ERROR = "failed_whisper_error"


### PR DESCRIPTION
## Summary
- clean up unused constants from `api/errors`
- drop `STALLED` state from `JobStatusEnum`

## Testing
- `black .`
- `pytest -q tests` *(fails: pytest_postgresql.exceptions.PostgresExecutorMissing)*

------
https://chatgpt.com/codex/tasks/task_e_6883cfdf635883258abacdd1aeff36d0