### PR TITLE
Add environment check to docker build

### DIFF
--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -15,6 +15,7 @@ if [ -z "${CACHE_DIR:-}" ]; then
     CACHE_DIR="/tmp/docker_cache"
 fi
 source "$SCRIPT_DIR/shared_checks.sh"
+"$SCRIPT_DIR/check_env.sh"
 
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/docker_build.log"


### PR DESCRIPTION
## Summary
- run `scripts/check_env.sh` when building Docker images

## Testing
- `pip install -r requirements-dev.txt`
- `black .`
- `scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868352b5508325b4a681f1069959e6