### PR TITLE
Remove unused import from logs route

### DIFF
--- a/api/routes/logs.py
+++ b/api/routes/logs.py
@@ -5,7 +5,7 @@ import asyncio
 from fastapi.responses import PlainTextResponse
 
 from api.errors import ErrorCode, http_error
-from api.paths import storage, LOG_DIR
+from api.paths import LOG_DIR
 from pathlib import Path
 from api.app_state import ACCESS_LOG, backend_log
 from api.schemas import StatusOut


### PR DESCRIPTION
## Summary
- tidy logs route imports
- run formatting
- execute the unit test suite

## Testing
- `pytest -q` *(fails: pg_ctl cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68843e794b0c8325b228f2e6410b27e6