### PR TITLE
Clarify frontend-only flag behavior

### DIFF
--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -29,7 +29,7 @@ The table below summarizes the helper scripts found under `/scripts`.
 
 **Partial**
 - `--update` – refresh dependencies and rebuild images using Docker cache.
-- `--frontend-only` – build just the React UI.
+- `--frontend-only` – rebuilds the React UI and refreshes the API/worker images.
 - `--validate-only` – run checks without building images.
 
 **Utility**


### PR DESCRIPTION
## Summary
- document that `--frontend-only` rebuilds API/worker images as well as the UI

## Testing
- `scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68894d9687188325b314829120b5df8d