### PR TITLE
Add manifest timestamp and additional hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,28 @@ run `prestage_dependencies.sh` without `--offline` to refresh everything when
 the base image or requirements change. Generating checksums with `--checksum`
 and validating them via `scripts/check_env.sh` helps detect stale packages.
 
+#### Manifest Verification
+
+When checksums are generated a `cache/manifest.txt` file is created. Each line
+has the form `KEY=value` listing the base image digest, a UTC timestamp and the
+SHA-256 sums of the cache directories and version lists:
+
+```text
+BASE_CODENAME=<codename>
+BASE_DIGEST=<digest>
+TIMESTAMP=<time>
+pip=<hash>
+pip_versions=<hash>
+npm=<hash>
+npm_versions=<hash>
+apt=<hash>
+images=<hash>
+```
+
+Run the prestage script with `--checksum` on another machine and compare the
+resulting manifest. Matching hashes confirm the cached packages are identical,
+ensuring builds reproduce consistently.
+
 ## Updating the Application
 
 Before rebuilding containers, update the repository:

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -170,6 +170,7 @@ if [ "$DRY_RUN" != "1" ]; then
     fi
     ls "$CACHE_DIR/pip"/*.whl | xargs -n1 basename | sort > "$CACHE_DIR/pip/pip_versions.txt"
     cp "$CACHE_DIR/pip/pip_versions.txt" "$ROOT_DIR/cache/pip/pip_versions.txt"
+    cp "$CACHE_DIR/pip/pip_versions.txt" "$ROOT_DIR/cache/pip_versions.txt"
 
     # Freeze resolved dependencies against the built wheels
     tmpenv=$(mktemp -d)
@@ -189,6 +190,7 @@ run_cmd npm ci --prefix "$ROOT_DIR/frontend" --cache "$CACHE_DIR/npm"
 if [ "$DRY_RUN" != "1" ]; then
     npm ls --prefix "$ROOT_DIR/frontend" --depth=0 > "$CACHE_DIR/npm/npm_versions.txt"
     cp "$CACHE_DIR/npm/npm_versions.txt" "$ROOT_DIR/cache/npm/npm_versions.txt"
+    cp "$CACHE_DIR/npm/npm_versions.txt" "$ROOT_DIR/cache/npm_versions.txt"
     cp "$ROOT_DIR/frontend/package-lock.json" "$CACHE_DIR/npm/package-lock.json"
     cp "$ROOT_DIR/frontend/package-lock.json" "$ROOT_DIR/cache/npm/package-lock.json"
     tar -cf "$CACHE_DIR/npm/npm-cache.tar" -C "$CACHE_DIR/npm" .
@@ -244,6 +246,7 @@ if [ "$CHECKSUM" = "1" ]; then
     if [ -n "$BASE_DIGEST" ]; then
         echo "BASE_DIGEST=$BASE_DIGEST" >> "$manifest"
     fi
+    echo "TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$manifest"
     for sub in pip npm apt images; do
         file="$CACHE_DIR/$sub/sha256sums.txt"
         if [ -f "$file" ]; then
@@ -251,6 +254,15 @@ if [ "$CHECKSUM" = "1" ]; then
             echo "$sub=$hash" >> "$manifest"
         fi
     done
+
+    if [ -f "$CACHE_DIR/pip/pip_versions.txt" ]; then
+        hash=$(sha256sum "$CACHE_DIR/pip/pip_versions.txt" | awk '{print $1}')
+        echo "pip_versions=$hash" >> "$manifest"
+    fi
+    if [ -f "$CACHE_DIR/npm/npm_versions.txt" ]; then
+        hash=$(sha256sum "$CACHE_DIR/npm/npm_versions.txt" | awk '{print $1}')
+        echo "npm_versions=$hash" >> "$manifest"
+    fi
 
     cp "$manifest" "$ROOT_DIR/cache/manifest.txt"
 fi


### PR DESCRIPTION
## Summary
- include UTC timestamp in manifest generated by prestage_dependencies.sh
- copy pip and npm version lists to the cache root and record their hashes
- document how to read the manifest and verify reproducibility

## Testing
- `black .`
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68878da90c248325963925b86ce6e6c6