### PR TITLE
Add cache dir diagnostic script

### DIFF
--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -8,6 +8,7 @@ The table below summarizes the helper scripts found under `/scripts`.
 | --- | --- | --- | --- | --- |
 | `check_env.sh` | Verifies host tools and base image versions before builds | `ALLOW_OS_MISMATCH`, `ALLOW_DIGEST_MISMATCH` | `scripts/check_env.sh` | Fails if required cache files or Docker are missing |
 | `diagnose_containers.sh` | Prints container status and recent logs for troubleshooting | `LOG_LINES` | `scripts/diagnose_containers.sh` | Useful when containers fail to start |
+| `check_cache_env.sh` | Displays how CACHE_DIR resolves on the current host | `CI` | `scripts/check_cache_env.sh` | Helps verify WSL overrides |
 | `docker-entrypoint.sh` | Entry script used inside containers to start the API or worker | `SERVICE_TYPE`, `BROKER_PING_TIMEOUT` | Invoked automatically by Docker | Creates log under `/app/logs/entrypoint.log` |
 | `docker_build.sh` | Full or incremental build of Docker images and stack | `--full` `--incremental` `--offline` `--force-frontend` | `sudo scripts/docker_build.sh --full` | Requires root to install packages |
 | `healthcheck.sh` | Container health probe used by Docker | `SERVICE_TYPE`, `VITE_API_HOST` | Invoked by Docker healthcheck | Exits non-zero when API or worker is unhealthy |

--- a/scripts/check_cache_env.sh
+++ b/scripts/check_cache_env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/shared_checks.sh"
+
+# Initialize CACHE_DIR and capture any warning output
+warn_file=$(mktemp)
+set_cache_dir 2>"$warn_file"
+warning=$(cat "$warn_file")
+rm -f "$warn_file"
+
+# Determine environment type
+if grep -qi microsoft /proc/version; then
+    env_type="WSL"
+else
+    env_type="Linux"
+fi
+
+[ -n "${CI:-}" ] && env_type="$env_type (CI)"
+
+cat <<INFO
+Environment: $env_type
+CACHE_DIR: $CACHE_DIR
+INFO
+
+if [ "${CACHE_OVERRIDE_WARNING:-0}" -eq 1 ]; then
+    echo "Override warning triggered"
+    echo "$warning"
+else
+    echo "Override warning not triggered"
+fi

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -5,10 +5,12 @@
 
 # Set CACHE_DIR appropriately depending on the host environment
 set_cache_dir() {
+    CACHE_OVERRIDE_WARNING=0
     if grep -qi microsoft /proc/version; then
         if [ "${CACHE_DIR:-}" != "/mnt/wsl/shared/docker_cache" ]; then
             echo "[WARNING] Detected WSL; overriding CACHE_DIR to /mnt/wsl/shared/docker_cache" >&2
             CACHE_DIR="/mnt/wsl/shared/docker_cache"
+            CACHE_OVERRIDE_WARNING=1
         fi
     else
         if [ -z "${CACHE_DIR:-}" ]; then
@@ -16,6 +18,7 @@ set_cache_dir() {
         fi
     fi
     export CACHE_DIR
+    export CACHE_OVERRIDE_WARNING
 }
 
 # Determine the default cache directory. /tmp/docker_cache is used when


### PR DESCRIPTION
## Summary
- track when `set_cache_dir` overrides `CACHE_DIR`
- add `check_cache_env.sh` helper to display cache settings
- document script in scripts reference

## Testing
- `black .`
- `scripts/run_tests.sh --backend` *(fails: docker not found)*
- `bash scripts/check_cache_env.sh`

------
https://chatgpt.com/codex/tasks/task_e_688813eb411c83259079e2e1dccf0dc8