### PR TITLE
Remove unused usage helper

### DIFF
--- a/scripts/whisper_build.sh
+++ b/scripts/whisper_build.sh
@@ -57,10 +57,7 @@ trap cleanup EXIT
 MODE="full"
 PURGE_CACHE=false
 VERIFY_SOURCES=false
-
-usage() {
-    print_help
-}
+# Codex: removed legacy usage() helper
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -81,12 +78,12 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -h|--help)
-            usage
+            print_help
             exit 0
             ;;
         *)
             echo "Unknown option: $1" >&2
-            usage >&2
+            print_help >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Summary
- drop the obsolete `usage()` wrapper in `whisper_build.sh`

## Testing
- `black .`
- `scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888db09ee808325ab76e24d206357d3