### PR TITLE
Simplify cache setup in helper scripts

### DIFF
--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -12,14 +12,9 @@ if ! docker info >/dev/null 2>&1; then
     exit 1
 fi
 
-# Location of cached dependencies. Prefer the Windows drive on WSL so that logs
-# and cached packages persist across distro upgrades.
+# Set CACHE_DIR if not already defined
 if [ -z "${CACHE_DIR:-}" ]; then
-    if grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        CACHE_DIR="/mnt/c/whisper_cache"
-    else
-        CACHE_DIR="/tmp/docker_cache"
-    fi
+    CACHE_DIR="/tmp/docker_cache"
 fi
 
 echo "Container status:"

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -10,14 +10,9 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Default the cache directory, preferring the Windows drive when running under
-# WSL so cached packages persist across sessions.
+# Default the cache directory when not explicitly set
 if [ -z "${CACHE_DIR:-}" ]; then
-    if grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        CACHE_DIR="/mnt/c/whisper_cache"
-    else
-        CACHE_DIR="/tmp/docker_cache"
-    fi
+    CACHE_DIR="/tmp/docker_cache"
 fi
 source "$SCRIPT_DIR/shared_checks.sh"
 

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -12,13 +12,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"
 
-# Use /mnt/c/whisper_cache on WSL for persistence unless CACHE_DIR is provided.
+# Default cache directory when not set
 if [ -z "${CACHE_DIR:-}" ]; then
-    if grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        CACHE_DIR="/mnt/c/whisper_cache"
-    else
-        CACHE_DIR="/tmp/docker_cache"
-    fi
+    CACHE_DIR="/tmp/docker_cache"
 fi
 
 # Verify that CACHE_DIR is writable before continuing.

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -3,13 +3,11 @@
 
 # Expect ROOT_DIR to be defined by the caller
 
-# Determine the default cache directory. Under WSL the Windows filesystem is
-# used so the cache persists across distro resets.
+# Determine the default cache directory. /tmp/docker_cache is used when
+# CACHE_DIR is not set.
 default_cache_dir() {
     if [ -n "${CACHE_DIR:-}" ]; then
         echo "$CACHE_DIR"
-    elif grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        echo "/mnt/c/whisper_cache"
     else
         echo "/tmp/docker_cache"
     fi

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -10,14 +10,9 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Determine default cache directory, using the Windows filesystem when running
-# under WSL so cached packages are preserved between sessions.
+# Determine default cache directory if not provided
 if [ -z "${CACHE_DIR:-}" ]; then
-    if grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        CACHE_DIR="/mnt/c/whisper_cache"
-    else
-        CACHE_DIR="/tmp/docker_cache"
-    fi
+    CACHE_DIR="/tmp/docker_cache"
 fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -10,15 +10,9 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Choose a persistent cache location when running under WSL. This keeps
-# cached packages on the Windows drive so they survive Linux
-# distribution resets.
+# Set CACHE_DIR to a sensible default when unset
 if [ -z "${CACHE_DIR:-}" ]; then
-    if grep -qi microsoft /proc/version && [ -d /mnt/c ]; then
-        CACHE_DIR="/mnt/c/whisper_cache"
-    else
-        CACHE_DIR="/tmp/docker_cache"
-    fi
+    CACHE_DIR="/tmp/docker_cache"
 fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"


### PR DESCRIPTION
## Summary
- drop WSL handling in `default_cache_dir` and related scripts
- always default to `/tmp/docker_cache` when `CACHE_DIR` is unset
- run `black` formatting

## Testing
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_68850523bc8883258e09a10cd86e5b21