### PR TITLE
Sync apt cache into Docker build context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 *.tmp
 .cache/
 cache/
+!cache/apt/*
 pip-log.txt
 pip-delete-this-directory.txt
 

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -127,6 +127,13 @@ check_docker_running
 check_cache_dirs
 stage_build_dependencies
 
+# === Sync APT packages into Docker build context ===
+# Dockerfile expects cache/apt to exist in the build context.
+# Copy from /tmp/docker_cache/apt (used by prestage_dependencies.sh) into ./cache/apt
+BUILD_CACHE_DIR="$ROOT_DIR/cache/apt"
+mkdir -p "$BUILD_CACHE_DIR"
+rsync -av --delete "$CACHE_DIR/apt/" "$BUILD_CACHE_DIR/"
+
 # Build frontend assets if missing or forced before verifying cached resources
 if [ "$FORCE_FRONTEND" = true ] || [ ! -d "$ROOT_DIR/frontend/dist" ]; then
     echo "Building frontend assets..."


### PR DESCRIPTION
## Summary
- sync apt packages after staging build dependencies
- allow apt cache to be committed if desired

## Testing
- `black . --check`
- `sudo bash scripts/docker_build.sh --full --force` *(fails: Unable to locate package libnode72)*

------
https://chatgpt.com/codex/tasks/task_e_68866d1e9e2c83258db1f64559db826c