### PR TITLE
Update patch log UTC naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ After each committed patch:
    metadata, agent metadata, test results, full diagnostic block, decisions/deviations**.  
 3. Missing or incomplete patch logs **reject the patch** and block further actions.
 
+Use UTC when constructing patch file names to align with TIMESTAMP (Z).
+
 ---
 
 ## Test Enforcement

--- a/docs/patch_logs/_TEMPLATE.md
+++ b/docs/patch_logs/_TEMPLATE.md
@@ -1,3 +1,4 @@
+patch_YYYYMMDD_HHMMSS_UTC_<short>.log
 =====TASK=====
 <brief task description>
 
@@ -16,6 +17,9 @@
 
 =====TIMESTAMP=====
 <UTC timestamp>
+
+=====BUILDER_DATE_TIME (UTC)=====
+<YYYYMMDD HHMMSS>
 
 =====PROMPTID=====
 <identifier for the builder prompt>

--- a/docs/patch_logs/patch_20250801_155438_UTC_utc-filename-fix-001.log
+++ b/docs/patch_logs/patch_20250801_155438_UTC_utc-filename-fix-001.log
@@ -1,0 +1,52 @@
+patch_20250801_155438_UTC_utc-filename-fix-001.log
+=====TASK=====
+enforce_utc_patchlog_naming
+
+=====OBJECTIVE=====
+Align patch-log filename rules with UTC convention used in TIMESTAMP fields.
+
+=====CONSTRAINTS=====
+- AtomicPatch: edit max 3 files; commit must fully succeed or revert.
+- Preserve alias lines and dense formatting; no markdown or emojis.
+
+=====SCOPE=====
+instructions/cag_dense.txt; docs/patch_logs/_TEMPLATE.md; AGENTS.md
+
+=====DIFFSUMMARY=====
+- Updated patch log naming to include UTC; added builder time field and note.
+
+=====TIMESTAMP=====
+2025-08-01T15:54:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 155438
+
+=====PROMPTID=====
+utc-filename-fix-001
+
+=====AGENTVERSION=====
+Unknown
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+24aaa5ce0d4f17321a2a1b54dd818a4e62cd8bf6
+
+=====SPEC_HASHES=====
+N/A
+
+=====SNAPSHOT=====
+N/A
+
+=====TESTRESULTS=====
+Docker not installed; tests skipped.
+
+=====DIAGNOSTICMETA=====
+{ "preflight": { "docker": false, "docker-compose": false, "python": "Python 3.12.10", "node": "v20.19.4", "npm": "11.4.2" } }
+
+=====DECISIONS=====
+- Updated naming to include UTC; added builder time section.; OS mismatch prevents preflight.

--- a/instructions/cag_dense.txt
+++ b/instructions/cag_dense.txt
@@ -1,1 +1,1 @@
-PatchLogging:C:EachCommittedPatch:XGeneratesLog /docs/patch_logs/ named patch_<YYYYMMDD><HHMMSS><short>.log;LogMustInclude(TASK,OBJECTIVE,CONSTRAINTS,SCOPE,DIFF,TS,prompt_id,AV,AH,CH,TESTRES,DIAGMETA,BDT,SPEC_HASHES);RejectWorkflowIfLogMissing;
+PatchLogging:C:EachCommittedPatch:XGeneratesLog /docs/patch_logs/ named patch_<YYYYMMDD><HHMMSS UTC>_<short>.log;LogMustInclude(TASK,OBJECTIVE,CONSTRAINTS,SCOPE,DIFF,TS,prompt_id,AV,AH,CH,TESTRES,DIAGMETA,BDT,SPEC_HASHES);RejectWorkflowIfLogMissing;


### PR DESCRIPTION
## Summary
- update dense patch logging rule to use UTC notation in filenames
- add UTC placeholder and builder date field to log template
- note UTC requirement in AGENTS patch logging section

## Testing
- `scripts/check_env.sh` *(fails: OS codename mismatch)*
- `scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce0eaa2948325b6566ee7dd048783