### PR TITLE
Document ALLOW_DIGEST_MISMATCH and fail on digest mismatch

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -38,7 +38,7 @@ Remove Docker Desktop to avoid conflicts when running WSL-native Docker.
 
 ## Build and run
 The compiled frontend assets live in `frontend/dist/`, which is not committed. Run `npm run build` in the `frontend` directory or use the helper scripts to generate this folder.
-Run `scripts/check_env.sh` before offline builds to validate DNS, confirm cached `.deb` packages align with the `python:3.11-jammy` base image and warn when the cached image digest no longer matches. If Docker fails to resolve registry hosts on WSL2, pass `DNS_SERVER=<ip>` to the build scripts or use `--network=host`.
+Run `scripts/check_env.sh` before offline builds to validate DNS, confirm cached `.deb` packages align with the `python:3.11-jammy` base image and **fail** when the cached image digest no longer matches. Set `ALLOW_DIGEST_MISMATCH=1` to ignore this failure. If Docker fails to resolve registry hosts on WSL2, pass `DNS_SERVER=<ip>` to the build scripts or use `--network=host`.
   ```bash
   uvicorn api.main:app
   ```

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -77,11 +77,11 @@ if command -v docker >/dev/null 2>&1; then
         exit 1
     fi
     if [ "$stored_digest" != "$current_digest" ]; then
+        echo "Base image digest mismatch: cached $stored_digest vs $current_digest" >&2
         if [ "${ALLOW_DIGEST_MISMATCH:-0}" != "1" ]; then
-            echo "Base image digest mismatch: cached $stored_digest vs $current_digest" >&2
             exit 1
         else
-            echo "WARNING: base image digest mismatch: cached $stored_digest vs $current_digest" >&2
+            echo "ALLOW_DIGEST_MISMATCH=1 set - continuing despite mismatch" >&2
         fi
     fi
 fi


### PR DESCRIPTION
## Summary
- fail in `check_env.sh` when the base image digest differs unless `ALLOW_DIGEST_MISMATCH=1`
- document this env var in the help docs

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -r requirements-dev.txt`
- `npm install` in `frontend`
- `pytest -n auto` *(fails: pytest_postgresql errors)*

------
https://chatgpt.com/codex/tasks/task_e_68878adf30a88325b593f2d6f5071d76