### PR TITLE
Add CONTRIBUTING and troubleshooting docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guide
+
+Thank you for wanting to contribute to Whisper Transcriber.
+This document explains how to get a development environment running and the
+conventions used for submitting changes.
+
+## Getting Started
+
+See [help.md](help.md) for a step-by-step setup guide. We recommend creating a
+virtual environment and installing dependencies with:
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+From the `frontend` directory install Node packages and build the UI:
+```bash
+npm install
+npm run build
+```
+Copy `.env.example` to `.env` and set a unique `SECRET_KEY` before running any
+commands.
+
+## Style Guide
+
+Run `black .` from the project root to format Python code. For the React
+frontend use Prettier if available, otherwise follow common React formatting
+conventions. Avoid very large pull requests; split changes into functional
+units when possible.
+
+## Testing
+
+Execute `scripts/run_tests.sh` before submitting a pull request.
+For backend-only changes run `scripts/run_backend_tests.sh`.
+Test logs are written to `logs/*.log`.
+
+## Submitting Changes
+
+Fork the repository and create a branch for your work.
+Commit messages should follow the conventional style such as
+`fix:`, `feat:`, or `refactor:`.
+Reference any relevant item in `future_updates.md` if applicable.
+Describe what changed and why in the pull request body.
+## Syncing Documentation
+
+Update `README.md` and `design_scope.md` whenever environment variables, API
+behavior, or architecture change. Keep `future_updates.md` current when new
+features are added or plans shift.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,56 @@
+# Troubleshooting Guide
+
+This page collects common errors and their resolutions to help users and
+developers diagnose problems quickly. Logs are saved under `logs/` and the
+`scripts/diagnose_containers.sh` script prints container status and build logs.
+
+## Build Failures
+
+- **Docker build fails at `dpkg -i /tmp/apt/*.deb`**
+  - *Cause*: `cache/apt` is missing or does not match the Dockerfile base image.
+  - *Fix*: Run `scripts/prestage_dependencies.sh` or confirm the base image
+    digest is correct.
+- **`--network=host` not supported in Docker Compose**
+  - *Cause*: Passing unsupported flags to the compose CLI.
+- *Fix*: Remove the flag or avoid Compose when unsupported.
+- **Docker build fails offline**
+  - *Fix*: Execute `prestage_dependencies.sh` beforehand so cached wheels and
+    packages are available.
+
+## Startup Errors
+
+- **Application exits due to missing `SECRET_KEY`**
+  - *Fix*: Generate a key and set it in `.env` or pass it via the helper script.
+- **API fails to connect to the database**
+  - *Fix*: Check `DB_URL`, wait for the database container to start and
+    increase connection retries if needed.
+
+## Job Failures
+
+- **Jobs stuck in queued or processing**
+  - *Fix*: Inspect worker logs and container health. Rebuild containers with
+    `scripts/update_images.sh` if they are corrupted.
+- **Transcript not generated**
+  - *Cause*: Whisper model files are missing or corrupted.
+  - *Fix*: Re-download `base.pt`, `large-v3.pt` and other models into `models/`.
+
+## Web UI or Frontend Issues
+
+- **Blank screen on load**
+  - *Fix*: Rebuild the frontend with `npm run build` or pass `--force-frontend`
+    to the build script.
+
+## Security Misconfiguration
+
+- **Open `/admin` routes in production**
+  - *Fix*: Configure CORS correctly, run behind a reverse proxy and enforce
+    admin roles.
+
+## Potential Future Scenarios
+
+These issues have not been observed yet but may occur based on the design:
+
+- Cache checksum mismatch after a WSL reset
+- Race conditions during parallel Docker builds
+- Missing model support when the Whisper CLI updates
+- React version upgrades breaking older UI components


### PR DESCRIPTION
## Summary
- add contributor onboarding instructions in `docs/CONTRIBUTING.md`
- document known issues and fixes in `docs/TROUBLESHOOTING.md`

## Testing
- `scripts/run_tests.sh --backend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d20c822883258c5b17b3aa8025c9