### PR TITLE
Update prestage dependency script to include wheel

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -79,7 +79,7 @@ done
 log_step "PYTHON"
 echo "Downloading Python packages..."
 pip download -d "$CACHE_DIR/pip" \
-    pip \
+    pip wheel \
     -r "$ROOT_DIR/requirements.txt" \
     -r "$ROOT_DIR/requirements-dev.txt"
 


### PR DESCRIPTION
## Summary
- modify the pip download step in `prestage_dependencies.sh` to also grab `wheel`

## Testing
- `black .`
- `ls -l /tmp/test_cache`

------
https://chatgpt.com/codex/tasks/task_e_6885765dc3048325a68890abcf128cc0