### PR TITLE
Fix Node.js installation script

### DIFF
--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -97,7 +97,10 @@ install_node18() {
         return 0
     fi
     echo "Installing Node.js 18..." >&2
-    apt-get purge -y nodejs npm libnode-dev nodejs-doc || true
+    # Remove any old Node.js packages that may conflict with NodeSource
+    # installations. libnode72 is provided by Ubuntu's Node 12 packages and
+    # clashes with newer releases.
+    apt-get purge -y nodejs npm libnode-dev nodejs-doc libnode72 || true
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
         apt-get install -y nodejs
     if ! check_node_version; then


### PR DESCRIPTION
## Summary
- purge libnode72 to avoid dpkg conflicts when installing Node 18

## Testing
- `black . --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68844d092e748325a1038e73aacb2f53