### PR TITLE
Drop unused request parameter

### DIFF
--- a/api/routes/jobs.py
+++ b/api/routes/jobs.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, UploadFile, File, Form, Request, status, HTTPException
+from fastapi import APIRouter, UploadFile, File, Form, status, HTTPException
 from fastapi.responses import FileResponse, HTMLResponse, Response
 from datetime import datetime
 from pathlib import Path
@@ -201,7 +201,7 @@ def analyze_job(job_id: str) -> AnalysisOut:
 
 
 @router.get("/transcript/{job_id}/view", response_class=HTMLResponse)
-def transcript_view(job_id: str, request: Request):
+def transcript_view(job_id: str):
     job = service_get_job(job_id)
     if not job:
         return HTMLResponse(


### PR DESCRIPTION
## Summary
- remove unused `Request` import and parameter from `transcript_view`

## Testing
- `black api/routes/jobs.py`
- `pytest -q tests` *(fails: ExecutableMissingException: Could not find postgresql server)*

------
https://chatgpt.com/codex/tasks/task_e_6883da1ad9b88325a23ef3741c8d2829