### PR TITLE
Add environment check to container startup

### DIFF
--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -74,7 +74,9 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Begin STAGING step by verifying the environment
 log_step "STAGING"
+"$SCRIPT_DIR/check_env.sh"
 # Ensure Node.js is available before downloading npm packages
 install_node18
 # Stage dependencies for an offline build, clearing the cache before downloads


### PR DESCRIPTION
## Summary
- verify apt cache matches docker base OS during container start

## Testing
- `black . --check`


------
https://chatgpt.com/codex/tasks/task_e_688684ae25908325937b3841e56b2917