### PR TITLE
Add cleanup log step

### DIFF
--- a/scripts/whisper_build.sh
+++ b/scripts/whisper_build.sh
@@ -182,6 +182,7 @@ run_validations() {
 
 # Codex: docker cleanup helper
 docker_cleanup() {
+    log_step "CLEANUP"
     docker image prune -f
     docker builder prune -f
 }


### PR DESCRIPTION
## Summary
- make docker cleanup announce 'CLEANUP' so users see pruning step

## Testing
- `scripts/run_tests.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68894e45731483258b96ab89948b1e3f