### PR TITLE
Fix help switch and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc
-FROM python:3.11-jammy
+FROM python:3.11-bookworm  # Codex: base image update
 
 # Install dev requirements when building test images
 ARG INSTALL_DEV=false

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -10,9 +10,12 @@ developers diagnose problems quickly. Logs are saved under `logs/` and the
   - *Cause*: `cache/apt` is missing or does not match the Dockerfile base image.
   - *Fix*: Run `scripts/whisper_build.sh --purge-cache` or confirm the base image
     digest is correct.
+- **Docker build fails due to invalid base image**
+  - *Cause*: The `FROM` tag in the Dockerfile references an image that cannot be pulled.
+  - *Fix*: Update the base image to a valid tag like `python:3.11-bookworm` and run `docker pull` to verify.
 - **`--network=host` not supported in Docker Compose**
   - *Cause*: Passing unsupported flags to the compose CLI.
-- *Fix*: Remove the flag or avoid Compose when unsupported.
+  - *Fix*: Remove the flag or avoid Compose when unsupported.
 - **Docker build fails offline**
   - *Fix*: Execute `whisper_build.sh --offline` after staging dependencies so cached wheels and packages are available.
 - **Cache is outdated or missing**

--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -10,7 +10,7 @@ The table below summarizes the helper scripts found under `/scripts`.
 | `diagnose_containers.sh` | Prints container status and recent logs for troubleshooting | `LOG_LINES` | `scripts/diagnose_containers.sh` | Useful when containers fail to start |
 | `check_cache_env.sh` | Displays how CACHE_DIR resolves on the current host | `CI` | `scripts/check_cache_env.sh` | Helps verify WSL overrides |
 | `docker-entrypoint.sh` | Entry script used inside containers to start the API or worker | `SERVICE_TYPE`, `BROKER_PING_TIMEOUT` | Invoked automatically by Docker | Creates log under `/app/logs/entrypoint.log` |
-| `whisper_build.sh` | Unified build and startup script | `--full` `--offline` `--purge-cache` `--verify-sources` | `sudo scripts/whisper_build.sh` | Logs to `logs/whisper_build.log`; sets `CACHE_DIR` automatically under WSL |
+| `whisper_build.sh` | Unified build and startup script | `--full` `--offline` `--purge-cache` `--verify-sources` `--help` | `sudo scripts/whisper_build.sh` | Logs to `logs/whisper_build.log`; sets `CACHE_DIR` automatically under WSL |
 | `healthcheck.sh` | Container health probe used by Docker | `SERVICE_TYPE`, `VITE_API_HOST` | Invoked by Docker healthcheck | Exits non-zero when API or worker is unhealthy |
 | `run_backend_tests.sh` | Runs Python unit tests inside the API container | `VITE_API_HOST` | `scripts/run_backend_tests.sh` | Requires Docker Compose stack to be running |
 | `run_tests.sh` | Executes backend tests, frontend unit tests and Cypress e2e tests | `--backend` `--frontend` `--cypress` | `scripts/run_tests.sh --backend` | Logs saved to `logs/full_test.log` |

--- a/scripts/whisper_build.sh
+++ b/scripts/whisper_build.sh
@@ -3,6 +3,27 @@ set -euo pipefail
 
 # Codex: unified build entrypoint
 
+print_help() {
+    cat <<EOF
+Usage: $(basename "$0") [--full|--offline] [--purge-cache] [--verify-sources]
+
+--full            Full online build (default)
+--offline         Require all assets to be pre-cached
+--purge-cache     Remove CACHE_DIR before staging dependencies
+--verify-sources  Test connectivity to package mirrors and registry
+--help            Show this help message
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+    esac
+done  # Codex: help guard
+
 echo "[NOTICE] Legacy build helpers removed. Use this script directly." >&2  # Codex:
 
 if [[ $EUID -ne 0 ]]; then
@@ -38,15 +59,7 @@ PURGE_CACHE=false
 VERIFY_SOURCES=false
 
 usage() {
-    cat <<EOF
-Usage: $(basename "$0") [--full|--offline] [--purge-cache] [--verify-sources]
-
---full            Full online build (default)
---offline         Require all assets to be pre-cached
---purge-cache     Remove CACHE_DIR before staging dependencies
---verify-sources  Test connectivity to package mirrors and registry
---help            Show this help message
-EOF
+    print_help
 }
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- stop whisper_build execution on `--help`
- update Python base image to bookworm
- document help flag
- add troubleshooting note for invalid image

## Testing
- `black .`
- `scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d045cd2c8325a9880424a0abdc2e