### PR TITLE
Add missing docs for environment and API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,29 @@
-SECRET_KEY=CHANGE_ME
+# Core application configuration
+PORT=8000
+VITE_API_HOST=http://localhost:8000
+JOB_QUEUE_BACKEND=thread
+STORAGE_BACKEND=local
+LOCAL_STORAGE_DIR=uploads
+MODEL_DIR=models
+
+# Logging
+LOG_LEVEL=INFO
+LOG_TO_STDOUT=false
+LOG_FORMAT=plain
+
+# Authentication
+# SECRET_KEY is used to sign JWTs. Must be 64 hex chars.
+SECRET_KEY=changemechangemechangemechangemechangemechangemechangemechangeme
+ALLOW_REGISTRATION=true
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+CORS_ORIGINS=*
+
+# Advanced settings
+MAX_CONCURRENT_JOBS=2
+CLEANUP_ENABLED=true
+CLEANUP_DAYS=30
+CLEANUP_INTERVAL_SECONDS=86400
+TIMEZONE=UTC
+WHISPER_LANGUAGE=en
+WHISPER_TIMEOUT_SECONDS=0
+OPENAI_MODEL=gpt-3.5-turbo

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,61 @@
+# HTTP API Reference
+
+## Jobs
+| Method | Endpoint | Auth? | Description |
+| --- | --- | --- | --- |
+| POST | `/jobs` | Token | Upload an audio file and start transcription. Parameter `file` is multipart form data; optional `model` selects the Whisper model. Returns job ID. |
+| GET | `/jobs` | Token | List jobs. Optional query params `search` and `status`. |
+| GET | `/jobs/{id}` | Token | Get status for a single job. |
+| DELETE | `/jobs/{id}` | Token | Remove a job and its files. |
+| POST | `/jobs/{id}/restart` | Token | Requeue a failed job. |
+| GET | `/jobs/{id}/download` | Token | Download transcript with optional `format` (`srt`, `txt`, `vtt`). |
+| GET | `/metadata/{id}` | Token | Retrieve generated metadata for a job. |
+| POST | `/jobs/{id}/analyze` | Token | Summarize and analyze a transcript using OpenAI. |
+
+## Admin (requires admin role)
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/admin/files` | List log, upload and transcript files. |
+| DELETE | `/admin/files` | Delete a single file (JSON body: `{"folder":"logs","filename":"foo.log"}`). |
+| GET | `/admin/browse` | Browse directories via `folder` and optional `path` query. |
+| POST | `/admin/reset` | Remove all data and database records. |
+| GET | `/admin/download-all` | Download a zip archive of all logs and transcripts. |
+| GET | `/admin/stats` | CPU, memory and job statistics. |
+| POST | `/admin/shutdown` | Shut down the running server when `ENABLE_SERVER_CONTROL=true`. |
+| POST | `/admin/restart` | Restart the server process. |
+| GET | `/admin/cleanup-config` | View cleanup settings. |
+| POST | `/admin/cleanup-config` | Update cleanup settings. |
+| GET | `/admin/concurrency` | View worker concurrency. |
+| POST | `/admin/concurrency` | Update worker concurrency. |
+
+## Logs
+| Method | Endpoint | Auth? | Description |
+| --- | --- | --- | --- |
+| GET | `/log/{job_id}` | Token | Retrieve a job log file. |
+| GET | `/logs/{filename}` | Token | Fetch arbitrary log file by name. |
+| GET | `/logs/access` | Token | Access log if enabled. |
+| WebSocket | `/ws/logs/{job_id}` | Token | Stream log output for a running job. |
+| WebSocket | `/ws/logs/system` | Admin | Stream system or access log in real time. |
+
+## Auth
+| Method | Endpoint | Auth? | Description |
+| --- | --- | --- | --- |
+| POST | `/register` | None (if enabled) | Create a new user account when `ALLOW_REGISTRATION=true`. |
+| POST | `/token` | Basic | Obtain a JWT for subsequent requests. |
+| POST | `/change-password` | Token | Update the current user's password. |
+
+Example request to submit a job:
+```bash
+curl -F 'file=@audio.wav' http://localhost:8000/jobs -H 'Authorization: Bearer <token>'
+```
+Example response from `/jobs/{id}`:
+```json
+{
+  "id": "123abc",
+  "original_filename": "audio.wav",
+  "model": "base",
+  "created_at": "2024-01-01T12:00:00Z",
+  "updated": "2024-01-01T12:05:00Z",
+  "status": "completed"
+}
+```

--- a/docs/architecture_diagram.md
+++ b/docs/architecture_diagram.md
@@ -1,0 +1,16 @@
+```
+ [Frontend]
+     |
+     | HTTP / WebSocket
+     v
+ [API] <-----> [Worker]
+     |              |
+     | REST/DB      |
+     v              v
+ [Database]    [Storage]
+     ^              |
+     | logs         |
+     +----> [System Log]
+
+Dashed boxes represent optional components when JOB_QUEUE_BACKEND=thread or STORAGE_BACKEND=local.
+```

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,78 @@
+# Environment Variables
+
+This page lists all configurable environment variables.
+
+## Core App Config
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| DB_URL | No | postgresql+psycopg2://whisper:whisper@db:5432/whisper | api/settings.py, docker-compose.yml | Database connection string |
+| PORT | No | 8000 | api/settings.py, scripts/server_entry.py | TCP port for Uvicorn |
+| VITE_API_HOST | No | http://localhost:8000 | api/settings.py, docker-compose.yml | Base URL for the API used by the web UI |
+| VITE_DEFAULT_TRANSCRIPT_FORMAT | No | txt | api/settings.py | Default transcript download format |
+| JOB_QUEUE_BACKEND | No | thread | api/settings.py, docker-compose.yml | Queue implementation to use |
+| MAX_CONCURRENT_JOBS | No | 2 | api/settings.py | Worker thread count for internal queue |
+| MODEL_DIR | No | models/ | api/settings.py | Directory of Whisper models |
+| WHISPER_BIN | No | whisper | api/settings.py | Path to Whisper CLI |
+| WHISPER_LANGUAGE | No | en | api/settings.py | Default language passed to Whisper |
+| WHISPER_TIMEOUT_SECONDS | No | 0 | api/settings.py | Max seconds to wait for Whisper before failing |
+| OPENAI_API_KEY | No | None | api/settings.py | API key enabling transcript analysis |
+| OPENAI_MODEL | No | gpt-3.5-turbo | api/settings.py | Model used when analysis is enabled |
+
+## Logging & Monitoring
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| LOG_LEVEL | No | DEBUG | api/settings.py | Logging level for backend loggers |
+| LOG_FORMAT | No | plain | api/settings.py | plain or json log format |
+| LOG_TO_STDOUT | No | False | api/settings.py | Mirror logs to container console |
+| LOG_MAX_BYTES | No | 10000000 | api/settings.py | Log file rotation size |
+| LOG_BACKUP_COUNT | No | 3 | api/settings.py | Number of rotated log files to keep |
+| TIMEZONE | No | UTC | api/settings.py | Local timezone for log timestamps |
+| API_HEALTH_TIMEOUT | No | 300 | scripts/* | Seconds scripts wait for API to become healthy |
+| DB_CONNECT_ATTEMPTS | No | 10 | api/settings.py | How many times to retry DB connection |
+| BROKER_CONNECT_ATTEMPTS | No | 20 | api/settings.py | How many times to ping the Celery broker |
+| BROKER_PING_TIMEOUT | No | 60 | scripts/docker-entrypoint.sh | Seconds worker waits for RabbitMQ |
+
+## Queue / Concurrency
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| CELERY_BROKER_URL | No | amqp://guest:guest@broker:5672// | api/settings.py, docker-compose.yml | Celery broker URL when JOB_QUEUE_BACKEND=broker |
+| CELERY_BACKEND_URL | No | rpc:// | api/settings.py, docker-compose.yml | Celery result backend |
+| MAX_CONCURRENT_JOBS | No | 2 | api/settings.py | Worker thread count |
+| JOB_QUEUE_BACKEND | No | thread | api/settings.py | Queue backend type |
+
+## Storage
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| STORAGE_BACKEND | No | local | api/settings.py | Storage implementation |
+| LOCAL_STORAGE_DIR | No | project root | api/settings.py | Base directory for local storage |
+| AWS_ACCESS_KEY_ID | No | None | api/settings.py | Access key for S3 backend |
+| AWS_SECRET_ACCESS_KEY | No | None | api/settings.py | Secret key for S3 backend |
+| S3_BUCKET | No | None | api/settings.py | Bucket name for cloud storage |
+| MAX_UPLOAD_SIZE | No | 2147483648 | api/settings.py | Maximum upload file size |
+
+## Security / Auth
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| SECRET_KEY | Yes | None | api/settings.py, .env.example | Secret used to sign JWTs |
+| ACCESS_TOKEN_EXPIRE_MINUTES | No | 60 | api/settings.py | JWT lifetime in minutes |
+| ALLOW_REGISTRATION | No | True | api/settings.py | Enable public /register endpoint |
+| AUTH_USERNAME | No | admin | api/settings.py | Legacy static username (deprecated) |
+| AUTH_PASSWORD | No | admin | api/settings.py | Legacy static password (deprecated) |
+| CORS_ORIGINS | No | * | api/settings.py | Allowed CORS origins |
+| ENABLE_SERVER_CONTROL | No | False | api/settings.py | Allow /admin/shutdown and /admin/restart |
+
+## Advanced Debug / Build
+
+| Variable Name | Required? | Default Value | Used In | Description |
+| --- | --- | --- | --- | --- |
+| CLEANUP_ENABLED | No | True | api/settings.py | Periodic cleanup of old transcripts |
+| CLEANUP_DAYS | No | 30 | api/settings.py | Days to keep transcripts |
+| CLEANUP_INTERVAL_SECONDS | No | 86400 | api/settings.py | Cleanup task interval |
+| CACHE_DIR | No | /tmp/docker_cache | design_scope.md, scripts/* | Directory for build cache |
+| SKIP_PRESTAGE | No | 0 | design_scope.md, scripts/* | Skip cache refresh during build |
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,40 +1,47 @@
 # Documentation Index
 
-👤 Target Audience: Users, Developers, Admins, Ops
-
 ## Getting Started
 | File | Scope/Purpose | Audience |
 | --- | --- | --- |
-| [README.md](../README.md) | Overview, environment variables and usage | Users, Dev, Admin |
+| [README.md](../README.md) | Overview and quickstart | Users, Dev, Admin |
 | [help.md](help.md) | Step-by-step setup instructions | Users |
+
+## 👤 Developer Docs
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
 | [onboarding.md](onboarding.md) | First steps for new contributors | Developers |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and code style | Developers |
-
-## System Internals
-| File | Scope/Purpose | Audience |
-| --- | --- | --- |
-| [design_scope.md](design_scope.md) | Architecture and build tooling | Developers |
-| [architecture_diagram.svg](architecture_diagram.svg) | Visual service layout | Developers |
-| [log_reference.md](log_reference.md) | Log file locations and meaning | Dev, Ops |
-| [performance_guidelines.md](performance_guidelines.md) | Resource planning and scaling | Admins, Ops |
-
-## Operations
-| File | Scope/Purpose | Audience |
-| --- | --- | --- |
-| [backup_and_recovery.md](backup_and_recovery.md) | Data preservation and restoration | Admins, Ops |
-| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and resolutions | Users, Dev |
-| [SECURITY.md](SECURITY.md) | Secrets handling and deployment tips | Admins, Ops |
-| [automation_tasks.md](automation_tasks.md) | Routine maintenance automation | Dev, Ops |
-
-## Development
-| File | Scope/Purpose | Audience |
-| --- | --- | --- |
 | [scripts_reference.md](scripts_reference.md) | Helper scripts overview | Developers |
 | [testing_strategy.md](testing_strategy.md) | How to run backend and frontend tests | Developers |
 | [versioning_policy.md](versioning_policy.md) | Release and tagging rules | Developers |
 | [future_updates.md](future_updates.md) | Planned features and roadmap | Developers |
 
-## Reference
+## 🛠 Operator Docs
 | File | Scope/Purpose | Audience |
 | --- | --- | --- |
-| [CHANGELOG.md](CHANGELOG.md) | Release history following semver | Users, Dev |
+| [backup_and_recovery.md](backup_and_recovery.md) | Data preservation and restoration | Admins, Ops |
+| [SECURITY.md](SECURITY.md) | Secrets handling and deployment tips | Admins, Ops |
+| [automation_tasks.md](automation_tasks.md) | Routine maintenance automation | Dev, Ops |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common issues and resolutions | Users, Dev |
+| [performance_guidelines.md](performance_guidelines.md) | Resource planning and scaling | Admins, Ops |
+
+## 📦 Architecture
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [design_scope.md](design_scope.md) | Architecture and build tooling | Developers |
+| [architecture_diagram.svg](architecture_diagram.svg) | Visual service layout | Developers |
+| [architecture_diagram.md](architecture_diagram.md) | ASCII component diagram | Developers |
+
+## 📊 Observability
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [log_reference.md](log_reference.md) | Log file locations and meaning | Dev, Ops |
+| [observability.md](observability.md) | Health checks and monitoring | Dev, Ops |
+
+## 📚 Reference
+| File | Scope/Purpose | Audience |
+| --- | --- | --- |
+| [environment.md](environment.md) | Supported environment variables | Dev, Ops |
+| [api_reference.md](api_reference.md) | HTTP endpoint details | Dev |
+| [upgrade.md](upgrade.md) | How to upgrade versions | Admins, Dev |
+| [CHANGELOG.md](CHANGELOG.md) | Release history | Users, Dev |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,26 @@
+# Observability Guide
+
+Whisper Transcriber exposes several endpoints and log files to aid monitoring.
+
+## Health Endpoints
+
+- **`/health`** – returns `{"status": "ok"}` when the API and database are reachable.
+- **`/metrics`** – Prometheus metrics. Requires an admin token.
+- **`/version`** – current application version from `pyproject.toml`.
+
+Docker Compose defines healthchecks for the `api`, `worker`, `db` and `broker` services. The compose stack waits until each container reports healthy before starting dependent services.
+
+## Logs
+
+- **File paths** – runtime logs live under `logs/`. Job logs are named `<job_id>.log`; the system log is `system.log`.
+- **WebSocket feeds** – connect to `/ws/logs/{job_id}` for a running job or `/ws/logs/system` for global logs.
+- **Container output** – when `LOG_TO_STDOUT=true`, logs also appear in `docker compose logs`.
+
+## Manual Checks
+
+Run `pgrep -f uvicorn` to verify the API is running or `curl http://localhost:8000/health` for a quick status check. Use `docker ps` or `docker compose ps` to confirm containers are up. The helper script `scripts/diagnose_containers.sh` collects these details automatically.
+
+## Suggested Alerts
+
+Monitor queue length (`queue_length` metric) and job duration (`job_duration_seconds`). Alerts should fire when the queue continues growing or jobs take unusually long. Disk usage under `uploads/`, `transcripts/` and `logs/` should also be watched.
+

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,30 @@
+# Upgrade Guide
+
+The project follows semantic versioning. Review `CHANGELOG.md` before upgrading to see if any breaking changes are noted.
+
+## When to Upgrade
+
+Check the `CHANGELOG.md` file for new releases. Minor and patch versions are usually safe drops in. Major versions may require additional steps.
+
+## Backup First
+
+Follow the steps in [backup_and_recovery.md](backup_and_recovery.md) to archive the database, `uploads/`, `transcripts/` and `logs/` directories before applying an update.
+
+## Validate Models and Dependencies
+
+After pulling a new version, run `scripts/prestage_dependencies.sh` to refresh cached packages and verify Whisper models are present. If the cache is already populated and you are offline, set `SKIP_PRESTAGE=1`.
+
+## Database Migrations
+
+The backend uses Alembic. Run:
+```bash
+alembic upgrade head
+```
+from the project root or allow `uvicorn` to run migrations automatically on startup.
+
+## Post-upgrade Steps
+
+1. Rebuild images with `scripts/docker_build.sh --full` or `scripts/update_images.sh`.
+2. Re-run `scripts/run_tests.sh` to ensure all tests pass.
+3. Restart the Docker Compose stack with `scripts/start_containers.sh`.
+


### PR DESCRIPTION
## Summary
- document all supported environment variables
- create example `.env` file
- document health checks and monitoring
- add HTTP API reference docs
- explain upgrade process
- add ASCII architecture diagram
- reorganize documentation index

## Testing
- `pip install fastapi uvicorn sqlalchemy passlib[bcrypt] psycopg2-binary python-multipart aiofiles pytest -q`
- `PYTHONPATH=. pytest tests/test_health.py::test_health_endpoint -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6887ec4ad5208325abc0beb4efaf1311