### PR TITLE
Implement broker queue shutdown

### DIFF
--- a/api/services/job_queue.py
+++ b/api/services/job_queue.py
@@ -109,5 +109,8 @@ class BrokerJobQueue(JobQueue):
         payload = pickle.dumps(func)
         self._celery_app.send_task(self._task_name, args=(payload,))
 
-    def shutdown(self) -> None:  # pragma: no cover - stub
-        pass
+    def shutdown(self) -> None:
+        """Close Celery connections if possible."""
+        close = getattr(self._celery_app, "close", None)
+        if callable(close):
+            close()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -45,6 +45,13 @@ def test_broker_job_queue_sends_task():
         assert func is sample_task
 
 
+def test_broker_job_queue_shutdown():
+    with patch("api.services.celery_app.celery_app.close") as close:
+        q = BrokerJobQueue()
+        q.shutdown()
+        close.assert_called_once()
+
+
 def test_broker_backend_dispatch(monkeypatch):
     monkeypatch.setenv("JOB_QUEUE_BACKEND", "broker")
     import importlib


### PR DESCRIPTION
## Summary
- add a Celery cleanup routine for `BrokerJobQueue`
- test that Celery close is invoked

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` *(failed to download Cypress due to blocked domain, but install completed)*
- `npm run build`
- `pytest -q tests` *(fails: ExecutableMissingException for PostgreSQL, missing ffmpeg, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5b28b348325966fa24af14fc9b8