### PR TITLE
Fix offline asset wheel check

### DIFF
--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -289,7 +289,8 @@ verify_offline_assets() {
                 req=$(echo "$req" | xargs)
                 [ -z "$req" ] && continue
                 pkg=${req%%[<=>]*}
-                if ! ls "$pip_cache"/"$pkg"-* >/dev/null 2>&1; then
+                local wheel_pkg="${pkg//-/_}"
+                if ! ls "$pip_cache"/"$wheel_pkg"-* >/dev/null 2>&1; then
                     echo "Missing wheel for $pkg in $pip_cache" >&2
                     missing=1
                 fi


### PR DESCRIPTION
## Summary
- ensure verify_offline_assets handles wheel filenames that use underscores

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688651af688c8325b34620d7798e4579