### PR TITLE
Improve WSL cache handling

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -18,8 +18,10 @@ developers diagnose problems quickly. Logs are saved under `logs/` and the
     packages are available.
 - **Whisper install fails with "No matching distribution found for wheel"**
   - *Fix*: Add `wheel` to `requirements-dev.txt` and rerun `prestage_dependencies.sh`.
-- **Cache fails to stage in WSL**
-  - *Fix*: Avoid using `/tmp/docker_cache`. Use `/mnt/wsl/shared/docker_cache` instead.
+- **WSL cache issues**
+  - *Fix*: When running under WSL the scripts automatically switch `CACHE_DIR`
+    to `/mnt/wsl/shared/docker_cache`. Ensure this shared path exists and
+    rerun `prestage_dependencies.sh` if staging fails.
 
 ## Startup Errors
 

--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -20,3 +20,11 @@ The table below summarizes the helper scripts found under `/scripts`.
 | `update_images.sh` | Incremental rebuild of API and worker images | `--force-frontend` `--offline` | `sudo scripts/update_images.sh --offline` | Skips container restart when images are healthy |
 | `validate_manifest.sh` | Checks the cache manifest against local Docker images | `--summary` `--json` | `scripts/validate_manifest.sh --summary` | Detects mismatches between cached and installed versions |
 
+## Environment-Sensitive Cache Pathing
+
+Most build scripts rely on a common cache directory. By default `CACHE_DIR`
+is `/tmp/docker_cache`. When the host is WSL, the scripts automatically
+override this path to `/mnt/wsl/shared/docker_cache` and print a warning.
+Setting `CACHE_DIR` manually is ignored under WSL so the cache always resides
+in the shared location.
+

--- a/scripts/diagnose_containers.sh
+++ b/scripts/diagnose_containers.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 LOG_LINES="${LOG_LINES:-20}"
+source "$SCRIPT_DIR/shared_checks.sh"
 
 # Ensure the Docker daemon is available before proceeding
 if ! docker info >/dev/null 2>&1; then
@@ -12,10 +13,8 @@ if ! docker info >/dev/null 2>&1; then
     exit 1
 fi
 
-# Set CACHE_DIR if not already defined
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/tmp/docker_cache"
-fi
+# Initialize CACHE_DIR for this environment
+set_cache_dir
 
 echo "Container status:"
 # Display container status including health information

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -9,12 +9,8 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Default the cache directory when not explicitly set
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/tmp/docker_cache"
-fi
 source "$SCRIPT_DIR/shared_checks.sh"
+set_cache_dir
 "$SCRIPT_DIR/check_env.sh"
 
 LOG_DIR="$ROOT_DIR/logs"

--- a/scripts/prestage_dependencies.sh
+++ b/scripts/prestage_dependencies.sh
@@ -5,6 +5,7 @@ trap 'echo "prestage_dependencies.sh failed near line $LINENO" >&2' ERR
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/shared_checks.sh"
+set_cache_dir
 
 # Parse options
 DRY_RUN="${DRY_RUN:-0}"
@@ -65,15 +66,7 @@ run_cmd() {
     fi
 }
 
-# Default cache directory when not set
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/tmp/docker_cache"
-fi
-if grep -qi microsoft /proc/version && [ "$CACHE_DIR" = "/tmp/docker_cache" ]; then
-    echo "[WARNING] WSL + /tmp/docker_cache may fail. Use /mnt/wsl/shared/docker_cache instead." >&2
-fi
-
-export CACHE_DIR
+# CACHE_DIR already initialized by set_cache_dir in shared_checks.sh
 
 if [ "$VERIFY_ONLY" = "1" ]; then
     verify_offline_assets

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -3,13 +3,28 @@
 
 # Expect ROOT_DIR to be defined by the caller
 
-# Determine the default cache directory. /tmp/docker_cache is used when
-# CACHE_DIR is not set.
-default_cache_dir() {
-    if [ -n "${CACHE_DIR:-}" ]; then
-        echo "$CACHE_DIR"
+# Set CACHE_DIR appropriately depending on the host environment
+set_cache_dir() {
+    if grep -qi microsoft /proc/version; then
+        if [ "${CACHE_DIR:-}" != "/mnt/wsl/shared/docker_cache" ]; then
+            echo "[WARNING] Detected WSL; overriding CACHE_DIR to /mnt/wsl/shared/docker_cache" >&2
+            CACHE_DIR="/mnt/wsl/shared/docker_cache"
+        fi
     else
-        echo "/tmp/docker_cache"
+        if [ -z "${CACHE_DIR:-}" ]; then
+            CACHE_DIR="/tmp/docker_cache"
+        fi
+    fi
+    export CACHE_DIR
+}
+
+# Determine the default cache directory. /tmp/docker_cache is used when
+# CACHE_DIR is not set. In WSL this function returns the WSL path.
+default_cache_dir() {
+    if grep -qi microsoft /proc/version; then
+        echo "${CACHE_DIR:-/mnt/wsl/shared/docker_cache}"
+    else
+        echo "${CACHE_DIR:-/tmp/docker_cache}"
     fi
 }
 

--- a/scripts/start_containers.sh
+++ b/scripts/start_containers.sh
@@ -9,13 +9,9 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Determine default cache directory if not provided
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/tmp/docker_cache"
-fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"
+set_cache_dir
 
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/start_containers.log"

--- a/scripts/update_images.sh
+++ b/scripts/update_images.sh
@@ -9,13 +9,9 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Set CACHE_DIR to a sensible default when unset
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/tmp/docker_cache"
-fi
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 source "$SCRIPT_DIR/shared_checks.sh"
+set_cache_dir
 
 LOG_DIR="$ROOT_DIR/logs"
 LOG_FILE="$LOG_DIR/update_images.log"


### PR DESCRIPTION
## Summary
- centralize cache path handling in `shared_checks.sh`
- update build and helper scripts to use new `set_cache_dir`
- document environment sensitive cache logic
- add troubleshooting note for WSL cache fallbacks

## Testing
- `black --check .`
- `./scripts/run_tests.sh --backend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880b1296908325b37ed79b7fea00e3