### PR TITLE
Update docs for modular build flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-09-02
+### Added
+- Modular build switches for `whisper_build.sh` (`--update`, `--frontend-only`, `--validate-only`, `--docker-cleanup`).
+### Changed
+- Documentation updated to explain switch groups and targeted builds.
+
 ## [1.0.2] - 2025-08-15
 ### Removed
 - Legacy scripts `docker_build.sh` and `prestage_dependencies.sh` in favour of `whisper_build.sh`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Documentation Index
 
-The unified build system is documented under [whisper_build.sh][build-system].
+The unified build system now supports targeted builds and is documented under [whisper_build.sh][build-system].
 
 ## Getting Started
 | File | Scope/Purpose | Audience |

--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -10,7 +10,7 @@ The table below summarizes the helper scripts found under `/scripts`.
 | `diagnose_containers.sh` | Prints container status and recent logs for troubleshooting | `LOG_LINES` | `scripts/diagnose_containers.sh` | Useful when containers fail to start |
 | `check_cache_env.sh` | Displays how CACHE_DIR resolves on the current host | `CI` | `scripts/check_cache_env.sh` | Helps verify WSL overrides |
 | `docker-entrypoint.sh` | Entry script used inside containers to start the API or worker | `SERVICE_TYPE`, `BROKER_PING_TIMEOUT` | Invoked automatically by Docker | Creates log under `/app/logs/entrypoint.log` |
-| `whisper_build.sh` | Unified build and startup script | `--full` `--offline` `--purge-cache` `--verify-sources` `--help` | `sudo scripts/whisper_build.sh` | Logs to `logs/whisper_build.log`; sets `CACHE_DIR` automatically under WSL |
+| `whisper_build.sh` | Unified build and startup script | `--full` `--update` `--frontend-only` `--validate-only` `--offline` `--purge-cache` `--docker-cleanup` `--verify-sources` `--help` | `sudo scripts/whisper_build.sh` | Logs to `logs/whisper_build.log`; sets `CACHE_DIR` automatically under WSL |
 | `healthcheck.sh` | Container health probe used by Docker | `SERVICE_TYPE`, `VITE_API_HOST` | Invoked by Docker healthcheck | Exits non-zero when API or worker is unhealthy |
 | `run_backend_tests.sh` | Runs Python unit tests inside the API container | `VITE_API_HOST` | `scripts/run_backend_tests.sh` | Requires Docker Compose stack to be running |
 | `run_tests.sh` | Executes backend tests, frontend unit tests and Cypress e2e tests | `--backend` `--frontend` `--cypress` | `scripts/run_tests.sh --backend` | Logs saved to `logs/full_test.log` |
@@ -19,6 +19,25 @@ The table below summarizes the helper scripts found under `/scripts`.
 | `start_containers.sh` | Deprecated wrapper for `whisper_build.sh` | N/A | `scripts/start_containers.sh` | Redirects to new script |
 | `update_images.sh` | Deprecated wrapper for `whisper_build.sh` | N/A | `scripts/update_images.sh` | Redirects to new script |
 | `validate_manifest.sh` | Checks the cache manifest against local Docker images | `--summary` `--json` | `scripts/validate_manifest.sh --summary` | Detects mismatches between cached and installed versions |
+
+## Build Switch Groups
+
+`whisper_build.sh` now supports targeted builds. Switches are organised into three categories:
+
+**Full**
+- `--full` – build all images and start the stack from scratch.
+
+**Partial**
+- `--update` – rebuild changed components only.
+- `--frontend-only` – build just the React UI.
+- `--validate-only` – run checks without building images.
+
+**Utility**
+- `--offline` – skip network access when assets exist locally.
+- `--purge-cache` – remove cached layers before building.
+- `--docker-cleanup` – prune unused Docker resources.
+- `--verify-sources` – validate base image digests.
+- `--help` – display the usage summary.
 
 ## Environment-Sensitive Cache Pathing
 


### PR DESCRIPTION
## Summary
- document targeted build system in docs
- list build switch groups for whisper_build.sh
- note new modular build switches in the changelog

## Testing
- `black --check .`
- `scripts/run_tests.sh --backend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e816fccc832584fc68a0d98d5c0c