### PR TITLE
Add hash_utils script

### DIFF
--- a/docs/patch_logs/patch_20250801_151351_HashUtilsScript.log
+++ b/docs/patch_logs/patch_20250801_151351_HashUtilsScript.log
@@ -1,0 +1,49 @@
+=====TASK=====
+Create script for hashing CAG spec and AGENTS.md.
+
+=====OBJECTIVE=====
+Provide function to compute SHA-256 hash of concatenated specification files.
+
+=====CONSTRAINTS=====
+- Follow existing shell script style.
+- Add script under scripts/hash_utils.sh.
+
+=====SCOPE=====
+scripts/hash_utils.sh
+
+=====DIFFSUMMARY=====
+- Added hash_utils.sh with cag_agents_hash function.
+
+=====TIMESTAMP=====
+2025-08-01T15:13:48Z
+
+=====PROMPTID=====
+HashUtilsScript
+
+=====AGENTVERSION=====
+Unknown
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+6e68f5e39341d7d5821ecd53098783bf0ec5ea68
+
+=====SPEC_HASHES=====
+c49149643820ef9da9bd0f636db533a7f9f83d80fe218cba191c8187121d2814
+
+=====SNAPSHOT=====
+Attempted: scripts/CPG_repo_audit.py (missing, [Errno 2]). Using git commit hash and timestamp as baseline.
+
+=====TESTRESULTS=====
+Docker not installed; tests skipped.
+
+=====DIAGNOSTICMETA=====
+{ "preflight": { "docker": false, "docker-compose": false, "python": "Python 3.12.10", "node": "v20.19.4", "npm": "11.4.2" } }
+
+=====DECISIONS=====
+- Created scripts/hash_utils.sh with cag_agents_hash.
+- Could not run repo audit or tests due to missing docker.

--- a/scripts/hash_utils.sh
+++ b/scripts/hash_utils.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Print SHA-256 hash of the concatenated contents of the CAG specification and AGENTS.md
+cag_agents_hash() {
+    local spec_file="$ROOT_DIR/docs/CAG_spec.md"
+    local agents_file="$ROOT_DIR/AGENTS.md"
+
+    if [[ ! -f "$spec_file" ]]; then
+        echo "CAG specification file not found: $spec_file" >&2
+        return 1
+    fi
+    if [[ ! -f "$agents_file" ]]; then
+        echo "AGENTS.md file not found: $agents_file" >&2
+        return 1
+    fi
+
+    cat "$spec_file" "$agents_file" | sha256sum | awk '{print $1}'
+}
+
+# If the script is executed directly, run the function
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    cag_agents_hash
+fi


### PR DESCRIPTION
## Summary
- add `scripts/hash_utils.sh` with a function to hash the CAG spec and AGENTS.md
- log the patch

## Testing
- `scripts/run_tests.sh` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688cd835e8548325b12856e3f83a93e9