### PR TITLE
Cache python base image digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Another script `scripts/docker_build.sh` performs a full rebuild or an increment
 Pass `--force-frontend` to rebuild the frontend even if `frontend/dist` exists.
 The build scripts store cached packages and Docker images in `/tmp/docker_cache`. You may set the `CACHE_DIR` environment variable to a different path—for example `/mnt/c/whisper_cache`—if you want the cache to persist across WSL resets.
 For auditing purposes the prestage script also writes the wheel filenames to `cache/pip/pip_versions.txt`, lists installed Node packages in `cache/npm/npm_versions.txt` and archives the npm cache as `cache/npm/npm-cache.tar`. Pass `--checksum` to additionally record SHA‑256 sums for everything under `cache/` in `cache/checksums.txt`.
-Run `scripts/check_env.sh` before offline builds to verify DNS resolution and confirm cached `.deb` archives match the `python:3.11-jammy` base image. If WSL2 DNS causes timeouts, set `DNS_SERVER=<ip>` or build with `--network=host` so Docker can reach the registry.
+Run `scripts/check_env.sh` before offline builds to verify DNS resolution, confirm cached `.deb` archives match the `python:3.11-jammy` base image and warn when the cached image digest differs from the current pull. If WSL2 DNS causes timeouts, set `DNS_SERVER=<ip>` or build with `--network=host` so Docker can reach the registry.
 The build helper scripts mirror their output to log files for easier troubleshooting: `logs/start_containers.log`, `logs/docker_build.log`, and `logs/update_images.log`. The container entrypoint also writes to `logs/entrypoint.log` when each service starts. All build logs reside in the `logs/` directory, and each script exits on the first failure to prevent cascading errors.
 
 ## Updating the Application

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -43,8 +43,9 @@ The application is considered working once these basics are functional:
 - All build helpers automatically install or upgrade Node.js 18 using the NodeSource repository when needed.
 - `run_backend_tests.sh` – runs backend tests and verifies the `/health` and `/version` endpoints, logging output to `logs/test.log`.
 - `diagnose_containers.sh` – checks that Docker is running, verifies cache directories, and prints container and build logs for troubleshooting.
- - `check_env.sh` – validates DNS resolution and ensures cached `.deb` packages
-   correspond to the base image used in the Dockerfile. Cached packages must
+ - `check_env.sh` – validates DNS resolution, ensures cached `.deb` packages
+   correspond to the base image and warns when the saved digest for
+   `python:3.11-jammy` differs from a fresh pull. Cached packages must
    match the `python:3.11-jammy` image to avoid build errors.
  - `run_tests.sh` – preferred wrapper that runs backend, frontend and Cypress
   tests by default. Pass `--backend`, `--frontend` or `--cypress` to run a

--- a/docs/help.md
+++ b/docs/help.md
@@ -38,7 +38,7 @@ Remove Docker Desktop to avoid conflicts when running WSL-native Docker.
 
 ## Build and run
 The compiled frontend assets live in `frontend/dist/`, which is not committed. Run `npm run build` in the `frontend` directory or use the helper scripts to generate this folder.
-Run `scripts/check_env.sh` before offline builds to validate DNS and ensure cached `.deb` packages align with the `python:3.11-jammy` base image. If Docker fails to resolve registry hosts on WSL2, pass `DNS_SERVER=<ip>` to the build scripts or use `--network=host`.
+Run `scripts/check_env.sh` before offline builds to validate DNS, confirm cached `.deb` packages align with the `python:3.11-jammy` base image and warn when the cached image digest no longer matches. If Docker fails to resolve registry hosts on WSL2, pass `DNS_SERVER=<ip>` to the build scripts or use `--network=host`.
   ```bash
   uvicorn api.main:app
   ```

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -55,4 +55,19 @@ if [ $mismatch -ne 0 ]; then
     exit 1
 fi
 
+# Check that the cached python:3.11-jammy digest matches the current one
+if command -v docker >/dev/null 2>&1; then
+    docker pull --quiet python:3.11-jammy >/dev/null
+    current_digest=$(docker image inspect python:3.11-jammy --format '{{index .RepoDigests 0}}' | awk -F@ '{print $2}')
+    digest_file="$ROOT_DIR/cache/images/python_3.11_digest.txt"
+    if [ -f "$digest_file" ]; then
+        stored_digest=$(cat "$digest_file")
+        if [ "$stored_digest" != "$current_digest" ]; then
+            echo "WARNING: cached python:3.11-jammy digest $stored_digest differs from $current_digest" >&2
+        fi
+    else
+        echo "WARNING: digest file $digest_file missing" >&2
+    fi
+fi
+
 printf 'Environment OK for codename %s\n' "$BASE_CODENAME"

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -83,7 +83,8 @@ run_cmd rm -rf "$CACHE_DIR"
 
 IMAGES_DIR="$CACHE_DIR/images"
 mkdir -p "$IMAGES_DIR" "$CACHE_DIR/pip" "$CACHE_DIR/npm" "$CACHE_DIR/apt" \
-    "$ROOT_DIR/cache/pip" "$ROOT_DIR/cache/npm" "$ROOT_DIR/cache/apt"
+    "$ROOT_DIR/cache/pip" "$ROOT_DIR/cache/npm" "$ROOT_DIR/cache/apt" \
+    "$ROOT_DIR/cache/images"
 
 # Echo a marker for major milestones
 log_step() {
@@ -126,6 +127,10 @@ for img in "${IMAGES[@]}"; do
     run_cmd docker pull "$img"
     tar_name=$(echo "$img" | sed 's#[/:]#_#g').tar
     run_cmd docker save "$img" -o "$IMAGES_DIR/$tar_name"
+    if [ "$DRY_RUN" != "1" ] && [ "$img" = "python:3.11-jammy" ]; then
+        digest=$(docker image inspect "$img" --format '{{index .RepoDigests 0}}' | awk -F@ '{print $2}')
+        echo "$digest" > "$ROOT_DIR/cache/images/python_3.11_digest.txt"
+    fi
 done
 
 log_step "PYTHON"


### PR DESCRIPTION
## Summary
- cache python:3.11-jammy digest after pulling images
- warn when cached digest differs in check_env.sh
- document new digest checks

## Testing
- `black .`
- `pytest tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68869bf5913483258a29bfc69d153e2b