### PR TITLE
Remove legacy script mentions from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ the container logs in the console.
 
 ## Codex Analyst GPT Workflow
 
-Audits, file fetches and patch generation are now handled entirely by **Codex Analyst GPT (CAG) v2.6**. When contributors request changes, Codex runs the `CPG_repo_audit.py`, `CPG_file_fetcher.py` and `CPG_audit_diff.py` scripts on demand and returns the results inside the conversation. Approved patches are applied automatically and the full diff is saved under `docs/patch_logs/` for reference. Manual ZIP uploads are no longer required—patch logs accumulate in that directory and serve as the canonical history.
+Repository introspection and patch creation are handled entirely by **Codex Analyst GPT (CAG)**. When contributors request changes, CAG retrieves file lists and contents through prompt-driven commands and returns the necessary diffs inside the conversation. Approved patches are applied automatically and the full diff is saved under `docs/patch_logs/` for reference. Manual ZIP uploads are no longer required—patch logs accumulate in that directory and serve as the canonical history.
 
 ## Contributing
 

--- a/docs/design_scope.md
+++ b/docs/design_scope.md
@@ -9,6 +9,8 @@ This repository implements a self‑contained audio transcription service. A Fas
 
 All contributors—including Codex—must update this document and `README.md` whenever features or configuration change. Keeping both files synchronized ensures the instructions remain accurate.
 
+## Codex Analyst GPT Integration
+Repository state is inspected and patched through Codex Analyst GPT (CAG) prompts. CAG retrieves file lists and contents on demand and returns diffs that are applied automatically. Patch histories are stored under `docs/patch_logs/`.
 
 ## System Design
 - **FastAPI entry point**: `api/main.py` bootstraps the web app. It mounts static directories, sets up CORS, and defines all API endpoints.

--- a/docs/help.md
+++ b/docs/help.md
@@ -27,3 +27,5 @@ docker compose up --build
 ```
 
 See [README.md](../README.md) for troubleshooting, offline setup and Docker details. The [design_scope.md](design_scope.md) document outlines how the system works under the hood.
+
+Codex Analyst GPT (CAG) drives repository audits and patch creation. CAG fetches file lists and contents through prompt-driven commands and returns the diffs to apply, so no manual scripts are needed.


### PR DESCRIPTION
## Summary
- replace old script workflow with CAG explanation in README
- note CAG-driven process in help and design scope docs

## Testing
- `scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7e263fa08325ba6b5fed1230bc85