### PR TITLE
Fix offline asset requirement parsing

### DIFF
--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -284,7 +284,8 @@ verify_offline_assets() {
         for req_file in "$ROOT_DIR/requirements.txt" "$ROOT_DIR/requirements-dev.txt"; do
             [ -f "$req_file" ] || continue
             while read -r req; do
-                req=${req%%[*#]*}
+                req=${req%%#*}
+                req=${req%%[*}
                 req=$(echo "$req" | xargs)
                 [ -z "$req" ] && continue
                 pkg=${req%%[<=>]*}


### PR DESCRIPTION
## Summary
- tweak requirement parsing in `verify_offline_assets`
- strip comments and extras before checking cached wheels

## Testing
- `black .`


------
https://chatgpt.com/codex/tasks/task_e_6886496910088325ae6256059269203b