### PR TITLE
Add wheel existence check in prestage script

### DIFF
--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -82,6 +82,12 @@ pip wheel --wheel-dir "$CACHE_DIR/pip" \
     -r "$ROOT_DIR/requirements.txt" \
     -r "$ROOT_DIR/requirements-dev.txt"
 
+# Verify the Whisper wheel was created
+if ! ls "$CACHE_DIR/pip"/openai_whisper-*.whl >/dev/null 2>&1; then
+    echo "openai_whisper wheel build failed; expected $CACHE_DIR/pip/openai_whisper-*.whl" >&2
+    exit 1
+fi
+
 log_step "NPM"
 echo "Caching Node modules..."
 npm install --prefix "$ROOT_DIR/frontend"


### PR DESCRIPTION
## Summary
- ensure `openai_whisper` wheel exists after building wheels in `prestage_dependencies.sh`

## Testing
- `black .`
- `pytest -k 'nonexistentpattern'` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(cancelled due to long downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68865a219cdc8325b4504014f4911d7f