### PR TITLE
Update CAG workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ docker compose restart
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
 
+## Codex Analyst GPT Workflow
+
+Audits, file fetches and patch generation are now handled entirely by **Codex Analyst GPT (CAG) v2.6**. When contributors request changes, Codex runs the `CPG_repo_audit.py`, `CPG_file_fetcher.py` and `CPG_audit_diff.py` scripts on demand and returns the results inside the conversation. Approved patches are applied automatically and the full diff is saved under `docs/patch_logs/` for reference. Manual ZIP uploads are no longer required—patch logs accumulate in that directory and serve as the canonical history.
+
 ## Contributing
 
 Run `black .` before committing changes. When adding features or changing configuration, update both `docs/design_scope.md`, `docs/future_updates.md`, and `README.md` so the documentation stays consistent.

--- a/frontend/src/components/PatchUploader.js
+++ b/frontend/src/components/PatchUploader.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+export default function PatchUploader() {
+  return (
+    <div style={{ marginTop: "1rem", color: "#a1a1aa" }}>
+      Patch logs are generated automatically from Codex Analyst GPT prompts and
+      saved under <code>docs/patch_logs/</code>. Manual ZIP uploads are no
+      longer needed.
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- document the new Codex Analyst GPT workflow in README
- add a PatchUploader component with notes about automatic patch logs

## Testing
- `scripts/run_tests.sh --backend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7b45ac748325be499eb54edd8c80