### PR TITLE
Add patch log template

### DIFF
--- a/docs/patch_logs/_TEMPLATE.md
+++ b/docs/patch_logs/_TEMPLATE.md
@@ -1,0 +1,48 @@
+=====TASK=====
+<brief task description>
+
+=====OBJECTIVE=====
+<desired outcome>
+
+=====CONSTRAINTS=====
+- <constraint 1>
+- <constraint 2>
+
+=====SCOPE=====
+<files or components touched>
+
+=====DIFFSUMMARY=====
+- <summary of changes>
+
+=====TIMESTAMP=====
+<UTC timestamp>
+
+=====PROMPTID=====
+<identifier for the builder prompt>
+
+=====AGENTVERSION=====
+<agent version>
+
+=====AGENTHASH=====
+<agent hash>
+
+=====PROMPTHASH=====
+<prompt hash>
+
+=====COMMITHASH=====
+<commit hash>
+
+=====SPEC_HASHES=====
+<spec hashes>
+
+=====SNAPSHOT=====
+<repo snapshot or audit details>
+
+=====TESTRESULTS=====
+<summary of executed tests>
+
+=====DIAGNOSTICMETA=====
+<JSON diagnostic block>
+
+=====DECISIONS=====
+- <key decisions and deviations>

--- a/docs/patch_logs/patch_20250801_145422_CreatePatchLogTemplate.txt
+++ b/docs/patch_logs/patch_20250801_145422_CreatePatchLogTemplate.txt
@@ -1,0 +1,49 @@
+=====TASK=====
+Add missing patch log template file.
+
+=====OBJECTIVE=====
+Provide a reusable template outlining required patch log sections.
+
+=====CONSTRAINTS=====
+- Only create docs/patch_logs/_TEMPLATE.md and new patch log.
+- Record snapshot and test results per AGENTS.md.
+
+=====SCOPE=====
+docs/patch_logs/_TEMPLATE.md
+
+=====DIFFSUMMARY=====
+- Created template with standard headers including SPEC_HASHES field.
+
+=====TIMESTAMP=====
+2025-08-01T14:54:22Z
+
+=====PROMPTID=====
+CreatePatchLogTemplate
+
+=====AGENTVERSION=====
+Unknown
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+201f479be5e503bcf8d03865e6117eb31dc6f779
+
+=====SPEC_HASHES=====
+N/A
+
+=====SNAPSHOT=====
+repo audit script missing; used git metadata.
+
+=====TESTRESULTS=====
+Docker not installed; tests skipped.
+
+=====DIAGNOSTICMETA=====
+{ "preflight": { "docker": false, "docker-compose": false, "python": "Python 3.12.10", "node": "v20.19.4", "npm": "11.4.2" } }
+
+=====DECISIONS=====
+- Created _TEMPLATE.md with required sections.
+- Could not run repo audit or tests due to missing docker.


### PR DESCRIPTION
## Summary
- document standard fields in `docs/patch_logs/_TEMPLATE.md`
- log this addition in `patch_20250801_145422_CreatePatchLogTemplate.txt`

## Testing
- `scripts/run_tests.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd3e914108325a2e01e2b34857030