### PR TITLE
Update help docs with WSL Docker steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ For prerequisites and installation steps, follow the instructions in
 [docs/help.md](docs/help.md). The guide covers Python and system
 dependencies as well as optional Docker usage. The build scripts will
 install or upgrade Node.js 18 automatically if it is missing.
+### Docker on WSL
+To install Docker inside WSL, run:
+1. `sudo apt remove docker docker.io containerd runc`
+2. `sudo apt update && sudo apt install docker.io`
+3. Enable and start the service:
+   ```bash
+   sudo systemctl enable docker
+   sudo service docker start
+   ```
+4. Add your user to the `docker` group with `sudo usermod -aG docker $USER` and log out.
+Remove Docker Desktop when relying on WSL-native Docker.
+
 
 ## Optional Environment Variables
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -7,6 +7,19 @@ Follow these steps to install and run Whisper Transcriber.
 - `ffmpeg` with `ffprobe`
 - Docker and Docker Compose *(optional)*
 
+## Docker on WSL
+Follow these steps to install Docker inside the WSL distribution:
+1. `sudo apt remove docker docker.io containerd runc`
+2. `sudo apt update && sudo apt install docker.io`
+3. Enable and start the daemon:
+   ```bash
+   sudo systemctl enable docker
+   sudo service docker start
+   ```
+4. Add your user to the `docker` group with `sudo usermod -aG docker $USER` and log out.
+Remove Docker Desktop to avoid conflicts when running WSL-native Docker.
+
+
 ## Install dependencies
 - Python packages:
   ```bash


### PR DESCRIPTION
## Summary
- document WSL Docker installation steps in `docs/help.md`
- add short WSL section in `README.md`

## Testing
- `black .`
- `scripts/run_tests.sh` *(fails: `API container is not running`)*

------
https://chatgpt.com/codex/tasks/task_e_6885079ddc0c832591e4d286c072c603