### PR TITLE
Fix Docker apt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ ARG INSTALL_DEV=false
 ARG SECRET_KEY
 
 COPY cache/apt /tmp/apt
-RUN dpkg -i /tmp/apt/*.deb && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ./tmp/apt/*.deb && \
     rm -rf /tmp/apt && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user to run Celery workers
 RUN groupadd -g 1000 appuser && \


### PR DESCRIPTION
## Summary
- install apt packages with `apt-get install` so dependencies are resolved

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` *(fails to reach download.cypress.io)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api' / pytest_postgresql errors)*

------
https://chatgpt.com/codex/tasks/task_e_688673c085ac8325b724a4c5f47b0df4