### PR TITLE
Purge old node packages before install

### DIFF
--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -97,6 +97,7 @@ install_node18() {
         return 0
     fi
     echo "Installing Node.js 18..." >&2
+    apt-get purge -y nodejs npm libnode-dev nodejs-doc || true
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
         apt-get install -y nodejs
     if ! check_node_version; then


### PR DESCRIPTION
## Summary
- purge legacy Node packages in `install_node18`

## Testing
- `black . --check`
- `pytest tests/test_health.py` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68842af169d08325aff90168f640c7f1