### PR TITLE
Add missing documentation files

### DIFF
--- a/docs/automation_tasks.md
+++ b/docs/automation_tasks.md
@@ -1,0 +1,21 @@
+# Automation Tasks
+
+👤 Target Audience: Developers and Operators
+
+The repository contains scripts and tooling for routine maintenance.
+
+## Linting
+- **Black** – Run `black .` before committing to format Python code.
+- **Prettier** – Optional for the React frontend. Execute `npx prettier -w frontend/src`.
+
+## Testing Automation
+- `scripts/run_tests.sh` runs backend tests, frontend unit tests and Cypress suites.
+- `scripts/run_backend_tests.sh` executes only the backend tests and verifies key API endpoints.
+
+## Cache Validation
+- `scripts/validate_manifest.sh` compares the staged dependency manifest against installed Docker images and cached packages.
+- Cron jobs can periodically run this script and alert when mismatches occur.
+
+## Optional Hooks
+- Git pre-commit hook calling `black` and `pytest`.
+- Documentation link checker or dependency audit tools can be integrated in the future.

--- a/docs/backup_and_recovery.md
+++ b/docs/backup_and_recovery.md
@@ -1,0 +1,45 @@
+# Backup and Recovery
+
+👤 Target Audience: Admins and Operators
+
+This project stores uploads, transcripts, logs and a PostgreSQL database. Preserve these assets regularly to avoid data loss.
+
+## Important Data
+- `uploads/` – source audio files
+- `transcripts/` – generated SRT and metadata
+- `logs/` – application and build logs
+- PostgreSQL database specified by `DB_URL`
+
+## Backup Procedures
+### Manual
+1. Stop the Docker stack so files are consistent:
+   ```bash
+   docker compose down
+   ```
+2. Archive the data directories:
+   ```bash
+   tar czf backup_$(date +%F).tar.gz uploads transcripts logs
+   pg_dump "$DB_URL" > db_$(date +%F).sql
+   ```
+
+### Automated
+- Schedule `pg_dump` and `tar` commands via cron.
+- When `STORAGE_BACKEND=cloud`, sync the `uploads/` and `transcripts/` directories to S3:
+   ```bash
+   aws s3 sync uploads s3://mybucket/uploads
+   aws s3 sync transcripts s3://mybucket/transcripts
+   ```
+- Rotate old backups and verify integrity periodically.
+
+## Restore Procedures
+1. Extract archived files back to the project root:
+   ```bash
+   tar xzf backup_2025-07-28.tar.gz -C .
+   psql "$DB_URL" < db_2025-07-28.sql
+   ```
+2. Restart the application stack:
+   ```bash
+   docker compose up -d
+   ```
+
+Ensure the same version of Whisper Transcriber is used when restoring from backups to avoid migration conflicts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,40 @@
 # Documentation Index
 
-| Document | Purpose | Audience |
+👤 Target Audience: Users, Developers, Admins, Ops
+
+## Getting Started
+| File | Scope/Purpose | Audience |
 | --- | --- | --- |
-| [README.md](../README.md) | Overview, environment variables and basic usage | Users, Admins, Developers |
-| [help.md](help.md) | Quick start setup steps | Users |
-| [design_scope.md](design_scope.md) | Developer architecture and build tooling | Developers |
-| [future_updates.md](future_updates.md) | Planned features and roadmap | Developers |
-| [CHANGELOG.md](CHANGELOG.md) | Release history following semver | Users, Developers |
-| [SECURITY.md](SECURITY.md) | Deployment and secrets best practices | Admins, Ops |
+| [README.md](../README.md) | Overview, environment variables and usage | Users, Dev, Admin |
+| [help.md](help.md) | Step-by-step setup instructions | Users |
+| [onboarding.md](onboarding.md) | First steps for new contributors | Developers |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and code style | Developers |
-| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and resolutions | Users, Developers |
-| [performance_guidelines.md](performance_guidelines.md) | Resource planning and scaling advice | Admins, Ops |
+
+## System Internals
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [design_scope.md](design_scope.md) | Architecture and build tooling | Developers |
+| [architecture_diagram.svg](architecture_diagram.svg) | Visual service layout | Developers |
+| [log_reference.md](log_reference.md) | Log file locations and meaning | Dev, Ops |
+| [performance_guidelines.md](performance_guidelines.md) | Resource planning and scaling | Admins, Ops |
+
+## Operations
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [backup_and_recovery.md](backup_and_recovery.md) | Data preservation and restoration | Admins, Ops |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and resolutions | Users, Dev |
+| [SECURITY.md](SECURITY.md) | Secrets handling and deployment tips | Admins, Ops |
+| [automation_tasks.md](automation_tasks.md) | Routine maintenance automation | Dev, Ops |
+
+## Development
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [scripts_reference.md](scripts_reference.md) | Helper scripts overview | Developers |
 | [testing_strategy.md](testing_strategy.md) | How to run backend and frontend tests | Developers |
-| [architecture_diagram.svg](architecture_diagram.svg) | Visual diagram of service components | Developers |
-| [log_reference.md](log_reference.md) | Explanation of all log files | Admins, Developers |
+| [versioning_policy.md](versioning_policy.md) | Release and tagging rules | Developers |
+| [future_updates.md](future_updates.md) | Planned features and roadmap | Developers |
 
-
+## Reference
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [CHANGELOG.md](CHANGELOG.md) | Release history following semver | Users, Dev |

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,19 @@
+# Integrations
+
+👤 Target Audience: Developers and Operators
+
+This document lists optional third-party services that can enhance or extend Whisper Transcriber.
+
+## Cloud Storage Providers
+- **Amazon S3** – Set `STORAGE_BACKEND=cloud` and configure `S3_BUCKET` and credentials. The worker uploads transcripts and audio files to the bucket.
+- **Local filesystem** – Default mode where data stays under `uploads/` and `transcripts/`.
+
+## LLMs
+- **OpenAI API** – Used for optional text analysis or future features. Set `OPENAI_API_KEY` to enable.
+
+## Monitoring Systems
+- **Prometheus** – Metrics endpoint exposed at `/metrics`. Point Prometheus to the API container.
+- **Log streaming** – Containers write logs under `logs/`. Use existing tools such as Filebeat to ship them.
+
+## CI/CD Pipelines
+- No official pipeline is provided yet. The scripts are designed to run in Docker-based CI platforms. Contributions are welcome to integrate GitHub Actions or similar services.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,41 @@
+# Onboarding Guide
+
+👤 Target Audience: New Developers
+
+This page helps new contributors get a working environment quickly.
+
+## What to Read First
+- [README.md](../README.md) for project overview and environment variables.
+- [help.md](help.md) for installation steps.
+- [CONTRIBUTING.md](CONTRIBUTING.md) for coding standards and workflow.
+- [testing_strategy.md](testing_strategy.md) for how tests are executed.
+
+## How to Get a Working Environment
+1. Clone the repository and install Python requirements:
+   ```bash
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
+   ```
+2. Install Node.js 18+ and build the frontend:
+   ```bash
+   cd frontend && npm install && npm run build && cd ..
+   ```
+3. Copy `.env.example` to `.env` and set `SECRET_KEY`.
+4. Start the stack in Docker:
+   ```bash
+   sudo scripts/start_containers.sh
+   ```
+
+## Setup Checklist
+- [ ] Python dependencies installed
+- [ ] Node modules installed
+- [ ] `.env` created with a unique `SECRET_KEY`
+- [ ] Docker Compose stack running
+- [ ] At least one Whisper model placed in `models/`
+
+## Optional Tools
+- **IDE plugins** – Configure Black and Prettier formatting on save.
+- **Test runners** – Use `scripts/run_tests.sh` for full test suite or `pytest` for specific files.
+- **Git hooks** – Add a pre-commit hook to run `black` and `pytest` automatically.
+
+Need more help? See [help.md](help.md) or reach out via repository issues.

--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -1,0 +1,22 @@
+# Scripts Reference
+
+👤 Target Audience: Developers
+
+The table below summarizes the helper scripts found under `/scripts`.
+
+| Script | Description | Flags / Env Vars | Example | Notes |
+| --- | --- | --- | --- | --- |
+| `check_env.sh` | Verifies host tools and base image versions before builds | `ALLOW_OS_MISMATCH`, `ALLOW_DIGEST_MISMATCH` | `scripts/check_env.sh` | Fails if required cache files or Docker are missing |
+| `diagnose_containers.sh` | Prints container status and recent logs for troubleshooting | `LOG_LINES` | `scripts/diagnose_containers.sh` | Useful when containers fail to start |
+| `docker-entrypoint.sh` | Entry script used inside containers to start the API or worker | `SERVICE_TYPE`, `BROKER_PING_TIMEOUT` | Invoked automatically by Docker | Creates log under `/app/logs/entrypoint.log` |
+| `docker_build.sh` | Full or incremental build of Docker images and stack | `--full` `--incremental` `--offline` `--force-frontend` | `sudo scripts/docker_build.sh --full` | Requires root to install packages |
+| `healthcheck.sh` | Container health probe used by Docker | `SERVICE_TYPE`, `VITE_API_HOST` | Invoked by Docker healthcheck | Exits non-zero when API or worker is unhealthy |
+| `prestage_dependencies.sh` | Downloads packages and images for offline builds | `--dry-run` `--checksum` `--verify-only` `CACHE_DIR` | `sudo scripts/prestage_dependencies.sh --checksum` | Requires internet unless run with `--verify-only` |
+| `run_backend_tests.sh` | Runs Python unit tests inside the API container | `VITE_API_HOST` | `scripts/run_backend_tests.sh` | Requires Docker Compose stack to be running |
+| `run_tests.sh` | Executes backend tests, frontend unit tests and Cypress e2e tests | `--backend` `--frontend` `--cypress` | `scripts/run_tests.sh --backend` | Logs saved to `logs/full_test.log` |
+| `server_entry.py` | Python entry point for local development | `PORT` | `python scripts/server_entry.py` | Starts Uvicorn with settings from `.env` |
+| `shared_checks.sh` | Library of common functions used by other scripts | N/A | Sourced by other scripts | Not executed directly |
+| `start_containers.sh` | Builds frontend if needed and launches Docker stack | `--force-frontend` `--offline` | `sudo scripts/start_containers.sh` | Writes log to `logs/start_containers.log` |
+| `update_images.sh` | Incremental rebuild of API and worker images | `--force-frontend` `--offline` | `sudo scripts/update_images.sh --offline` | Skips container restart when images are healthy |
+| `validate_manifest.sh` | Checks the cache manifest against local Docker images | `--summary` `--json` | `scripts/validate_manifest.sh --summary` | Detects mismatches between cached and installed versions |
+

--- a/docs/versioning_policy.md
+++ b/docs/versioning_policy.md
@@ -1,0 +1,24 @@
+# Versioning Policy
+
+👤 Target Audience: Developers, Release Managers
+
+Whisper Transcriber follows [Semantic Versioning](https://semver.org/) and records all changes in [CHANGELOG.md](CHANGELOG.md).
+
+## Strategy
+- **Major** version increments for incompatible API changes or significant redesigns.
+- **Minor** version increments for new features that remain backward compatible.
+- **Patch** version increments for bug fixes and documentation updates only.
+
+Releases are cut when notable features land or critical fixes are required. There is no fixed cadence, but versions are tagged at least once per quarter.
+
+## Tagging Practice
+- Git tags are created using the format `vMAJOR.MINOR.PATCH`, e.g. `v1.2.3`.
+- Each tag corresponds to a section in `CHANGELOG.md`.
+- Release assets are built from the tagged commit.
+
+## Backward Compatibility
+- Minor and patch releases maintain API compatibility with prior minor releases within the same major series.
+- Deprecated CLI flags or environment variables remain for one major cycle before removal.
+- Database migrations are included with each release so upgrades are one-way and non-destructive.
+
+See the [README](../README.md) for environment variables and [CHANGELOG.md](CHANGELOG.md) for historical context.


### PR DESCRIPTION
## Summary
- expand documentation index with grouping
- add script reference for helper scripts
- provide onboarding instructions for new contributors
- describe semantic versioning policy
- document backups and recovery steps
- outline optional integrations
- list automation tasks

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `npm install` *(network blocked for Cypress)*
- `PYTHONPATH=. pytest tests/test_access_log.py::test_log_write_error`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_6887e74821f483259ccf191ce52879d1