### PR TITLE
Add binary guard dry run prompt

### DIFF
--- a/docs/patch_logs/patch_20250801_153325_BinaryGuardTest.log
+++ b/docs/patch_logs/patch_20250801_153325_BinaryGuardTest.log
@@ -1,0 +1,49 @@
+=====TASK=====
+Create binary_guard_test.md under scripts/dry_run_prompt_examples.
+
+=====OBJECTIVE=====
+Provide a dry-run prompt referencing large/binary data to trip the BinaryGuard.
+
+=====CONSTRAINTS=====
+- Do not include actual binary content.
+- File must be placed under scripts/dry_run_prompt_examples/.
+
+=====SCOPE=====
+scripts/dry_run_prompt_examples/binary_guard_test.md
+
+=====DIFFSUMMARY=====
+- Added binary_guard_test.md with example query referencing large binary file.
+
+=====TIMESTAMP=====
+2025-08-01T15:33:34Z
+
+=====PROMPTID=====
+BinaryGuardTest
+
+=====AGENTVERSION=====
+Unknown
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+07b469359ada2cd9102c775bbb77c9d30b344bd8
+
+=====SPEC_HASHES=====
+c49149643820ef9da9bd0f636db533a7f9f83d80fe218cba191c8187121d2814
+
+=====SNAPSHOT=====
+Attempted: scripts/CPG_repo_audit.py (missing, [Errno 2]). Using git commit hash and timestamp as baseline.
+
+=====TESTRESULTS=====
+Docker not installed; tests skipped.
+
+=====DIAGNOSTICMETA=====
+{ "preflight": { "docker": false, "docker-compose": false, "python": "Python 3.12.10", "node": "v20.19.4", "npm": "11.4.2" } }
+
+=====DECISIONS=====
+- Added dry-run prompt to test BinaryGuard.
+- Could not run repo audit or tests due to missing docker.

--- a/scripts/dry_run_prompt_examples/binary_guard_test.md
+++ b/scripts/dry_run_prompt_examples/binary_guard_test.md
@@ -1,0 +1,3 @@
+Prompt: Provide a sample query that references an extremely large binary file (e.g., a 2 GB
+video or a 100 MB ZIP archive) to ensure the BinaryGuard triggers. Do not include actual
+binary data—only describe the request and mention the large/binary nature of the content.


### PR DESCRIPTION
## Summary
- add dry run prompt for testing binary guard trip
- log patch details

## Testing
- `black --check .`
- `scripts/run_tests.sh` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688cdc8b4c6c8325a25d385702e6e5b1