### PR TITLE
Update apt package prestaging

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -92,7 +92,7 @@ log_step "APT"
 echo "Downloading apt packages..."
 apt-get update
 curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-apt-get install -y --download-only --no-install-recommends \
+apt-get install -y --download-only --reinstall --no-install-recommends \
     ffmpeg git curl gosu nodejs docker-compose-plugin
 if ls /var/cache/apt/archives/*.deb >/dev/null 2>&1; then
     ls /var/cache/apt/archives/*.deb \


### PR DESCRIPTION
## Summary
- ensure apt packages are re-fetched on every run in `prestage_dependencies.sh`

## Testing
- `pip install -r requirements.txt`
- `npm install --prefix frontend`
- `pip install -r requirements-dev.txt`
- `./scripts/run_tests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68864a21122883258dbb803d48910182