### PR TITLE
Finalize docs for file retention and FAQ

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,48 +1,124 @@
 # HTTP API Reference
 
 ## Jobs
-| Method | Endpoint | Auth? | Description |
-| --- | --- | --- | --- |
-| POST | `/jobs` | Token | Upload an audio file and start transcription. Parameter `file` is multipart form data; optional `model` selects the Whisper model. Returns job ID. |
-| GET | `/jobs` | Token | List jobs. Optional query params `search` and `status`. |
-| GET | `/jobs/{id}` | Token | Get status for a single job. |
-| DELETE | `/jobs/{id}` | Token | Remove a job and its files. |
-| POST | `/jobs/{id}/restart` | Token | Requeue a failed job. |
-| GET | `/jobs/{id}/download` | Token | Download transcript with optional `format` (`srt`, `txt`, `vtt`). |
-| GET | `/metadata/{id}` | Token | Retrieve generated metadata for a job. |
-| POST | `/jobs/{id}/analyze` | Token | Summarize and analyze a transcript using OpenAI. |
 
-## Admin (requires admin role)
-| Method | Endpoint | Description |
-| --- | --- | --- |
-| GET | `/admin/files` | List log, upload and transcript files. |
-| DELETE | `/admin/files` | Delete a single file (JSON body: `{"folder":"logs","filename":"foo.log"}`). |
-| GET | `/admin/browse` | Browse directories via `folder` and optional `path` query. |
-| POST | `/admin/reset` | Remove all data and database records. |
-| GET | `/admin/download-all` | Download a zip archive of all logs and transcripts. |
-| GET | `/admin/stats` | CPU, memory and job statistics. |
-| POST | `/admin/shutdown` | Shut down the running server when `ENABLE_SERVER_CONTROL=true`. |
-| POST | `/admin/restart` | Restart the server process. |
-| GET | `/admin/cleanup-config` | View cleanup settings. |
-| POST | `/admin/cleanup-config` | Update cleanup settings. |
-| GET | `/admin/concurrency` | View worker concurrency. |
-| POST | `/admin/concurrency` | Update worker concurrency. |
+### POST /jobs
+Upload an audio file and start transcription. Parameter `file` is multipart form data; optional `model` selects the Whisper model. Returns job ID.
+🔐 Auth Required: user
+
+### GET /jobs
+List jobs. Optional query params `search` and `status`.
+🔐 Auth Required: user
+
+### GET /jobs/{id}
+Get status for a single job.
+🔐 Auth Required: user
+
+### DELETE /jobs/{id}
+Remove a job and its files.
+🔐 Auth Required: user
+
+### POST /jobs/{id}/restart
+Requeue a failed job.
+🔐 Auth Required: user
+
+### GET /jobs/{id}/download
+Download transcript with optional `format` (`srt`, `txt`, `vtt`).
+🔐 Auth Required: user
+
+### GET /metadata/{id}
+Retrieve generated metadata for a job.
+🔐 Auth Required: user
+
+### POST /jobs/{id}/analyze
+Summarize and analyze a transcript using OpenAI.
+🔐 Auth Required: user
+
+## Admin
+
+### GET /admin/files
+List log, upload and transcript files.
+🔐 Auth Required: admin
+
+### DELETE /admin/files
+Delete a single file (JSON body: `{"folder":"logs","filename":"foo.log"}`).
+🔐 Auth Required: admin
+
+### GET /admin/browse
+Browse directories via `folder` and optional `path` query.
+🔐 Auth Required: admin
+
+### POST /admin/reset
+Remove all data and database records.
+🔐 Auth Required: admin
+
+### GET /admin/download-all
+Download a zip archive of all logs and transcripts.
+🔐 Auth Required: admin
+
+### GET /admin/stats
+CPU, memory and job statistics.
+🔐 Auth Required: admin
+
+### POST /admin/shutdown
+Shut down the running server when `ENABLE_SERVER_CONTROL=true`.
+🔐 Auth Required: admin
+
+### POST /admin/restart
+Restart the server process.
+🔐 Auth Required: admin
+
+### GET /admin/cleanup-config
+View cleanup settings.
+🔐 Auth Required: admin
+
+### POST /admin/cleanup-config
+Update cleanup settings.
+🔐 Auth Required: admin
+
+### GET /admin/concurrency
+View worker concurrency.
+🔐 Auth Required: admin
+
+### POST /admin/concurrency
+Update worker concurrency.
+🔐 Auth Required: admin
 
 ## Logs
-| Method | Endpoint | Auth? | Description |
-| --- | --- | --- | --- |
-| GET | `/log/{job_id}` | Token | Retrieve a job log file. |
-| GET | `/logs/{filename}` | Token | Fetch arbitrary log file by name. |
-| GET | `/logs/access` | Token | Access log if enabled. |
-| WebSocket | `/ws/logs/{job_id}` | Token | Stream log output for a running job. |
-| WebSocket | `/ws/logs/system` | Admin | Stream system or access log in real time. |
+
+### GET /log/{job_id}
+Retrieve a job log file.
+🔐 Auth Required: user
+
+### GET /logs/{filename}
+Fetch arbitrary log file by name.
+🔐 Auth Required: user
+
+### GET /logs/access
+Access log if enabled.
+🔐 Auth Required: user
+
+### WebSocket /ws/logs/{job_id}
+Stream log output for a running job.
+🔐 Auth Required: user
+
+### WebSocket /ws/logs/system
+Stream system or access log in real time.
+🔐 Auth Required: admin
 
 ## Auth
-| Method | Endpoint | Auth? | Description |
-| --- | --- | --- | --- |
-| POST | `/register` | None (if enabled) | Create a new user account when `ALLOW_REGISTRATION=true`. |
-| POST | `/token` | Basic | Obtain a JWT for subsequent requests. |
-| POST | `/change-password` | Token | Update the current user's password. |
+
+### POST /register
+Create a new user account when `ALLOW_REGISTRATION=true`.
+🔐 Auth Required: none
+
+### POST /token
+Obtain a JWT for subsequent requests.
+🔐 Auth Required: none
+
+### POST /change-password
+Update the current user's password.
+🔐 Auth Required: user
 
 Example request to submit a job:
 ```bash

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,22 @@
+# Frequently Asked Questions
+
+### Why does my job stay in "Queued"?
+Jobs remain queued until a worker thread picks them up. If concurrency is limited or the worker crashed, the queue may stall. Check `/admin/concurrency` and the worker logs under `logs/`.
+
+### How can I check logs if a job fails?
+Each job writes a log file named `<job_id>.log` in the `logs/` directory. Use `/log/{job_id}` or stream live output from `/ws/logs/{job_id}`. For system-wide issues consult `system.log`.
+
+### What’s the easiest way to debug a Docker build failure?
+Run `scripts/docker_build.sh` manually and inspect `logs/docker_build.log`. The troubleshooting guide covers common errors.
+
+### Can I run this without Docker?
+Yes. Install the Python and Node dependencies, then start the API with `uvicorn api.main:app`. The frontend can be served by running `npm run build` and pointing a static server at `frontend/dist`.
+
+### Why isn’t my frontend updating after rebuild?
+Browsers often cache the old bundle. Clear the cache or append a query string to the URL. Ensure `npm run build` completed without errors.
+
+### How do I test concurrency or simulate multiple jobs?
+Use a loop or small script to POST multiple files to `/jobs`. You can adjust worker threads with `/admin/concurrency` to see how the system behaves under load.
+
+### Where are my transcripts stored?
+Transcripts live under `transcripts/{job_id}` by default or in your configured S3 bucket when `STORAGE_BACKEND=cloud`. See [file_retention.md](file_retention.md) for cleanup policies.

--- a/docs/file_retention.md
+++ b/docs/file_retention.md
@@ -1,0 +1,25 @@
+# File Retention Policy
+
+This document explains how Whisper Transcriber retains or cleans up artifacts generated during transcription.
+
+## Transcript Artifacts
+- Completed transcripts and metadata are written under `transcripts/{job_id}`.
+- Original uploads remain in `uploads/`.
+- When `CLEANUP_ENABLED=true`, a background task removes uploads and transcript folders older than `CLEANUP_DAYS`.
+- Disable cleanup by setting `CLEANUP_ENABLED=false` or adjust the number of days with `CLEANUP_DAYS`.
+
+## Logs
+- Runtime and build logs live in `logs/`.
+- Files rotate at `LOG_MAX_BYTES` with `LOG_BACKUP_COUNT` backups retained.
+- When cleanup is enabled, log files older than the cutoff are deleted.
+- If `LOG_TO_STDOUT=true` the same output is also streamed to the container logs.
+
+## Abandoned Jobs
+- Jobs that were in progress when the server stopped are automatically requeued at startup.
+- Failed or missing uploads are marked accordingly so the cleanup task can remove their artifacts.
+
+## Cleanup Mechanism
+- The API spawns a cleanup thread at startup when enabled. It runs every `CLEANUP_INTERVAL_SECONDS`.
+- Administrators can view or update the current settings via the `/admin/cleanup-config` endpoint.
+
+See also: [observability.md](observability.md) and the admin endpoints in [api_reference.md](api_reference.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,11 +37,13 @@
 | --- | --- | --- |
 | [log_reference.md](log_reference.md) | Log file locations and meaning | Dev, Ops |
 | [observability.md](observability.md) | Health checks and monitoring | Dev, Ops |
+| [file_retention.md](file_retention.md) | File and log cleanup policy | Dev, Ops |
 
 ## 📚 Reference
 | File | Scope/Purpose | Audience |
 | --- | --- | --- |
 | [environment.md](environment.md) | Supported environment variables | Dev, Ops |
 | [api_reference.md](api_reference.md) | HTTP endpoint details | Dev |
+| [faq.md](faq.md) | Common questions and answers | Users, Dev |
 | [upgrade.md](upgrade.md) | How to upgrade versions | Admins, Dev |
 | [CHANGELOG.md](CHANGELOG.md) | Release history | Users, Dev |


### PR DESCRIPTION
## Summary
- document file and log retention
- clarify auth scopes for each endpoint
- add a developer FAQ
- update documentation index

## Testing
- `black .`
- `pip install -r requirements.txt` *(fails: operation cancelled)*
- `npm install` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6887f0497a608325ac703b6e974a6a9b