### PR TITLE
Enforce positive concurrency

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -238,10 +238,13 @@ def get_concurrency() -> ConcurrencyConfigOut:
 def update_concurrency(
     payload: ConcurrencyConfigIn, user=Depends(require_admin)
 ) -> ConcurrencyConfigOut:
-    value = config_service.update_concurrency(payload.max_concurrent_jobs)
-    settings.max_concurrent_jobs = value
-    if settings.job_queue_backend == "thread" and isinstance(
-        app_state.job_queue, ThreadJobQueue
-    ):
-        app_state.job_queue.resize(value)
+    try:
+        value = config_service.update_concurrency(payload.max_concurrent_jobs)
+        settings.max_concurrent_jobs = value
+        if settings.job_queue_backend == "thread" and isinstance(
+            app_state.job_queue, ThreadJobQueue
+        ):
+            app_state.job_queue.resize(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
     return ConcurrencyConfigOut(max_concurrent_jobs=value)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from api.models import JobStatusEnum
 
@@ -105,6 +105,12 @@ class ConcurrencyConfigOut(BaseModel):
 
 class ConcurrencyConfigIn(BaseModel):
     max_concurrent_jobs: int
+
+    @model_validator(mode="after")
+    def _check_max_jobs(cls, values: "ConcurrencyConfigIn") -> "ConcurrencyConfigIn":
+        if values.max_concurrent_jobs <= 0:
+            raise ValueError("max_concurrent_jobs must be greater than 0")
+        return values
 
 
 class UserOut(BaseModel):

--- a/tests/test_admin_concurrency.py
+++ b/tests/test_admin_concurrency.py
@@ -67,3 +67,15 @@ def test_concurrency_update_forbidden(admin_client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 403
+
+
+def test_admin_update_concurrency_invalid(admin_client):
+    create_user("admin", "pw", role="admin")
+    token = _token(admin_client, "admin", "pw")
+
+    resp = admin_client.post(
+        "/admin/concurrency",
+        json={"max_concurrent_jobs": 0},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- validate `ConcurrencyConfigIn.max_concurrent_jobs` must be greater than 0
- return HTTP 422 if concurrency setting fails validation
- test invalid concurrency values

## Testing
- `pytest -k admin_concurrency -vv` *(fails: ExecutableMissingException: Could not found /usr/lib/postgresql/16/bin/pg_ctl)*

------
https://chatgpt.com/codex/tasks/task_e_68844abc60648325835ce6a4713eb287