### PR TITLE
Fix duplicate pip wheel call in prestage script

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -79,7 +79,6 @@ done
 log_step "PYTHON"
 echo "Downloading and building Python wheels..."
 pip wheel --wheel-dir "$CACHE_DIR/pip" \
-    pip wheel \
     -r "$ROOT_DIR/requirements.txt" \
     -r "$ROOT_DIR/requirements-dev.txt"
 


### PR DESCRIPTION
## Summary
- clean up pip wheel command in `prestage_dependencies.sh`

## Testing
- `black scripts/prestage_dependencies.sh` *(fails: Cannot parse for target version Python 3.13)*

------
https://chatgpt.com/codex/tasks/task_e_6886574933f8832591cca5eedd230f27