### PR TITLE
Add environment check script

### DIFF
--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APT_CACHE="$ROOT_DIR/cache/apt"
+
+# Verify DNS resolution for package mirrors
+if ! getent hosts archive.ubuntu.com >/dev/null 2>&1; then
+    echo "DNS resolution failed for archive.ubuntu.com" >&2
+    exit 1
+fi
+
+# Determine base image from Dockerfile
+BASE_IMAGE=$(grep -m1 '^FROM ' "$ROOT_DIR/Dockerfile" | awk '{print $2}')
+
+# Extract VERSION_CODENAME from the base image
+if command -v docker >/dev/null 2>&1; then
+    BASE_CODENAME=$(docker run --rm "$BASE_IMAGE" bash -c 'source /etc/os-release && echo $VERSION_CODENAME')
+else
+    BASE_CODENAME="${BASE_IMAGE##*-}"
+fi
+
+if [ -z "$BASE_CODENAME" ]; then
+    echo "Failed to determine VERSION_CODENAME from base image" >&2
+    exit 1
+fi
+
+# Ensure cached APT packages correspond to the codename
+if [ ! -d "$APT_CACHE" ]; then
+    echo "APT cache directory $APT_CACHE missing" >&2
+    exit 1
+fi
+
+if [ ! -f "$APT_CACHE/deb_list.txt" ]; then
+    echo "Package list $APT_CACHE/deb_list.txt missing" >&2
+    exit 1
+fi
+
+mismatch=0
+while read -r deb; do
+    [ -z "$deb" ] && continue
+    if [[ "$deb" != *"$BASE_CODENAME"* ]]; then
+        echo "Package $deb does not match codename $BASE_CODENAME" >&2
+        mismatch=1
+    fi
+    if [ ! -f "$APT_CACHE/$deb" ]; then
+        echo "Missing file $APT_CACHE/$deb" >&2
+        mismatch=1
+    fi
+done < "$APT_CACHE/deb_list.txt"
+
+if [ $mismatch -ne 0 ]; then
+    echo "Cached packages do not align with $BASE_CODENAME" >&2
+    exit 1
+fi
+
+printf 'Environment OK for codename %s\n' "$BASE_CODENAME"


### PR DESCRIPTION
## Summary
- verify DNS for apt mirror
- pull OS codename from Docker base image
- validate cached APT packages against codename

## Testing
- `black . --check`


------
https://chatgpt.com/codex/tasks/task_e_6886812b5b9083258f3858e528a487c3