### PR TITLE
Update cache handling

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -19,7 +19,8 @@ LOG_FILE="$ROOT_DIR/logs/prestage_dependencies.log"
 mkdir -p "$(dirname "$LOG_FILE")"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
-CACHE_DIR="$ROOT_DIR/cache"
+CACHE_DIR="${CACHE_DIR:-$ROOT_DIR/cache}"
+export CACHE_DIR
 
 # Always start from a clean cache so staged packages match the
 # current requirements.


### PR DESCRIPTION
## Summary
- make CACHE_DIR configurable in prestage scripts

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` in `frontend`
- `scripts/run_tests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688454217270832594da40af4e0b124f