### PR TITLE
Backfill patch logs for historical commits

### DIFF
--- a/docs/patch_logs/patch_20250728_220057_a9f8a90dc9844ffbf056a03bbc6301a14c95edd0.log
+++ b/docs/patch_logs/patch_20250728_220057_a9f8a90dc9844ffbf056a03bbc6301a14c95edd0.log
@@ -1,0 +1,64 @@
+patch_20250728_220057_a9f8a90dc9844ffbf056a03bbc6301a14c95edd0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit a9f8a90dc9844ffbf056a03bbc6301a14c95edd0
+
+=====DIFFSUMMARY=====
+commit a9f8a90dc9844ffbf056a03bbc6301a14c95edd0
+Merge: ca9481f c807c88
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 16:00:57 2025 -0600
+
+    Merge pull request #507 from buymeagoat/codex/finalize-whisper-transcriber-documentation-suite
+    
+    Finalize docs for file retention and FAQ
+
+ docs/api_reference.md  | 152 ++++++++++++++++++++++++++++++++++++-------------
+ docs/faq.md            |  22 +++++++
+ docs/file_retention.md |  25 ++++++++
+ docs/index.md          |   2 +
+ 4 files changed, 163 insertions(+), 38 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T22:00:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a9f8a90dc9844ffbf056a03bbc6301a14c95edd0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_222011_fb382a8bd527b2ab5a761eb704fdc0e26c5f3583.log
+++ b/docs/patch_logs/patch_20250728_222011_fb382a8bd527b2ab5a761eb704fdc0e26c5f3583.log
@@ -1,0 +1,58 @@
+patch_20250728_222011_fb382a8bd527b2ab5a761eb704fdc0e26c5f3583.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit fb382a8bd527b2ab5a761eb704fdc0e26c5f3583
+
+=====DIFFSUMMARY=====
+commit fb382a8bd527b2ab5a761eb704fdc0e26c5f3583
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 16:20:11 2025 -0600
+
+    Update project setup instructions
+
+ AGENTS.md | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T22:20:11Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fb382a8bd527b2ab5a761eb704fdc0e26c5f3583
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_222023_597f12553750c0fea98e2272c53d54963624a5c6.log
+++ b/docs/patch_logs/patch_20250728_222023_597f12553750c0fea98e2272c53d54963624a5c6.log
@@ -1,0 +1,61 @@
+patch_20250728_222023_597f12553750c0fea98e2272c53d54963624a5c6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 597f12553750c0fea98e2272c53d54963624a5c6
+
+=====DIFFSUMMARY=====
+commit 597f12553750c0fea98e2272c53d54963624a5c6
+Merge: a9f8a90 fb382a8
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 16:20:23 2025 -0600
+
+    Merge pull request #508 from buymeagoat/codex/update-agents.md-with-setup-instructions
+    
+    Update AGENTS setup instructions
+
+ AGENTS.md | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T22:20:23Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+597f12553750c0fea98e2272c53d54963624a5c6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_225845_426d2ebad8b6019bd5ad10c1f7078009603c7fc9.log
+++ b/docs/patch_logs/patch_20250728_225845_426d2ebad8b6019bd5ad10c1f7078009603c7fc9.log
@@ -1,0 +1,63 @@
+patch_20250728_225845_426d2ebad8b6019bd5ad10c1f7078009603c7fc9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 426d2ebad8b6019bd5ad10c1f7078009603c7fc9
+
+=====DIFFSUMMARY=====
+commit 426d2ebad8b6019bd5ad10c1f7078009603c7fc9
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 16:58:45 2025 -0600
+
+    Harden build scripts and update docs
+
+ docs/TROUBLESHOOTING.md          |  6 ++++++
+ docs/environment.md              |  2 +-
+ docs/observability.md            |  8 ++++++++
+ requirements-dev.txt             |  1 +
+ scripts/docker_build.sh          | 17 ++++++++++++++---
+ scripts/prestage_dependencies.sh | 15 ++++++++++-----
+ 6 files changed, 40 insertions(+), 9 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T22:58:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+426d2ebad8b6019bd5ad10c1f7078009603c7fc9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_225858_6db62100f6df490a52c21911ff19ef0c11210a91.log
+++ b/docs/patch_logs/patch_20250728_225858_6db62100f6df490a52c21911ff19ef0c11210a91.log
@@ -1,0 +1,66 @@
+patch_20250728_225858_6db62100f6df490a52c21911ff19ef0c11210a91.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 6db62100f6df490a52c21911ff19ef0c11210a91
+
+=====DIFFSUMMARY=====
+commit 6db62100f6df490a52c21911ff19ef0c11210a91
+Merge: 597f125 426d2eb
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 16:58:58 2025 -0600
+
+    Merge pull request #509 from buymeagoat/codex/patch-build-scripts-and-update-documentation
+    
+    Update build scripts and docs
+
+ docs/TROUBLESHOOTING.md          |  6 ++++++
+ docs/environment.md              |  2 +-
+ docs/observability.md            |  8 ++++++++
+ requirements-dev.txt             |  1 +
+ scripts/docker_build.sh          | 17 ++++++++++++++---
+ scripts/prestage_dependencies.sh | 15 ++++++++++-----
+ 6 files changed, 40 insertions(+), 9 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T22:58:58Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6db62100f6df490a52c21911ff19ef0c11210a91
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_232457_97316f88a2558389404ef061c1a6e6af1309b561.log
+++ b/docs/patch_logs/patch_20250728_232457_97316f88a2558389404ef061c1a6e6af1309b561.log
@@ -1,0 +1,63 @@
+patch_20250728_232457_97316f88a2558389404ef061c1a6e6af1309b561.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 97316f88a2558389404ef061c1a6e6af1309b561
+
+=====DIFFSUMMARY=====
+commit 97316f88a2558389404ef061c1a6e6af1309b561
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 18:24:57 2025 -0500
+
+    Delete docs/install_logs directory
+
+ docs/install_logs/20250720-1730.log |  9967 ------
+ docs/install_logs/20250721-1925.log | 31718 ------------------
+ docs/install_logs/20250721-2314.log |  4674 ---
+ docs/install_logs/20250722-0938.log |  4452 ---
+ docs/install_logs/20250722-1153.log |  6632 ----
+ docs/install_logs/20250722-1757.log | 58503 ----------------------------------
+ 6 files changed, 115946 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T23:24:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+97316f88a2558389404ef061c1a6e6af1309b561
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_234946_18ac2c196ee271813d71d49ebe9c8ee2682704b9.log
+++ b/docs/patch_logs/patch_20250728_234946_18ac2c196ee271813d71d49ebe9c8ee2682704b9.log
@@ -1,0 +1,65 @@
+patch_20250728_234946_18ac2c196ee271813d71d49ebe9c8ee2682704b9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 18ac2c196ee271813d71d49ebe9c8ee2682704b9
+
+=====DIFFSUMMARY=====
+commit 18ac2c196ee271813d71d49ebe9c8ee2682704b9
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 17:49:46 2025 -0600
+
+    Handle WSL cache path
+
+ docs/TROUBLESHOOTING.md          |  6 ++++--
+ docs/scripts_reference.md        |  8 ++++++++
+ scripts/diagnose_containers.sh   |  7 +++----
+ scripts/docker_build.sh          |  6 +-----
+ scripts/prestage_dependencies.sh | 11 ++---------
+ scripts/shared_checks.sh         | 23 +++++++++++++++++++----
+ scripts/start_containers.sh      |  6 +-----
+ scripts/update_images.sh         |  6 +-----
+ 8 files changed, 39 insertions(+), 34 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T23:49:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+18ac2c196ee271813d71d49ebe9c8ee2682704b9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250728_235001_4bb903694ff5e425f49771fe51a819f2ea46f479.log
+++ b/docs/patch_logs/patch_20250728_235001_4bb903694ff5e425f49771fe51a819f2ea46f479.log
@@ -1,0 +1,68 @@
+patch_20250728_235001_4bb903694ff5e425f49771fe51a819f2ea46f479.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 4bb903694ff5e425f49771fe51a819f2ea46f479
+
+=====DIFFSUMMARY=====
+commit 4bb903694ff5e425f49771fe51a819f2ea46f479
+Merge: 97316f8 18ac2c1
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 17:50:01 2025 -0600
+
+    Merge pull request #510 from buymeagoat/codex/implement-wsl-aware-cache_dir-logic
+    
+    Improve WSL cache handling
+
+ docs/TROUBLESHOOTING.md          |  6 ++++--
+ docs/scripts_reference.md        |  8 ++++++++
+ scripts/diagnose_containers.sh   |  7 +++----
+ scripts/docker_build.sh          |  6 +-----
+ scripts/prestage_dependencies.sh | 11 ++---------
+ scripts/shared_checks.sh         | 23 +++++++++++++++++++----
+ scripts/start_containers.sh      |  6 +-----
+ scripts/update_images.sh         |  6 +-----
+ 8 files changed, 39 insertions(+), 34 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T23:50:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4bb903694ff5e425f49771fe51a819f2ea46f479
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_002536_e2b910cf4a6af0c51ca15a9e730665ca901f676b.log
+++ b/docs/patch_logs/patch_20250729_002536_e2b910cf4a6af0c51ca15a9e730665ca901f676b.log
@@ -1,0 +1,60 @@
+patch_20250729_002536_e2b910cf4a6af0c51ca15a9e730665ca901f676b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit e2b910cf4a6af0c51ca15a9e730665ca901f676b
+
+=====DIFFSUMMARY=====
+commit e2b910cf4a6af0c51ca15a9e730665ca901f676b
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 18:25:36 2025 -0600
+
+    Add cache dir diagnostic script
+
+ docs/scripts_reference.md  |  1 +
+ scripts/check_cache_env.sh | 33 +++++++++++++++++++++++++++++++++
+ scripts/shared_checks.sh   |  3 +++
+ 3 files changed, 37 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-29T00:25:36Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e2b910cf4a6af0c51ca15a9e730665ca901f676b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_002546_1e74865ed988f32e6b90751eaf2bce8a6f584314.log
+++ b/docs/patch_logs/patch_20250729_002546_1e74865ed988f32e6b90751eaf2bce8a6f584314.log
@@ -1,0 +1,63 @@
+patch_20250729_002546_1e74865ed988f32e6b90751eaf2bce8a6f584314.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 1e74865ed988f32e6b90751eaf2bce8a6f584314
+
+=====DIFFSUMMARY=====
+commit 1e74865ed988f32e6b90751eaf2bce8a6f584314
+Merge: 4bb9036 e2b910c
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 18:25:46 2025 -0600
+
+    Merge pull request #511 from buymeagoat/4fpsi7-codex/add-diagnostic-script-for-cache_dir-verification
+    
+    Add cache dir diagnostic script
+
+ docs/scripts_reference.md  |  1 +
+ scripts/check_cache_env.sh | 33 +++++++++++++++++++++++++++++++++
+ scripts/shared_checks.sh   |  3 +++
+ 3 files changed, 37 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-29T00:25:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+1e74865ed988f32e6b90751eaf2bce8a6f584314
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_003738_f87985b31bcc19df9bf13ced2555f56e70d2bc1d.log
+++ b/docs/patch_logs/patch_20250729_003738_f87985b31bcc19df9bf13ced2555f56e70d2bc1d.log
@@ -1,0 +1,60 @@
+patch_20250729_003738_f87985b31bcc19df9bf13ced2555f56e70d2bc1d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit f87985b31bcc19df9bf13ced2555f56e70d2bc1d
+
+=====DIFFSUMMARY=====
+commit f87985b31bcc19df9bf13ced2555f56e70d2bc1d
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 18:37:38 2025 -0600
+
+    docs: add Codex markers for cache logic
+
+ docs/TROUBLESHOOTING.md   | 2 +-
+ docs/scripts_reference.md | 2 +-
+ scripts/shared_checks.sh  | 7 ++++---
+ 3 files changed, 6 insertions(+), 5 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T00:37:38Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f87985b31bcc19df9bf13ced2555f56e70d2bc1d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_003751_fced3a40d3ae4a78aba440dd343edc70d27609e3.log
+++ b/docs/patch_logs/patch_20250729_003751_fced3a40d3ae4a78aba440dd343edc70d27609e3.log
@@ -1,0 +1,63 @@
+patch_20250729_003751_fced3a40d3ae4a78aba440dd343edc70d27609e3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit fced3a40d3ae4a78aba440dd343edc70d27609e3
+
+=====DIFFSUMMARY=====
+commit fced3a40d3ae4a78aba440dd343edc70d27609e3
+Merge: 1e74865 f87985b
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 18:37:51 2025 -0600
+
+    Merge pull request #512 from buymeagoat/codex/add-codex-validation-markers-in-scripts
+    
+    Add Codex validation markers for cache docs
+
+ docs/TROUBLESHOOTING.md   | 2 +-
+ docs/scripts_reference.md | 2 +-
+ scripts/shared_checks.sh  | 7 ++++---
+ 3 files changed, 6 insertions(+), 5 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T00:37:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fced3a40d3ae4a78aba440dd343edc70d27609e3
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_011137_71720608982bbd623d5b97aa0da437c193884d02.log
+++ b/docs/patch_logs/patch_20250729_011137_71720608982bbd623d5b97aa0da437c193884d02.log
@@ -1,0 +1,69 @@
+patch_20250729_011137_71720608982bbd623d5b97aa0da437c193884d02.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 71720608982bbd623d5b97aa0da437c193884d02
+
+=====DIFFSUMMARY=====
+commit 71720608982bbd623d5b97aa0da437c193884d02
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 19:11:37 2025 -0600
+
+    refactor: unify build script
+
+ docs/TROUBLESHOOTING.md          |   9 +-
+ docs/design_scope.md             |   6 +-
+ docs/faq.md                      |   2 +-
+ docs/log_reference.md            |  20 +--
+ docs/onboarding.md               |   2 +-
+ docs/scripts_reference.md        |   8 +-
+ docs/upgrade.md                  |   6 +-
+ scripts/docker_build.sh          | 272 +--------------------------------------
+ scripts/prestage_dependencies.sh | 272 +--------------------------------------
+ scripts/start_containers.sh      | 192 +--------------------------
+ scripts/update_images.sh         | 159 +----------------------
+ scripts/whisper_build.sh         | 208 ++++++++++++++++++++++++++++++
+ 12 files changed, 241 insertions(+), 915 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T01:11:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+71720608982bbd623d5b97aa0da437c193884d02
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_011202_580e9f5dc445c991312b77312f8a478398149029.log
+++ b/docs/patch_logs/patch_20250729_011202_580e9f5dc445c991312b77312f8a478398149029.log
@@ -1,0 +1,72 @@
+patch_20250729_011202_580e9f5dc445c991312b77312f8a478398149029.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 580e9f5dc445c991312b77312f8a478398149029
+
+=====DIFFSUMMARY=====
+commit 580e9f5dc445c991312b77312f8a478398149029
+Merge: fced3a4 7172060
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 19:12:02 2025 -0600
+
+    Merge pull request #513 from buymeagoat/1ozqb1-codex/refactor-build-system-to-use-whisper_build.sh
+    
+    Unify build process into whisper_build.sh
+
+ docs/TROUBLESHOOTING.md          |   9 +-
+ docs/design_scope.md             |   6 +-
+ docs/faq.md                      |   2 +-
+ docs/log_reference.md            |  20 +--
+ docs/onboarding.md               |   2 +-
+ docs/scripts_reference.md        |   8 +-
+ docs/upgrade.md                  |   6 +-
+ scripts/docker_build.sh          | 272 +--------------------------------------
+ scripts/prestage_dependencies.sh | 272 +--------------------------------------
+ scripts/start_containers.sh      | 192 +--------------------------
+ scripts/update_images.sh         | 159 +----------------------
+ scripts/whisper_build.sh         | 208 ++++++++++++++++++++++++++++++
+ 12 files changed, 241 insertions(+), 915 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T01:12:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+580e9f5dc445c991312b77312f8a478398149029
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_015855_c85b4d6acde64fa83778a1014993685c0e935a20.log
+++ b/docs/patch_logs/patch_20250729_015855_c85b4d6acde64fa83778a1014993685c0e935a20.log
@@ -1,0 +1,65 @@
+patch_20250729_015855_c85b4d6acde64fa83778a1014993685c0e935a20.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit c85b4d6acde64fa83778a1014993685c0e935a20
+
+=====DIFFSUMMARY=====
+commit c85b4d6acde64fa83778a1014993685c0e935a20
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 19:58:55 2025 -0600
+
+    docs: unify build instructions
+
+ docs/CHANGELOG.md         | 8 ++++++++
+ docs/TROUBLESHOOTING.md   | 4 ++++
+ docs/design_scope.md      | 2 +-
+ docs/future_updates.md    | 4 ++--
+ docs/index.md             | 4 ++++
+ docs/log_reference.md     | 6 +++---
+ docs/scripts_reference.md | 2 +-
+ scripts/whisper_build.sh  | 6 +++---
+ 8 files changed, 26 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T01:58:55Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c85b4d6acde64fa83778a1014993685c0e935a20
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_015905_8e112f649e155760033b12a7f78e5f6ce98af578.log
+++ b/docs/patch_logs/patch_20250729_015905_8e112f649e155760033b12a7f78e5f6ce98af578.log
@@ -1,0 +1,68 @@
+patch_20250729_015905_8e112f649e155760033b12a7f78e5f6ce98af578.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 8e112f649e155760033b12a7f78e5f6ce98af578
+
+=====DIFFSUMMARY=====
+commit 8e112f649e155760033b12a7f78e5f6ce98af578
+Merge: 580e9f5 c85b4d6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Mon Jul 28 19:59:05 2025 -0600
+
+    Merge pull request #514 from buymeagoat/codex/update-documentation-for-whisper_build.sh
+    
+    Unify build docs around whisper_build.sh
+
+ docs/CHANGELOG.md         | 8 ++++++++
+ docs/TROUBLESHOOTING.md   | 4 ++++
+ docs/design_scope.md      | 2 +-
+ docs/future_updates.md    | 4 ++--
+ docs/index.md             | 4 ++++
+ docs/log_reference.md     | 6 +++---
+ docs/scripts_reference.md | 2 +-
+ scripts/whisper_build.sh  | 6 +++---
+ 8 files changed, 26 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T01:59:05Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8e112f649e155760033b12a7f78e5f6ce98af578
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_134333_7d44d09fcd0b5a6df9df719b0f90666af5dbc94a.log
+++ b/docs/patch_logs/patch_20250729_134333_7d44d09fcd0b5a6df9df719b0f90666af5dbc94a.log
@@ -1,0 +1,65 @@
+patch_20250729_134333_7d44d09fcd0b5a6df9df719b0f90666af5dbc94a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 7d44d09fcd0b5a6df9df719b0f90666af5dbc94a
+
+=====DIFFSUMMARY=====
+commit 7d44d09fcd0b5a6df9df719b0f90666af5dbc94a
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 07:43:33 2025 -0600
+
+    Remove legacy build scripts
+
+ README.md                        |  2 ++
+ docs/CHANGELOG.md                |  8 ++++++++
+ docs/design_scope.md             |  2 +-
+ docs/log_reference.md            | 10 ----------
+ docs/scripts_reference.md        |  1 -
+ scripts/docker_build.sh          |  5 -----
+ scripts/prestage_dependencies.sh |  5 -----
+ scripts/whisper_build.sh         |  2 ++
+ 8 files changed, 13 insertions(+), 22 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T13:43:33Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7d44d09fcd0b5a6df9df719b0f90666af5dbc94a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_134345_738066c79ed13979c5e262010f576987974d8e5c.log
+++ b/docs/patch_logs/patch_20250729_134345_738066c79ed13979c5e262010f576987974d8e5c.log
@@ -1,0 +1,68 @@
+patch_20250729_134345_738066c79ed13979c5e262010f576987974d8e5c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 738066c79ed13979c5e262010f576987974d8e5c
+
+=====DIFFSUMMARY=====
+commit 738066c79ed13979c5e262010f576987974d8e5c
+Merge: 8e112f6 7d44d09
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 07:43:45 2025 -0600
+
+    Merge pull request #515 from buymeagoat/codex/remove-legacy-build-scripts-and-references
+    
+    Remove legacy build scripts
+
+ README.md                        |  2 ++
+ docs/CHANGELOG.md                |  8 ++++++++
+ docs/design_scope.md             |  2 +-
+ docs/log_reference.md            | 10 ----------
+ docs/scripts_reference.md        |  1 -
+ scripts/docker_build.sh          |  5 -----
+ scripts/prestage_dependencies.sh |  5 -----
+ scripts/whisper_build.sh         |  2 ++
+ 8 files changed, 13 insertions(+), 22 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T13:43:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+738066c79ed13979c5e262010f576987974d8e5c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_141254_750a945a8f5e6b6d4cb5257e8e9677e8806e644b.log
+++ b/docs/patch_logs/patch_20250729_141254_750a945a8f5e6b6d4cb5257e8e9677e8806e644b.log
@@ -1,0 +1,61 @@
+patch_20250729_141254_750a945a8f5e6b6d4cb5257e8e9677e8806e644b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 750a945a8f5e6b6d4cb5257e8e9677e8806e644b
+
+=====DIFFSUMMARY=====
+commit 750a945a8f5e6b6d4cb5257e8e9677e8806e644b
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 08:12:54 2025 -0600
+
+    fix help flag and update base image
+
+ Dockerfile                |  2 +-
+ docs/TROUBLESHOOTING.md   |  5 ++++-
+ docs/scripts_reference.md |  2 +-
+ scripts/whisper_build.sh  | 31 ++++++++++++++++++++++---------
+ 4 files changed, 28 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T14:12:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+750a945a8f5e6b6d4cb5257e8e9677e8806e644b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_141322_49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a.log
+++ b/docs/patch_logs/patch_20250729_141322_49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a.log
@@ -1,0 +1,64 @@
+patch_20250729_141322_49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a
+
+=====DIFFSUMMARY=====
+commit 49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a
+Merge: 738066c 750a945
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 08:13:22 2025 -0600
+
+    Merge pull request #516 from buymeagoat/codex/fix-whisper_build.sh-for-help-handling
+    
+    Fix help switch and base image
+
+ Dockerfile                |  2 +-
+ docs/TROUBLESHOOTING.md   |  5 ++++-
+ docs/scripts_reference.md |  2 +-
+ scripts/whisper_build.sh  | 31 ++++++++++++++++++++++---------
+ 4 files changed, 28 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T14:13:22Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+49f4f69b754d710b6ea98db4ebdf92e5fad2fb3a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_143803_8911c234441faace83ffc2a4d9817cdde967f89e.log
+++ b/docs/patch_logs/patch_20250729_143803_8911c234441faace83ffc2a4d9817cdde967f89e.log
@@ -1,0 +1,58 @@
+patch_20250729_143803_8911c234441faace83ffc2a4d9817cdde967f89e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 8911c234441faace83ffc2a4d9817cdde967f89e
+
+=====DIFFSUMMARY=====
+commit 8911c234441faace83ffc2a4d9817cdde967f89e
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 08:38:03 2025 -0600
+
+    chore: drop unused usage helper
+
+ scripts/whisper_build.sh | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T14:38:03Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8911c234441faace83ffc2a4d9817cdde967f89e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_143813_9e20b6251baa4534d357299ca54421114c84bdfa.log
+++ b/docs/patch_logs/patch_20250729_143813_9e20b6251baa4534d357299ca54421114c84bdfa.log
@@ -1,0 +1,61 @@
+patch_20250729_143813_9e20b6251baa4534d357299ca54421114c84bdfa.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 9e20b6251baa4534d357299ca54421114c84bdfa
+
+=====DIFFSUMMARY=====
+commit 9e20b6251baa4534d357299ca54421114c84bdfa
+Merge: 49f4f69 8911c23
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 08:38:13 2025 -0600
+
+    Merge pull request #517 from buymeagoat/codex/remove-unused-usage-function-from-whisper_build.sh
+    
+    Remove unused usage helper
+
+ scripts/whisper_build.sh | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T14:38:13Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9e20b6251baa4534d357299ca54421114c84bdfa
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_150139_68ecb39a0576d8fcc0a7b268ff49cd1af1296b08.log
+++ b/docs/patch_logs/patch_20250729_150139_68ecb39a0576d8fcc0a7b268ff49cd1af1296b08.log
@@ -1,0 +1,58 @@
+patch_20250729_150139_68ecb39a0576d8fcc0a7b268ff49cd1af1296b08.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 68ecb39a0576d8fcc0a7b268ff49cd1af1296b08
+
+=====DIFFSUMMARY=====
+commit 68ecb39a0576d8fcc0a7b268ff49cd1af1296b08
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 09:01:39 2025 -0600
+
+    feat: add modular build modes
+
+ scripts/whisper_build.sh | 123 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 113 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T15:01:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+68ecb39a0576d8fcc0a7b268ff49cd1af1296b08
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_150249_cf3e4cd07ba058a5e944778639d1efd47540e718.log
+++ b/docs/patch_logs/patch_20250729_150249_cf3e4cd07ba058a5e944778639d1efd47540e718.log
@@ -1,0 +1,61 @@
+patch_20250729_150249_cf3e4cd07ba058a5e944778639d1efd47540e718.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit cf3e4cd07ba058a5e944778639d1efd47540e718
+
+=====DIFFSUMMARY=====
+commit cf3e4cd07ba058a5e944778639d1efd47540e718
+Merge: 9e20b62 68ecb39
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 09:02:49 2025 -0600
+
+    Merge pull request #518 from buymeagoat/codex/extend-whisper_build.sh-for-modular-builds
+    
+    Add modular build modes
+
+ scripts/whisper_build.sh | 123 +++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 113 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T15:02:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cf3e4cd07ba058a5e944778639d1efd47540e718
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_215133_dd9f903f5d742d8e2f49c876778b6c11869fdad8.log
+++ b/docs/patch_logs/patch_20250729_215133_dd9f903f5d742d8e2f49c876778b6c11869fdad8.log
@@ -1,0 +1,60 @@
+patch_20250729_215133_dd9f903f5d742d8e2f49c876778b6c11869fdad8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit dd9f903f5d742d8e2f49c876778b6c11869fdad8
+
+=====DIFFSUMMARY=====
+commit dd9f903f5d742d8e2f49c876778b6c11869fdad8
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 15:51:33 2025 -0600
+
+    docs: add modular build switches
+
+ docs/CHANGELOG.md         |  6 ++++++
+ docs/index.md             |  2 +-
+ docs/scripts_reference.md | 21 ++++++++++++++++++++-
+ 3 files changed, 27 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T21:51:33Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+dd9f903f5d742d8e2f49c876778b6c11869fdad8
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_215223_b3995a5c567b2d793856b7121bc3d34d54510afa.log
+++ b/docs/patch_logs/patch_20250729_215223_b3995a5c567b2d793856b7121bc3d34d54510afa.log
@@ -1,0 +1,63 @@
+patch_20250729_215223_b3995a5c567b2d793856b7121bc3d34d54510afa.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit b3995a5c567b2d793856b7121bc3d34d54510afa
+
+=====DIFFSUMMARY=====
+commit b3995a5c567b2d793856b7121bc3d34d54510afa
+Merge: cf3e4cd dd9f903
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 15:52:23 2025 -0600
+
+    Merge pull request #519 from buymeagoat/codex/update-documentation-and-changelog-for-modular-builds
+    
+    Update docs for modular build flags
+
+ docs/CHANGELOG.md         |  6 ++++++
+ docs/index.md             |  2 +-
+ docs/scripts_reference.md | 21 ++++++++++++++++++++-
+ 3 files changed, 27 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T21:52:23Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b3995a5c567b2d793856b7121bc3d34d54510afa
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_223829_56cef304ce56e64688db0a09051033d4c201af5b.log
+++ b/docs/patch_logs/patch_20250729_223829_56cef304ce56e64688db0a09051033d4c201af5b.log
@@ -1,0 +1,59 @@
+patch_20250729_223829_56cef304ce56e64688db0a09051033d4c201af5b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 56cef304ce56e64688db0a09051033d4c201af5b
+
+=====DIFFSUMMARY=====
+commit 56cef304ce56e64688db0a09051033d4c201af5b
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 16:38:29 2025 -0600
+
+    docs: clarify full rebuild
+
+ docs/scripts_reference.md | 4 ++--
+ scripts/whisper_build.sh  | 3 +++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T22:38:29Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+56cef304ce56e64688db0a09051033d4c201af5b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_223841_2b215185332cb4841e89b73cfc6d553a86c81263.log
+++ b/docs/patch_logs/patch_20250729_223841_2b215185332cb4841e89b73cfc6d553a86c81263.log
@@ -1,0 +1,62 @@
+patch_20250729_223841_2b215185332cb4841e89b73cfc6d553a86c81263.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 2b215185332cb4841e89b73cfc6d553a86c81263
+
+=====DIFFSUMMARY=====
+commit 2b215185332cb4841e89b73cfc6d553a86c81263
+Merge: b3995a5 56cef30
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 16:38:41 2025 -0600
+
+    Merge pull request #520 from buymeagoat/codex/update-docs-for-rebuild-behavior
+    
+    Clarify full rebuild workflow
+
+ docs/scripts_reference.md | 4 ++--
+ scripts/whisper_build.sh  | 3 +++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-29T22:38:41Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2b215185332cb4841e89b73cfc6d553a86c81263
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250729_224157_6a4efd63cf606dec1b78acab93365ca4adca5cac.log
+++ b/docs/patch_logs/patch_20250729_224157_6a4efd63cf606dec1b78acab93365ca4adca5cac.log
@@ -1,0 +1,58 @@
+patch_20250729_224157_6a4efd63cf606dec1b78acab93365ca4adca5cac.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 6a4efd63cf606dec1b78acab93365ca4adca5cac
+
+=====DIFFSUMMARY=====
+commit 6a4efd63cf606dec1b78acab93365ca4adca5cac
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 16:41:57 2025 -0600
+
+    Update frontend-only flag description
+
+ docs/scripts_reference.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-29T22:41:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6a4efd63cf606dec1b78acab93365ca4adca5cac
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_022120_e7688eb802b1581807faf42284a4d97b0730a2e2.log
+++ b/docs/patch_logs/patch_20250730_022120_e7688eb802b1581807faf42284a4d97b0730a2e2.log
@@ -1,0 +1,58 @@
+patch_20250730_022120_e7688eb802b1581807faf42284a4d97b0730a2e2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit e7688eb802b1581807faf42284a4d97b0730a2e2
+
+=====DIFFSUMMARY=====
+commit e7688eb802b1581807faf42284a4d97b0730a2e2
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 20:21:20 2025 -0600
+
+    Add cleanup log step
+
+ scripts/whisper_build.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T02:21:20Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e7688eb802b1581807faf42284a4d97b0730a2e2
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_022134_27ddbd082320540d995b0315eb45f655875917f0.log
+++ b/docs/patch_logs/patch_20250730_022134_27ddbd082320540d995b0315eb45f655875917f0.log
@@ -1,0 +1,61 @@
+patch_20250730_022134_27ddbd082320540d995b0315eb45f655875917f0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 27ddbd082320540d995b0315eb45f655875917f0
+
+=====DIFFSUMMARY=====
+commit 27ddbd082320540d995b0315eb45f655875917f0
+Merge: 2b21518 e7688eb
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 20:21:34 2025 -0600
+
+    Merge pull request #522 from buymeagoat/codex/add-log_step-for-docker_cleanup
+    
+    Add cleanup log step
+
+ scripts/whisper_build.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T02:21:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+27ddbd082320540d995b0315eb45f655875917f0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_041714_b70f65f19a512308b1778581ff58b1b406c578dc.log
+++ b/docs/patch_logs/patch_20250730_041714_b70f65f19a512308b1778581ff58b1b406c578dc.log
@@ -1,0 +1,58 @@
+patch_20250730_041714_b70f65f19a512308b1778581ff58b1b406c578dc.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit b70f65f19a512308b1778581ff58b1b406c578dc
+
+=====DIFFSUMMARY=====
+commit b70f65f19a512308b1778581ff58b1b406c578dc
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 22:17:14 2025 -0600
+
+    Validate single mode flag
+
+ scripts/whisper_build.sh | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T04:17:14Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b70f65f19a512308b1778581ff58b1b406c578dc
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_041725_78d155d85fdf54f9605490381051199556bcd528.log
+++ b/docs/patch_logs/patch_20250730_041725_78d155d85fdf54f9605490381051199556bcd528.log
@@ -1,0 +1,61 @@
+patch_20250730_041725_78d155d85fdf54f9605490381051199556bcd528.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 78d155d85fdf54f9605490381051199556bcd528
+
+=====DIFFSUMMARY=====
+commit 78d155d85fdf54f9605490381051199556bcd528
+Merge: 27ddbd0 b70f65f
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Tue Jul 29 22:17:25 2025 -0600
+
+    Merge pull request #523 from buymeagoat/codex/add-mode-flag-validation
+    
+    Enforce single build mode flag
+
+ scripts/whisper_build.sh | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T04:17:25Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+78d155d85fdf54f9605490381051199556bcd528
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_115124_7e96e47bd3692ea5ab0aa98de360651ea436e082.log
+++ b/docs/patch_logs/patch_20250730_115124_7e96e47bd3692ea5ab0aa98de360651ea436e082.log
@@ -1,0 +1,58 @@
+patch_20250730_115124_7e96e47bd3692ea5ab0aa98de360651ea436e082.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 7e96e47bd3692ea5ab0aa98de360651ea436e082
+
+=====DIFFSUMMARY=====
+commit 7e96e47bd3692ea5ab0aa98de360651ea436e082
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 05:51:24 2025 -0600
+
+    log environment check
+
+ scripts/whisper_build.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T11:51:24Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7e96e47bd3692ea5ab0aa98de360651ea436e082
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_115144_db8f7bb74de70ad4857c4c12fa07477cc512cf88.log
+++ b/docs/patch_logs/patch_20250730_115144_db8f7bb74de70ad4857c4c12fa07477cc512cf88.log
@@ -1,0 +1,61 @@
+patch_20250730_115144_db8f7bb74de70ad4857c4c12fa07477cc512cf88.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit db8f7bb74de70ad4857c4c12fa07477cc512cf88
+
+=====DIFFSUMMARY=====
+commit db8f7bb74de70ad4857c4c12fa07477cc512cf88
+Merge: 78d155d 7e96e47
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 05:51:44 2025 -0600
+
+    Merge pull request #524 from buymeagoat/codex/redirect-stdout/stderr-in-check_env.sh
+    
+    Fix build log ordering
+
+ scripts/whisper_build.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T11:51:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+db8f7bb74de70ad4857c4c12fa07477cc512cf88
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_144018_bf45231f3d07227d302174813996dae1299e3af6.log
+++ b/docs/patch_logs/patch_20250730_144018_bf45231f3d07227d302174813996dae1299e3af6.log
@@ -1,0 +1,58 @@
+patch_20250730_144018_bf45231f3d07227d302174813996dae1299e3af6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit bf45231f3d07227d302174813996dae1299e3af6
+
+=====DIFFSUMMARY=====
+commit bf45231f3d07227d302174813996dae1299e3af6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 08:40:18 2025 -0600
+
+    fix build modes and logging
+
+ scripts/whisper_build.sh | 78 ++++++++++++++++++++++++++----------------------
+ 1 file changed, 43 insertions(+), 35 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-30T14:40:18Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bf45231f3d07227d302174813996dae1299e3af6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_144037_23ceb224ce9ef7ce6d22f2353a79a74cda191fd9.log
+++ b/docs/patch_logs/patch_20250730_144037_23ceb224ce9ef7ce6d22f2353a79a74cda191fd9.log
@@ -1,0 +1,61 @@
+patch_20250730_144037_23ceb224ce9ef7ce6d22f2353a79a74cda191fd9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 23ceb224ce9ef7ce6d22f2353a79a74cda191fd9
+
+=====DIFFSUMMARY=====
+commit 23ceb224ce9ef7ce6d22f2353a79a74cda191fd9
+Merge: db8f7bb bf45231
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 08:40:37 2025 -0600
+
+    Merge pull request #525 from buymeagoat/codex/patch-whisper_build.sh-for-build-mode-fixes
+    
+    Fix whisper_build build mode logic
+
+ scripts/whisper_build.sh | 78 ++++++++++++++++++++++++++----------------------
+ 1 file changed, 43 insertions(+), 35 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-30T14:40:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+23ceb224ce9ef7ce6d22f2353a79a74cda191fd9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_154732_bf44123148a3446eca22778edb79ca5969e2f2b6.log
+++ b/docs/patch_logs/patch_20250730_154732_bf44123148a3446eca22778edb79ca5969e2f2b6.log
@@ -1,0 +1,61 @@
+patch_20250730_154732_bf44123148a3446eca22778edb79ca5969e2f2b6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit bf44123148a3446eca22778edb79ca5969e2f2b6
+
+=====DIFFSUMMARY=====
+commit bf44123148a3446eca22778edb79ca5969e2f2b6
+Merge: 23ceb22 6a4efd6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 09:47:32 2025 -0600
+
+    Merge pull request #521 from buymeagoat/codex/modify-docker_build_frontend-for-frontend-only
+    
+    Clarify frontend-only flag behavior
+
+ docs/scripts_reference.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T15:47:32Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bf44123148a3446eca22778edb79ca5969e2f2b6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_161017_d7746fe4641db7474f6391d63c6477f61d6f4b78.log
+++ b/docs/patch_logs/patch_20250730_161017_d7746fe4641db7474f6391d63c6477f61d6f4b78.log
@@ -1,0 +1,58 @@
+patch_20250730_161017_d7746fe4641db7474f6391d63c6477f61d6f4b78.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit d7746fe4641db7474f6391d63c6477f61d6f4b78
+
+=====DIFFSUMMARY=====
+commit d7746fe4641db7474f6391d63c6477f61d6f4b78
+Author: buymeagoat <akapinos@gmail.com>
+Date:   Wed Jul 30 11:09:29 2025 -0500
+
+    Track package-lock.json for frontend dependency locking
+
+ frontend/package-lock.json | 6710 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 6710 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T16:10:17Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d7746fe4641db7474f6391d63c6477f61d6f4b78
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_161017_fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1.log
+++ b/docs/patch_logs/patch_20250730_161017_fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1.log
@@ -1,0 +1,58 @@
+patch_20250730_161017_fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1
+
+=====DIFFSUMMARY=====
+commit fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1
+Author: buymeagoat <akapinos@gmail.com>
+Date:   Wed Jul 30 11:02:59 2025 -0500
+
+    Add initial version of repo_audit.py for filtered audits
+
+ scripts/repo_audit.py | 73 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 73 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T16:10:17Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fe1c268250913be1ecdd3651ac4bb73d5dd8cdf1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_161304_a4d54bbdcccfdf2263fa876542b75e526ff118e2.log
+++ b/docs/patch_logs/patch_20250730_161304_a4d54bbdcccfdf2263fa876542b75e526ff118e2.log
@@ -1,0 +1,58 @@
+patch_20250730_161304_a4d54bbdcccfdf2263fa876542b75e526ff118e2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit a4d54bbdcccfdf2263fa876542b75e526ff118e2
+
+=====DIFFSUMMARY=====
+commit a4d54bbdcccfdf2263fa876542b75e526ff118e2
+Author: buymeagoat <akapinos@gmail.com>
+Date:   Wed Jul 30 11:13:04 2025 -0500
+
+    Restore uploads/.gitkeep and commit .gitignore update
+
+ .gitignore | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T16:13:04Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a4d54bbdcccfdf2263fa876542b75e526ff118e2
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_161914_71c1794183561734a1daa0b6eb9743303c5ebdff.log
+++ b/docs/patch_logs/patch_20250730_161914_71c1794183561734a1daa0b6eb9743303c5ebdff.log
@@ -1,0 +1,61 @@
+patch_20250730_161914_71c1794183561734a1daa0b6eb9743303c5ebdff.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 71c1794183561734a1daa0b6eb9743303c5ebdff
+
+=====DIFFSUMMARY=====
+commit 71c1794183561734a1daa0b6eb9743303c5ebdff
+Author: buymeagoat <akapinos@gmail.com>
+Date:   Wed Jul 30 11:19:14 2025 -0500
+
+    Preserve runtime directories with .gitkeep anchors
+
+ .gitignore      | 12 ++++++++++++
+ cache/.gitkeep  |  0
+ logs/.gitkeep   |  0
+ models/.gitkeep |  0
+ 4 files changed, 12 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T16:19:14Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+71c1794183561734a1daa0b6eb9743303c5ebdff
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_163607_cd21e948a71322200755b9cd0730a67777941b99.log
+++ b/docs/patch_logs/patch_20250730_163607_cd21e948a71322200755b9cd0730a67777941b99.log
@@ -1,0 +1,60 @@
+patch_20250730_163607_cd21e948a71322200755b9cd0730a67777941b99.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit cd21e948a71322200755b9cd0730a67777941b99
+
+=====DIFFSUMMARY=====
+commit cd21e948a71322200755b9cd0730a67777941b99
+Author: buymeagoat <akapinos@gmail.com>
+Date:   Wed Jul 30 11:36:07 2025 -0500
+
+    Replace repo_audit.py with dual_repo_audit.py; add setup_runtime_dirs.sh
+
+ scripts/dual_repo_audit.py    | 103 ++++++++++++++++++++++++++++++++++++++++++
+ scripts/repo_audit.py         |  73 ------------------------------
+ scripts/setup_runtime_dirs.sh |  74 ++++++++++++++++++++++++++++++
+ 3 files changed, 177 insertions(+), 73 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-30T16:36:07Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cd21e948a71322200755b9cd0730a67777941b99
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_182628_0bc4997010d13ac60768289b5f3fb509dcf4f221.log
+++ b/docs/patch_logs/patch_20250730_182628_0bc4997010d13ac60768289b5f3fb509dcf4f221.log
@@ -1,0 +1,58 @@
+patch_20250730_182628_0bc4997010d13ac60768289b5f3fb509dcf4f221.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 0bc4997010d13ac60768289b5f3fb509dcf4f221
+
+=====DIFFSUMMARY=====
+commit 0bc4997010d13ac60768289b5f3fb509dcf4f221
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 13:26:28 2025 -0500
+
+    Create 20250730_1326_CAGchat.log
+
+ docs/CodexAnalystGPTchats/20250730_1326_CAGchat.log | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T18:26:28Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0bc4997010d13ac60768289b5f3fb509dcf4f221
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_182644_26296e43417596a04f22ce46f114520ea7cba52d.log
+++ b/docs/patch_logs/patch_20250730_182644_26296e43417596a04f22ce46f114520ea7cba52d.log
@@ -1,0 +1,58 @@
+patch_20250730_182644_26296e43417596a04f22ce46f114520ea7cba52d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 26296e43417596a04f22ce46f114520ea7cba52d
+
+=====DIFFSUMMARY=====
+commit 26296e43417596a04f22ce46f114520ea7cba52d
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 13:26:44 2025 -0500
+
+    Update 20250730_1326_CAGchat.log
+
+ .../CodexAnalystGPTchats/20250730_1326_CAGchat.log | 1055 ++++++++++++++++++++
+ 1 file changed, 1055 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T18:26:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+26296e43417596a04f22ce46f114520ea7cba52d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_182728_ac721b4faa272c8ad85d8d2f772ee13d31839bf1.log
+++ b/docs/patch_logs/patch_20250730_182728_ac721b4faa272c8ad85d8d2f772ee13d31839bf1.log
@@ -1,0 +1,58 @@
+patch_20250730_182728_ac721b4faa272c8ad85d8d2f772ee13d31839bf1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit ac721b4faa272c8ad85d8d2f772ee13d31839bf1
+
+=====DIFFSUMMARY=====
+commit ac721b4faa272c8ad85d8d2f772ee13d31839bf1
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 13:27:28 2025 -0500
+
+    Create start.txt
+
+ docs/patch_logs/start.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T18:27:28Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ac721b4faa272c8ad85d8d2f772ee13d31839bf1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_182754_b4681e84a96501d7521ab5ef76c6344f52695c90.log
+++ b/docs/patch_logs/patch_20250730_182754_b4681e84a96501d7521ab5ef76c6344f52695c90.log
@@ -1,0 +1,68 @@
+patch_20250730_182754_b4681e84a96501d7521ab5ef76c6344f52695c90.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit b4681e84a96501d7521ab5ef76c6344f52695c90
+
+=====DIFFSUMMARY=====
+commit b4681e84a96501d7521ab5ef76c6344f52695c90
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 12:27:54 2025 -0600
+
+    Add files via upload
+
+ docs/patch_logs/patch_20250728_1852.txt |  832 +++++++
+ docs/patch_logs/patch_20250728_1918.txt |  672 +++++
+ docs/patch_logs/patch_20250728_2008.txt | 1875 ++++++++++++++
+ docs/patch_logs/patch_20250728_2022.txt |  921 +++++++
+ docs/patch_logs/patch_20250728_2058.txt |  583 +++++
+ docs/patch_logs/patch_20250729_0910.txt |  445 ++++
+ docs/patch_logs/patch_20250729_0930.txt |  212 ++
+ docs/patch_logs/patch_20250729_0942.txt |  539 +++++
+ docs/patch_logs/patch_20250729_1004.txt |  288 +++
+ docs/patch_logs/patch_20250729_1730.txt |   97 +
+ docs/patch_logs/patch_20250730_0938.txt | 4040 +++++++++++++++++++++++++++++++
+ 11 files changed, 10504 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T18:27:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b4681e84a96501d7521ab5ef76c6344f52695c90
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_192040_81fcfa509867388dd18866338678bf0fd737537c.log
+++ b/docs/patch_logs/patch_20250730_192040_81fcfa509867388dd18866338678bf0fd737537c.log
@@ -1,0 +1,58 @@
+patch_20250730_192040_81fcfa509867388dd18866338678bf0fd737537c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 81fcfa509867388dd18866338678bf0fd737537c
+
+=====DIFFSUMMARY=====
+commit 81fcfa509867388dd18866338678bf0fd737537c
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 13:20:40 2025 -0600
+
+    Update agent role instructions
+
+ AGENTS.md | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T19:20:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+81fcfa509867388dd18866338678bf0fd737537c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_192054_eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea.log
+++ b/docs/patch_logs/patch_20250730_192054_eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea.log
@@ -1,0 +1,61 @@
+patch_20250730_192054_eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea
+
+=====DIFFSUMMARY=====
+commit eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea
+Merge: b4681e8 81fcfa5
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 13:20:54 2025 -0600
+
+    Merge pull request #526 from buymeagoat/codex/update-codex-agent-role-instructions
+    
+    Update AGENTS instructions
+
+ AGENTS.md | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T19:20:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+eeaa8dd7f9a284cf868b0a4017ea12bc987d8cea
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_192741_026f43b4f662562308caea76c95e9478578bb6e4.log
+++ b/docs/patch_logs/patch_20250730_192741_026f43b4f662562308caea76c95e9478578bb6e4.log
@@ -1,0 +1,58 @@
+patch_20250730_192741_026f43b4f662562308caea76c95e9478578bb6e4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 026f43b4f662562308caea76c95e9478578bb6e4
+
+=====DIFFSUMMARY=====
+commit 026f43b4f662562308caea76c95e9478578bb6e4
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:27:41 2025 -0500
+
+    Delete scripts/dual_repo_audit.py
+
+ scripts/dual_repo_audit.py | 103 ---------------------------------------------
+ 1 file changed, 103 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-30T19:27:41Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+026f43b4f662562308caea76c95e9478578bb6e4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_200354_3c453dba027a5a1ea333f983296ec6062ae6dffe.log
+++ b/docs/patch_logs/patch_20250730_200354_3c453dba027a5a1ea333f983296ec6062ae6dffe.log
@@ -1,0 +1,58 @@
+patch_20250730_200354_3c453dba027a5a1ea333f983296ec6062ae6dffe.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 3c453dba027a5a1ea333f983296ec6062ae6dffe
+
+=====DIFFSUMMARY=====
+commit 3c453dba027a5a1ea333f983296ec6062ae6dffe
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:03:54 2025 -0600
+
+    Add placeholder patch log
+
+ docs/patch_logs/test_patch_CAG_placeholder.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T20:03:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3c453dba027a5a1ea333f983296ec6062ae6dffe
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_200418_86496a6af784e90ffec858c72e00a18a331427aa.log
+++ b/docs/patch_logs/patch_20250730_200418_86496a6af784e90ffec858c72e00a18a331427aa.log
@@ -1,0 +1,61 @@
+patch_20250730_200418_86496a6af784e90ffec858c72e00a18a331427aa.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 86496a6af784e90ffec858c72e00a18a331427aa
+
+=====DIFFSUMMARY=====
+commit 86496a6af784e90ffec858c72e00a18a331427aa
+Merge: 026f43b 3c453db
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:04:18 2025 -0600
+
+    Merge pull request #527 from buymeagoat/codex/update-agent-behavior-to-cag-v2.6
+    
+    Add placeholder patch log
+
+ docs/patch_logs/test_patch_CAG_placeholder.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-30T20:04:18Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+86496a6af784e90ffec858c72e00a18a331427aa
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_201808_86fecaadb1241f66634bac7518103aea9e3cc932.log
+++ b/docs/patch_logs/patch_20250730_201808_86fecaadb1241f66634bac7518103aea9e3cc932.log
@@ -1,0 +1,59 @@
+patch_20250730_201808_86fecaadb1241f66634bac7518103aea9e3cc932.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 86fecaadb1241f66634bac7518103aea9e3cc932
+
+=====DIFFSUMMARY=====
+commit 86fecaadb1241f66634bac7518103aea9e3cc932
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:18:08 2025 -0600
+
+    docs: clarify CAG workflow
+
+ README.md                                |  4 ++++
+ frontend/src/components/PatchUploader.js | 11 +++++++++++
+ 2 files changed, 15 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T20:18:08Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+86fecaadb1241f66634bac7518103aea9e3cc932
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_201819_461ebc2cdb1a3c939600755bd634dde5d52dba06.log
+++ b/docs/patch_logs/patch_20250730_201819_461ebc2cdb1a3c939600755bd634dde5d52dba06.log
@@ -1,0 +1,62 @@
+patch_20250730_201819_461ebc2cdb1a3c939600755bd634dde5d52dba06.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 461ebc2cdb1a3c939600755bd634dde5d52dba06
+
+=====DIFFSUMMARY=====
+commit 461ebc2cdb1a3c939600755bd634dde5d52dba06
+Merge: 86496a6 86fecaa
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:18:19 2025 -0600
+
+    Merge pull request #528 from buymeagoat/codex/update-documentation-for-cag-v2.6-architecture
+    
+    Update CAG workflow docs
+
+ README.md                                |  4 ++++
+ frontend/src/components/PatchUploader.js | 11 +++++++++++
+ 2 files changed, 15 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-30T20:18:19Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+461ebc2cdb1a3c939600755bd634dde5d52dba06
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_202306_08806db2c918c44f088cd26d0773710a14f2397b.log
+++ b/docs/patch_logs/patch_20250730_202306_08806db2c918c44f088cd26d0773710a14f2397b.log
@@ -1,0 +1,60 @@
+patch_20250730_202306_08806db2c918c44f088cd26d0773710a14f2397b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 08806db2c918c44f088cd26d0773710a14f2397b
+
+=====DIFFSUMMARY=====
+commit 08806db2c918c44f088cd26d0773710a14f2397b
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:23:06 2025 -0600
+
+    docs: update CAG workflow
+
+ README.md            | 2 +-
+ docs/design_scope.md | 2 ++
+ docs/help.md         | 2 ++
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T20:23:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+08806db2c918c44f088cd26d0773710a14f2397b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_202317_a1464f59aa304b3f26889b0ce1135f3cb832f6c3.log
+++ b/docs/patch_logs/patch_20250730_202317_a1464f59aa304b3f26889b0ce1135f3cb832f6c3.log
@@ -1,0 +1,63 @@
+patch_20250730_202317_a1464f59aa304b3f26889b0ce1135f3cb832f6c3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit a1464f59aa304b3f26889b0ce1135f3cb832f6c3
+
+=====DIFFSUMMARY=====
+commit a1464f59aa304b3f26889b0ce1135f3cb832f6c3
+Merge: 461ebc2 08806db
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:23:17 2025 -0600
+
+    Merge pull request #529 from buymeagoat/codex/remove-deprecated-scripts-from-documentation
+    
+    Remove legacy script mentions from docs
+
+ README.md            | 2 +-
+ docs/design_scope.md | 2 ++
+ docs/help.md         | 2 ++
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T20:23:17Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a1464f59aa304b3f26889b0ce1135f3cb832f6c3
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_204018_a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76.log
+++ b/docs/patch_logs/patch_20250730_204018_a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76.log
@@ -1,0 +1,58 @@
+patch_20250730_204018_a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76
+
+=====DIFFSUMMARY=====
+commit a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:40:18 2025 -0600
+
+    chore: remove placeholder patch file
+
+ docs/patch_logs/test_patch_CAG_placeholder.md | 1 -
+ 1 file changed, 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T20:40:18Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a203ef6bb7ad2c9e6cd867d245a7aff9ee083f76
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250730_205300_088909b2e1875394e2304a57a40e99d57e6d5f03.log
+++ b/docs/patch_logs/patch_20250730_205300_088909b2e1875394e2304a57a40e99d57e6d5f03.log
@@ -1,0 +1,61 @@
+patch_20250730_205300_088909b2e1875394e2304a57a40e99d57e6d5f03.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 088909b2e1875394e2304a57a40e99d57e6d5f03
+
+=====DIFFSUMMARY=====
+commit 088909b2e1875394e2304a57a40e99d57e6d5f03
+Merge: a1464f5 a203ef6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 14:53:00 2025 -0600
+
+    Merge pull request #530 from buymeagoat/codex/remove-placeholder-patch-file
+    
+    Remove unused placeholder patch log
+
+ docs/patch_logs/test_patch_CAG_placeholder.md | 1 -
+ 1 file changed, 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-30T20:53:00Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+088909b2e1875394e2304a57a40e99d57e6d5f03
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_013605_6ade3ca35e899c115d14ef76183b3c96bff15ec6.log
+++ b/docs/patch_logs/patch_20250731_013605_6ade3ca35e899c115d14ef76183b3c96bff15ec6.log
@@ -1,0 +1,58 @@
+patch_20250731_013605_6ade3ca35e899c115d14ef76183b3c96bff15ec6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 6ade3ca35e899c115d14ef76183b3c96bff15ec6
+
+=====DIFFSUMMARY=====
+commit 6ade3ca35e899c115d14ef76183b3c96bff15ec6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 19:36:05 2025 -0600
+
+    chore: improve OS codename mismatch guidance
+
+ scripts/check_env.sh | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T01:36:05Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6ade3ca35e899c115d14ef76183b3c96bff15ec6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_013635_8d831657188ed16ee1b6bc47ee6c4d9496e6db67.log
+++ b/docs/patch_logs/patch_20250731_013635_8d831657188ed16ee1b6bc47ee6c4d9496e6db67.log
@@ -1,0 +1,61 @@
+patch_20250731_013635_8d831657188ed16ee1b6bc47ee6c4d9496e6db67.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 8d831657188ed16ee1b6bc47ee6c4d9496e6db67
+
+=====DIFFSUMMARY=====
+commit 8d831657188ed16ee1b6bc47ee6c4d9496e6db67
+Merge: 088909b 6ade3ca
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Wed Jul 30 19:36:35 2025 -0600
+
+    Merge pull request #531 from buymeagoat/codex/retrieve-project-structure-for-whisper_transcriber
+    
+    Improve OS mismatch warning
+
+ scripts/check_env.sh | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T01:36:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8d831657188ed16ee1b6bc47ee6c4d9496e6db67
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_184417_2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72.log
+++ b/docs/patch_logs/patch_20250731_184417_2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72.log
@@ -1,0 +1,58 @@
+patch_20250731_184417_2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72
+
+=====DIFFSUMMARY=====
+commit 2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Thu Jul 31 12:44:17 2025 -0600
+
+    Update AGENTS guidelines
+
+ AGENTS.md | 101 +++++++++++++++++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 73 insertions(+), 28 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T18:44:17Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2191aec2a8aefc0382d33d6f1fdbc444c1f1ed72
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_184448_bc724a9fb9e5e4a644fa3eeb1a36f2c347983090.log
+++ b/docs/patch_logs/patch_20250731_184448_bc724a9fb9e5e4a644fa3eeb1a36f2c347983090.log
@@ -1,0 +1,61 @@
+patch_20250731_184448_bc724a9fb9e5e4a644fa3eeb1a36f2c347983090.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit bc724a9fb9e5e4a644fa3eeb1a36f2c347983090
+
+=====DIFFSUMMARY=====
+commit bc724a9fb9e5e4a644fa3eeb1a36f2c347983090
+Merge: 8d83165 2191aec
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Thu Jul 31 12:44:48 2025 -0600
+
+    Merge pull request #532 from buymeagoat/codex/revise-agents.md-for-cag-compliance
+    
+    Update AGENTS instructions
+
+ AGENTS.md | 101 +++++++++++++++++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 73 insertions(+), 28 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T18:44:48Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bc724a9fb9e5e4a644fa3eeb1a36f2c347983090
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_190727_1e676f5bc0de089fbd18e8bb26e325e6f7c098e8.log
+++ b/docs/patch_logs/patch_20250731_190727_1e676f5bc0de089fbd18e8bb26e325e6f7c098e8.log
@@ -1,0 +1,59 @@
+patch_20250731_190727_1e676f5bc0de089fbd18e8bb26e325e6f7c098e8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 1e676f5bc0de089fbd18e8bb26e325e6f7c098e8
+
+=====DIFFSUMMARY=====
+commit 1e676f5bc0de089fbd18e8bb26e325e6f7c098e8
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Thu Jul 31 13:07:27 2025 -0600
+
+    chore: add patch log for AGENTS update
+
+ AGENTS.md                                          | 107 ++++++++++-----------
+ ...31_185931_CAG-UpdateAgentsMd-2025-08-01-001.log |  64 ++++++++++++
+ 2 files changed, 117 insertions(+), 54 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T19:07:27Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+1e676f5bc0de089fbd18e8bb26e325e6f7c098e8
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_190739_9af8fde012e989ad51365e299fd9e3da1bb9b3d0.log
+++ b/docs/patch_logs/patch_20250731_190739_9af8fde012e989ad51365e299fd9e3da1bb9b3d0.log
@@ -1,0 +1,62 @@
+patch_20250731_190739_9af8fde012e989ad51365e299fd9e3da1bb9b3d0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 9af8fde012e989ad51365e299fd9e3da1bb9b3d0
+
+=====DIFFSUMMARY=====
+commit 9af8fde012e989ad51365e299fd9e3da1bb9b3d0
+Merge: bc724a9 1e676f5
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Thu Jul 31 13:07:39 2025 -0600
+
+    Merge pull request #533 from buymeagoat/codex/update-agents.md-and-generate-patch-log
+    
+    Update agent instructions and log
+
+ AGENTS.md                                          | 107 ++++++++++-----------
+ ...31_185931_CAG-UpdateAgentsMd-2025-08-01-001.log |  64 ++++++++++++
+ 2 files changed, 117 insertions(+), 54 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T19:07:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9af8fde012e989ad51365e299fd9e3da1bb9b3d0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250731_191224_064a3bb5b1f62b8534d00144160609ba562a2f4e.log
+++ b/docs/patch_logs/patch_20250731_191224_064a3bb5b1f62b8534d00144160609ba562a2f4e.log
@@ -1,0 +1,58 @@
+patch_20250731_191224_064a3bb5b1f62b8534d00144160609ba562a2f4e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 064a3bb5b1f62b8534d00144160609ba562a2f4e
+
+=====DIFFSUMMARY=====
+commit 064a3bb5b1f62b8534d00144160609ba562a2f4e
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Thu Jul 31 14:12:24 2025 -0500
+
+    Rename patch_20250731_185931_CAG-UpdateAgentsMd-2025-08-01-001.log to patch_20250731_1405_CAG-UpdateAgentsMd.log
+
+ ...tsMd-2025-08-01-001.log => patch_20250731_1405_CAG-UpdateAgentsMd.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-31T19:12:24Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+064a3bb5b1f62b8534d00144160609ba562a2f4e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_140756_4749df16a776b507e46ff24d28d2044a58876b21.log
+++ b/docs/patch_logs/patch_20250801_140756_4749df16a776b507e46ff24d28d2044a58876b21.log
@@ -1,0 +1,58 @@
+patch_20250801_140756_4749df16a776b507e46ff24d28d2044a58876b21.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 4749df16a776b507e46ff24d28d2044a58876b21
+
+=====DIFFSUMMARY=====
+commit 4749df16a776b507e46ff24d28d2044a58876b21
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:07:56 2025 -0500
+
+    Update AGENTS.md
+
+ AGENTS.md | 148 +++++++++++++++++++++++++++++++++++++++++++-------------------
+ 1 file changed, 102 insertions(+), 46 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T14:07:56Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4749df16a776b507e46ff24d28d2044a58876b21
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_144851_c9c6931dfc0f32ce93c8a42c594facdccdbc3afd.log
+++ b/docs/patch_logs/patch_20250801_144851_c9c6931dfc0f32ce93c8a42c594facdccdbc3afd.log
@@ -1,0 +1,59 @@
+patch_20250801_144851_c9c6931dfc0f32ce93c8a42c594facdccdbc3afd.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit c9c6931dfc0f32ce93c8a42c594facdccdbc3afd
+
+=====DIFFSUMMARY=====
+commit c9c6931dfc0f32ce93c8a42c594facdccdbc3afd
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 08:48:51 2025 -0600
+
+    Add patch log for guard-rail comment
+
+ AGENTS.md                                          |  1 +
+ ...tch_20250801_144653_CAG-AddGuardRailComment.log | 46 ++++++++++++++++++++++
+ 2 files changed, 47 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T14:48:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c9c6931dfc0f32ce93c8a42c594facdccdbc3afd
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_144948_33e3f642262750ca0f2302d536eae12c6be85410.log
+++ b/docs/patch_logs/patch_20250801_144948_33e3f642262750ca0f2302d536eae12c6be85410.log
@@ -1,0 +1,58 @@
+patch_20250801_144948_33e3f642262750ca0f2302d536eae12c6be85410.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 33e3f642262750ca0f2302d536eae12c6be85410
+
+=====DIFFSUMMARY=====
+commit 33e3f642262750ca0f2302d536eae12c6be85410
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:49:48 2025 -0500
+
+    Rename patch_20250801_144653_CAG-AddGuardRailComment.log to patch_20250801_0949_CAG-AddGuardRailComment.log
+
+ ...ardRailComment.log => patch_20250801_0949_CAG-AddGuardRailComment.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T14:49:48Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+33e3f642262750ca0f2302d536eae12c6be85410
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_145114_7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179.log
+++ b/docs/patch_logs/patch_20250801_145114_7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179.log
@@ -1,0 +1,58 @@
+patch_20250801_145114_7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179
+
+=====DIFFSUMMARY=====
+commit 7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:51:14 2025 -0500
+
+    Create CAG_spec.md
+
+ docs/CAG_spec.md | 44 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T14:51:14Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7b2b8144dd30d7a5601c2fb8aca92e5e9ebe9179
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_145540_6a2c0e0b2d2a14af73ed9d53471da42eb9af41df.log
+++ b/docs/patch_logs/patch_20250801_145540_6a2c0e0b2d2a14af73ed9d53471da42eb9af41df.log
@@ -1,0 +1,59 @@
+patch_20250801_145540_6a2c0e0b2d2a14af73ed9d53471da42eb9af41df.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 6a2c0e0b2d2a14af73ed9d53471da42eb9af41df
+
+=====DIFFSUMMARY=====
+commit 6a2c0e0b2d2a14af73ed9d53471da42eb9af41df
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 08:55:40 2025 -0600
+
+    docs: add patch log template
+
+ docs/patch_logs/_TEMPLATE.md                       | 48 +++++++++++++++++++++
+ ...atch_20250801_145422_CreatePatchLogTemplate.txt | 49 ++++++++++++++++++++++
+ 2 files changed, 97 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T14:55:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6a2c0e0b2d2a14af73ed9d53471da42eb9af41df
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_145550_cf7d4e58b59138c625a2167123ad5bad4e1b1fba.log
+++ b/docs/patch_logs/patch_20250801_145550_cf7d4e58b59138c625a2167123ad5bad4e1b1fba.log
@@ -1,0 +1,62 @@
+patch_20250801_145550_cf7d4e58b59138c625a2167123ad5bad4e1b1fba.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit cf7d4e58b59138c625a2167123ad5bad4e1b1fba
+
+=====DIFFSUMMARY=====
+commit cf7d4e58b59138c625a2167123ad5bad4e1b1fba
+Merge: 7b2b814 6a2c0e0
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 08:55:50 2025 -0600
+
+    Merge pull request #535 from buymeagoat/codex/ensure-patch-log-template-exists-and-update
+    
+    Add patch log template
+
+ docs/patch_logs/_TEMPLATE.md                       | 48 +++++++++++++++++++++
+ ...atch_20250801_145422_CreatePatchLogTemplate.txt | 49 ++++++++++++++++++++++
+ 2 files changed, 97 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T14:55:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cf7d4e58b59138c625a2167123ad5bad4e1b1fba
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_150701_8d7e1068793ca1dadba0c9e512dc13e51c7aca32.log
+++ b/docs/patch_logs/patch_20250801_150701_8d7e1068793ca1dadba0c9e512dc13e51c7aca32.log
@@ -1,0 +1,59 @@
+patch_20250801_150701_8d7e1068793ca1dadba0c9e512dc13e51c7aca32.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 8d7e1068793ca1dadba0c9e512dc13e51c7aca32
+
+=====DIFFSUMMARY=====
+commit 8d7e1068793ca1dadba0c9e512dc13e51c7aca32
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:07:01 2025 -0600
+
+    Add SPEC_HASHES to PatchLogging
+
+ ...atch_20250801_150357_UpdatePatchLoggingSpec.log | 51 ++++++++++++++++++++++
+ instructions/cag_dense.txt                         |  1 +
+ 2 files changed, 52 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:07:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8d7e1068793ca1dadba0c9e512dc13e51c7aca32
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_150720_9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3.log
+++ b/docs/patch_logs/patch_20250801_150720_9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3.log
@@ -1,0 +1,62 @@
+patch_20250801_150720_9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3
+
+=====DIFFSUMMARY=====
+commit 9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3
+Merge: abf0cbe 8d7e106
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:07:20 2025 -0600
+
+    Merge pull request #536 from buymeagoat/codex/locate-instructions/cag_dense.txt-and-modify-patchlogging
+    
+    Update PatchLogging spec with SPEC_HASHES
+
+ ...atch_20250801_150357_UpdatePatchLoggingSpec.log | 51 ++++++++++++++++++++++
+ instructions/cag_dense.txt                         |  1 +
+ 2 files changed, 52 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:07:20Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9f83d174b3b94a6038e95bd9506dfcf2a8fa7ee3
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_150922_f640289e661e45607f059587d7d9ab0470f6a192.log
+++ b/docs/patch_logs/patch_20250801_150922_f640289e661e45607f059587d7d9ab0470f6a192.log
@@ -1,0 +1,58 @@
+patch_20250801_150922_f640289e661e45607f059587d7d9ab0470f6a192.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit f640289e661e45607f059587d7d9ab0470f6a192
+
+=====DIFFSUMMARY=====
+commit f640289e661e45607f059587d7d9ab0470f6a192
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:09:22 2025 -0500
+
+    Rename patch_20250801_150357_UpdatePatchLoggingSpec.log to patch_20250801_1009_UpdatePatchLoggingSpec.log
+
+ ...atchLoggingSpec.log => patch_20250801_1009_UpdatePatchLoggingSpec.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T15:09:22Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f640289e661e45607f059587d7d9ab0470f6a192
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_151456_981d9dd4993ffe1af473b61ff9c000f8f2b7d12a.log
+++ b/docs/patch_logs/patch_20250801_151456_981d9dd4993ffe1af473b61ff9c000f8f2b7d12a.log
@@ -1,0 +1,59 @@
+patch_20250801_151456_981d9dd4993ffe1af473b61ff9c000f8f2b7d12a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 981d9dd4993ffe1af473b61ff9c000f8f2b7d12a
+
+=====DIFFSUMMARY=====
+commit 981d9dd4993ffe1af473b61ff9c000f8f2b7d12a
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:14:56 2025 -0600
+
+    Add patch log for hash utils
+
+ .../patch_20250801_151351_HashUtilsScript.log      | 49 ++++++++++++++++++++++
+ scripts/hash_utils.sh                              | 27 ++++++++++++
+ 2 files changed, 76 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:14:56Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+981d9dd4993ffe1af473b61ff9c000f8f2b7d12a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_151510_813aa06cedbe99ea4d254999385b3dcd983e2d94.log
+++ b/docs/patch_logs/patch_20250801_151510_813aa06cedbe99ea4d254999385b3dcd983e2d94.log
@@ -1,0 +1,62 @@
+patch_20250801_151510_813aa06cedbe99ea4d254999385b3dcd983e2d94.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 813aa06cedbe99ea4d254999385b3dcd983e2d94
+
+=====DIFFSUMMARY=====
+commit 813aa06cedbe99ea4d254999385b3dcd983e2d94
+Merge: f640289 981d9dd
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:15:10 2025 -0600
+
+    Merge pull request #537 from buymeagoat/codex/create-hash_utils.sh-script-with-hash-function
+    
+    Add hash_utils script
+
+ .../patch_20250801_151351_HashUtilsScript.log      | 49 ++++++++++++++++++++++
+ scripts/hash_utils.sh                              | 27 ++++++++++++
+ 2 files changed, 76 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:15:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+813aa06cedbe99ea4d254999385b3dcd983e2d94
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_151657_684ffc5cfeb949b6ac8e67d3b3af3831f25bb720.log
+++ b/docs/patch_logs/patch_20250801_151657_684ffc5cfeb949b6ac8e67d3b3af3831f25bb720.log
@@ -1,0 +1,58 @@
+patch_20250801_151657_684ffc5cfeb949b6ac8e67d3b3af3831f25bb720.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 684ffc5cfeb949b6ac8e67d3b3af3831f25bb720
+
+=====DIFFSUMMARY=====
+commit 684ffc5cfeb949b6ac8e67d3b3af3831f25bb720
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:16:57 2025 -0500
+
+    Rename patch_20250801_151351_HashUtilsScript.log to patch_20250801_1016_HashUtilsScript.log
+
+ ...151351_HashUtilsScript.log => patch_20250801_1016_HashUtilsScript.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T15:16:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+684ffc5cfeb949b6ac8e67d3b3af3831f25bb720
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_152512_355d85de8f7d2b802df439a2ab3e3628c586f774.log
+++ b/docs/patch_logs/patch_20250801_152512_355d85de8f7d2b802df439a2ab3e3628c586f774.log
@@ -1,0 +1,59 @@
+patch_20250801_152512_355d85de8f7d2b802df439a2ab3e3628c586f774.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 355d85de8f7d2b802df439a2ab3e3628c586f774
+
+=====DIFFSUMMARY=====
+commit 355d85de8f7d2b802df439a2ab3e3628c586f774
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:25:12 2025 -0600
+
+    Add dry run prompt for alias map
+
+ .../patch_20250801_152221_EchoAliasMap.log         | 49 ++++++++++++++++++++++
+ scripts/dry_run_prompt_examples/echo_alias_map.md  |  1 +
+ 2 files changed, 50 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:25:12Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+355d85de8f7d2b802df439a2ab3e3628c586f774
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_152550_e5261b9b3d997090291d45bae385c12509672b53.log
+++ b/docs/patch_logs/patch_20250801_152550_e5261b9b3d997090291d45bae385c12509672b53.log
@@ -1,0 +1,62 @@
+patch_20250801_152550_e5261b9b3d997090291d45bae385c12509672b53.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit e5261b9b3d997090291d45bae385c12509672b53
+
+=====DIFFSUMMARY=====
+commit e5261b9b3d997090291d45bae385c12509672b53
+Merge: 684ffc5 355d85d
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:25:50 2025 -0600
+
+    Merge pull request #538 from buymeagoat/jeyfil-codex/create-dry-run-prompt-examples-directory
+    
+    Add dry run alias map prompt
+
+ .../patch_20250801_152221_EchoAliasMap.log         | 49 ++++++++++++++++++++++
+ scripts/dry_run_prompt_examples/echo_alias_map.md  |  1 +
+ 2 files changed, 50 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:25:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e5261b9b3d997090291d45bae385c12509672b53
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_153454_dba2dfbdc0a652117590b0d02323b88ec14c1a89.log
+++ b/docs/patch_logs/patch_20250801_153454_dba2dfbdc0a652117590b0d02323b88ec14c1a89.log
@@ -1,0 +1,59 @@
+patch_20250801_153454_dba2dfbdc0a652117590b0d02323b88ec14c1a89.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit dba2dfbdc0a652117590b0d02323b88ec14c1a89
+
+=====DIFFSUMMARY=====
+commit dba2dfbdc0a652117590b0d02323b88ec14c1a89
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:34:54 2025 -0600
+
+    chore: add patch log for binary guard prompt
+
+ .../patch_20250801_153325_BinaryGuardTest.log      | 49 ++++++++++++++++++++++
+ .../dry_run_prompt_examples/binary_guard_test.md   |  3 ++
+ 2 files changed, 52 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:34:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+dba2dfbdc0a652117590b0d02323b88ec14c1a89
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_153507_8bccfd9ed1e5a0b05c68783af447251a6b569b7a.log
+++ b/docs/patch_logs/patch_20250801_153507_8bccfd9ed1e5a0b05c68783af447251a6b569b7a.log
@@ -1,0 +1,62 @@
+patch_20250801_153507_8bccfd9ed1e5a0b05c68783af447251a6b569b7a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 8bccfd9ed1e5a0b05c68783af447251a6b569b7a
+
+=====DIFFSUMMARY=====
+commit 8bccfd9ed1e5a0b05c68783af447251a6b569b7a
+Merge: e5261b9 dba2dfb
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 09:35:07 2025 -0600
+
+    Merge pull request #539 from buymeagoat/codex/create-binary-guard-test-prompt-file
+    
+    Add binary guard dry run prompt
+
+ .../patch_20250801_153325_BinaryGuardTest.log      | 49 ++++++++++++++++++++++
+ .../dry_run_prompt_examples/binary_guard_test.md   |  3 ++
+ 2 files changed, 52 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T15:35:07Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8bccfd9ed1e5a0b05c68783af447251a6b569b7a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_153720_0dd092b00b01c3678de332c24070aff1a2194efd.log
+++ b/docs/patch_logs/patch_20250801_153720_0dd092b00b01c3678de332c24070aff1a2194efd.log
@@ -1,0 +1,58 @@
+patch_20250801_153720_0dd092b00b01c3678de332c24070aff1a2194efd.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 0dd092b00b01c3678de332c24070aff1a2194efd
+
+=====DIFFSUMMARY=====
+commit 0dd092b00b01c3678de332c24070aff1a2194efd
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:37:20 2025 -0500
+
+    Rename patch_20250801_153325_BinaryGuardTest.log to patch_20250801_1036_BinaryGuardTest.log
+
+ ...153325_BinaryGuardTest.log => patch_20250801_1036_BinaryGuardTest.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T15:37:20Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0dd092b00b01c3678de332c24070aff1a2194efd
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_154004_4cf04d2873b30762acfade860f8f6597d12f5098.log
+++ b/docs/patch_logs/patch_20250801_154004_4cf04d2873b30762acfade860f8f6597d12f5098.log
@@ -1,0 +1,58 @@
+patch_20250801_154004_4cf04d2873b30762acfade860f8f6597d12f5098.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 4cf04d2873b30762acfade860f8f6597d12f5098
+
+=====DIFFSUMMARY=====
+commit 4cf04d2873b30762acfade860f8f6597d12f5098
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:40:04 2025 -0500
+
+    Rename patch_20250801_152221_EchoAliasMap.log to patch_20250801_1029_EchoAliasMap.log
+
+ ...50801_152221_EchoAliasMap.log => patch_20250801_1029_EchoAliasMap.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T15:40:04Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4cf04d2873b30762acfade860f8f6597d12f5098
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160506_3c31f03c9a82a7461135c0cf9917593ba783e96a.log
+++ b/docs/patch_logs/patch_20250801_160506_3c31f03c9a82a7461135c0cf9917593ba783e96a.log
@@ -1,0 +1,61 @@
+patch_20250801_160506_3c31f03c9a82a7461135c0cf9917593ba783e96a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 3c31f03c9a82a7461135c0cf9917593ba783e96a
+
+=====DIFFSUMMARY=====
+commit 3c31f03c9a82a7461135c0cf9917593ba783e96a
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:05:06 2025 -0600
+
+    patchlog: utc filename update
+
+ AGENTS.md                                          |  2 +
+ docs/patch_logs/_TEMPLATE.md                       |  4 ++
+ ...ch_20250801_155438_UTC_utc-filename-fix-001.log | 52 ++++++++++++++++++++++
+ instructions/cag_dense.txt                         |  2 +-
+ 4 files changed, 59 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:05:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3c31f03c9a82a7461135c0cf9917593ba783e96a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160518_a7ef709dab2cb66259b183b4e8074f7dad5267f0.log
+++ b/docs/patch_logs/patch_20250801_160518_a7ef709dab2cb66259b183b4e8074f7dad5267f0.log
@@ -1,0 +1,64 @@
+patch_20250801_160518_a7ef709dab2cb66259b183b4e8074f7dad5267f0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit a7ef709dab2cb66259b183b4e8074f7dad5267f0
+
+=====DIFFSUMMARY=====
+commit a7ef709dab2cb66259b183b4e8074f7dad5267f0
+Merge: 4cf04d2 3c31f03
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:05:18 2025 -0600
+
+    Merge pull request #540 from buymeagoat/codex/enforce-utc-patch-log-naming-convention
+    
+    Update patch log UTC naming
+
+ AGENTS.md                                          |  2 +
+ docs/patch_logs/_TEMPLATE.md                       |  4 ++
+ ...ch_20250801_155438_UTC_utc-filename-fix-001.log | 52 ++++++++++++++++++++++
+ instructions/cag_dense.txt                         |  2 +-
+ 4 files changed, 59 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:05:18Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a7ef709dab2cb66259b183b4e8074f7dad5267f0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160634_522bd4d47ff58782bee8a5ce1621986b31123229.log
+++ b/docs/patch_logs/patch_20250801_160634_522bd4d47ff58782bee8a5ce1621986b31123229.log
@@ -1,0 +1,58 @@
+patch_20250801_160634_522bd4d47ff58782bee8a5ce1621986b31123229.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 522bd4d47ff58782bee8a5ce1621986b31123229
+
+=====DIFFSUMMARY=====
+commit 522bd4d47ff58782bee8a5ce1621986b31123229
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:06:34 2025 -0500
+
+    Rename patch_20250801_0949_CAG-AddGuardRailComment.log to patch_20250801_144653_CAG-AddGuardRailComment.log
+
+ ...dRailComment.log => patch_20250801_144653_CAG-AddGuardRailComment.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:06:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+522bd4d47ff58782bee8a5ce1621986b31123229
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160708_0404ead398d98320caf575371dcb8fb065643cef.log
+++ b/docs/patch_logs/patch_20250801_160708_0404ead398d98320caf575371dcb8fb065643cef.log
@@ -1,0 +1,58 @@
+patch_20250801_160708_0404ead398d98320caf575371dcb8fb065643cef.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 0404ead398d98320caf575371dcb8fb065643cef
+
+=====DIFFSUMMARY=====
+commit 0404ead398d98320caf575371dcb8fb065643cef
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:07:08 2025 -0500
+
+    Rename patch_20250801_0956_CreatePatchLogTemplate.txt to patch_20250801_145422_CreatePatchLogTemplate.txt
+
+ ...chLogTemplate.txt => patch_20250801_145422_CreatePatchLogTemplate.txt} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:07:08Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0404ead398d98320caf575371dcb8fb065643cef
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160750_661f0a5630037bbadfaca6262132802addcbe9f6.log
+++ b/docs/patch_logs/patch_20250801_160750_661f0a5630037bbadfaca6262132802addcbe9f6.log
@@ -1,0 +1,58 @@
+patch_20250801_160750_661f0a5630037bbadfaca6262132802addcbe9f6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 661f0a5630037bbadfaca6262132802addcbe9f6
+
+=====DIFFSUMMARY=====
+commit 661f0a5630037bbadfaca6262132802addcbe9f6
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:07:50 2025 -0500
+
+    Rename patch_20250801_1009_UpdatePatchLoggingSpec.log to patch_20250801_150357_UpdatePatchLoggingSpec.log
+
+ ...chLoggingSpec.log => patch_20250801_150357_UpdatePatchLoggingSpec.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:07:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+661f0a5630037bbadfaca6262132802addcbe9f6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160840_9e25de272d0afb9684adafe8402e23a0c8f398a9.log
+++ b/docs/patch_logs/patch_20250801_160840_9e25de272d0afb9684adafe8402e23a0c8f398a9.log
@@ -1,0 +1,58 @@
+patch_20250801_160840_9e25de272d0afb9684adafe8402e23a0c8f398a9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 9e25de272d0afb9684adafe8402e23a0c8f398a9
+
+=====DIFFSUMMARY=====
+commit 9e25de272d0afb9684adafe8402e23a0c8f398a9
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:08:40 2025 -0500
+
+    Rename patch_20250801_1036_BinaryGuardTest.log to patch_20250801_153325_BinaryGuardTest.log
+
+ ...1036_BinaryGuardTest.log => patch_20250801_153325_BinaryGuardTest.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:08:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9e25de272d0afb9684adafe8402e23a0c8f398a9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160908_6ee4c64cbffd85026fd428612e37a9d07d8a9612.log
+++ b/docs/patch_logs/patch_20250801_160908_6ee4c64cbffd85026fd428612e37a9d07d8a9612.log
@@ -1,0 +1,58 @@
+patch_20250801_160908_6ee4c64cbffd85026fd428612e37a9d07d8a9612.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 6ee4c64cbffd85026fd428612e37a9d07d8a9612
+
+=====DIFFSUMMARY=====
+commit 6ee4c64cbffd85026fd428612e37a9d07d8a9612
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:09:08 2025 -0500
+
+    Rename patch_20250801_1029_EchoAliasMap.log to patch_20250801_152221_EchoAliasMap.log
+
+ ...50801_1029_EchoAliasMap.log => patch_20250801_152221_EchoAliasMap.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:09:08Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6ee4c64cbffd85026fd428612e37a9d07d8a9612
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_160929_3529eafcab748d26ea3f93b5e4575a20d0741628.log
+++ b/docs/patch_logs/patch_20250801_160929_3529eafcab748d26ea3f93b5e4575a20d0741628.log
@@ -1,0 +1,58 @@
+patch_20250801_160929_3529eafcab748d26ea3f93b5e4575a20d0741628.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 3529eafcab748d26ea3f93b5e4575a20d0741628
+
+=====DIFFSUMMARY=====
+commit 3529eafcab748d26ea3f93b5e4575a20d0741628
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:09:29 2025 -0500
+
+    Rename patch_20250801_1016_HashUtilsScript.log to patch_20250801_151351_HashUtilsScript.log
+
+ ...1016_HashUtilsScript.log => patch_20250801_151351_HashUtilsScript.log} | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:09:29Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3529eafcab748d26ea3f93b5e4575a20d0741628
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_163936_1bc33b016306c83b723be7395f3092728e464a0a.log
+++ b/docs/patch_logs/patch_20250801_163936_1bc33b016306c83b723be7395f3092728e464a0a.log
@@ -1,0 +1,70 @@
+patch_20250801_163936_1bc33b016306c83b723be7395f3092728e464a0a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 1bc33b016306c83b723be7395f3092728e464a0a
+
+=====DIFFSUMMARY=====
+commit 1bc33b016306c83b723be7395f3092728e464a0a
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:39:36 2025 -0600
+
+    Add patch log for legacy normalization
+
+ ...0728_1852.txt => patch_20250728_235200_UTC.log} | 1717 +++--
+ ...0728_1918.txt => patch_20250729_001800_UTC.log} | 1397 ++--
+ ...0728_2008.txt => patch_20250729_010800_UTC.log} | 3802 ++++-----
+ ...0728_2022.txt => patch_20250729_012200_UTC.log} | 1894 ++---
+ ...0728_2058.txt => patch_20250729_015800_UTC.log} | 1219 +--
+ ...0729_0910.txt => patch_20250729_141000_UTC.log} |  943 +--
+ ...0729_0930.txt => patch_20250729_143000_UTC.log} |  476 +-
+ ...0729_0942.txt => patch_20250729_144200_UTC.log} | 1129 +--
+ ...0729_1004.txt => patch_20250729_150400_UTC.log} |  629 +-
+ ...0729_1730.txt => patch_20250729_223000_UTC.log} |  247 +-
+ ...0730_0938.txt => patch_20250730_143800_UTC.log} | 8133 ++++++++++----------
+ ...tch_20250731_190500_UTC_CAG-UpdateAgentsMd.log} |   53 +
+ ...20250801_163702_normalize-patchlogs-utc-001.log |   53 +
+ 13 files changed, 11188 insertions(+), 10504 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:39:36Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+1bc33b016306c83b723be7395f3092728e464a0a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_164054_85cd83622962ff38638f9e2b6502f11ad9bec1e4.log
+++ b/docs/patch_logs/patch_20250801_164054_85cd83622962ff38638f9e2b6502f11ad9bec1e4.log
@@ -1,0 +1,73 @@
+patch_20250801_164054_85cd83622962ff38638f9e2b6502f11ad9bec1e4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 85cd83622962ff38638f9e2b6502f11ad9bec1e4
+
+=====DIFFSUMMARY=====
+commit 85cd83622962ff38638f9e2b6502f11ad9bec1e4
+Merge: 3529eaf 1bc33b0
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:40:54 2025 -0600
+
+    Merge pull request #541 from buymeagoat/codex/normalize-legacy-patch-logs-to-utc
+    
+    Normalize legacy patch logs
+
+ ...0728_1852.txt => patch_20250728_235200_UTC.log} | 1717 +++--
+ ...0728_1918.txt => patch_20250729_001800_UTC.log} | 1397 ++--
+ ...0728_2008.txt => patch_20250729_010800_UTC.log} | 3802 ++++-----
+ ...0728_2022.txt => patch_20250729_012200_UTC.log} | 1894 ++---
+ ...0728_2058.txt => patch_20250729_015800_UTC.log} | 1219 +--
+ ...0729_0910.txt => patch_20250729_141000_UTC.log} |  943 +--
+ ...0729_0930.txt => patch_20250729_143000_UTC.log} |  476 +-
+ ...0729_0942.txt => patch_20250729_144200_UTC.log} | 1129 +--
+ ...0729_1004.txt => patch_20250729_150400_UTC.log} |  629 +-
+ ...0729_1730.txt => patch_20250729_223000_UTC.log} |  247 +-
+ ...0730_0938.txt => patch_20250730_143800_UTC.log} | 8133 ++++++++++----------
+ ...tch_20250731_190500_UTC_CAG-UpdateAgentsMd.log} |   53 +
+ ...20250801_163702_normalize-patchlogs-utc-001.log |   53 +
+ 13 files changed, 11188 insertions(+), 10504 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T16:40:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+85cd83622962ff38638f9e2b6502f11ad9bec1e4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_165857_f7a709742f396f8489a311928d1b06fcf71263f7.log
+++ b/docs/patch_logs/patch_20250801_165857_f7a709742f396f8489a311928d1b06fcf71263f7.log
@@ -1,0 +1,69 @@
+patch_20250801_165857_f7a709742f396f8489a311928d1b06fcf71263f7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit f7a709742f396f8489a311928d1b06fcf71263f7
+
+=====DIFFSUMMARY=====
+commit f7a709742f396f8489a311928d1b06fcf71263f7
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:58:57 2025 -0600
+
+    Add patch log for renaming
+
+ ...C.log => patch_20250728_235200_SetCacheDir.log} |  0
+ ...h_20250729_001800_OfflineBuildVerification.log} |  0
+ ... => patch_20250729_010800_UnifyBuildScript.log} |  0
+ ...og => patch_20250729_012200_DocsUnifyBuild.log} |  0
+ ... patch_20250729_015800_RemoveLegacyScripts.log} |  0
+ ..._20250729_141000_HandleHelpUpdateBaseImage.log} |  0
+ ... patch_20250729_143000_RemoveUsageFunction.log} |  0
+ ...patch_20250729_144200_ModularBuildSwitches.log} |  0
+ ...atch_20250729_150400_UpdateDocsForSwitches.log} |  0
+ ... => patch_20250729_223000_AuditSwitchLogic.log} |  0
+ ...g => patch_20250730_143800_FixBuildLogging.log} |  0
+ .../patch_20250801_165047_patch-log-renames.log    | 45 ++++++++++++++++++++++
+ 12 files changed, 45 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T16:58:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f7a709742f396f8489a311928d1b06fcf71263f7
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_165908_074bb2a94e7dedf9ea0e69d913d88532d829c858.log
+++ b/docs/patch_logs/patch_20250801_165908_074bb2a94e7dedf9ea0e69d913d88532d829c858.log
@@ -1,0 +1,72 @@
+patch_20250801_165908_074bb2a94e7dedf9ea0e69d913d88532d829c858.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 074bb2a94e7dedf9ea0e69d913d88532d829c858
+
+=====DIFFSUMMARY=====
+commit 074bb2a94e7dedf9ea0e69d913d88532d829c858
+Merge: 85cd836 f7a7097
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 10:59:08 2025 -0600
+
+    Merge pull request #542 from buymeagoat/codex/update-log-filenames-with-descriptions
+    
+    Rename early patch logs with descriptive names
+
+ ...C.log => patch_20250728_235200_SetCacheDir.log} |  0
+ ...h_20250729_001800_OfflineBuildVerification.log} |  0
+ ... => patch_20250729_010800_UnifyBuildScript.log} |  0
+ ...og => patch_20250729_012200_DocsUnifyBuild.log} |  0
+ ... patch_20250729_015800_RemoveLegacyScripts.log} |  0
+ ..._20250729_141000_HandleHelpUpdateBaseImage.log} |  0
+ ... patch_20250729_143000_RemoveUsageFunction.log} |  0
+ ...patch_20250729_144200_ModularBuildSwitches.log} |  0
+ ...atch_20250729_150400_UpdateDocsForSwitches.log} |  0
+ ... => patch_20250729_223000_AuditSwitchLogic.log} |  0
+ ...g => patch_20250730_143800_FixBuildLogging.log} |  0
+ .../patch_20250801_165047_patch-log-renames.log    | 45 ++++++++++++++++++++++
+ 12 files changed, 45 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T16:59:08Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+074bb2a94e7dedf9ea0e69d913d88532d829c858
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_174857_3339594475be939ea7b916b83492ff39ea0ae129.log
+++ b/docs/patch_logs/patch_20250801_174857_3339594475be939ea7b916b83492ff39ea0ae129.log
@@ -1,0 +1,58 @@
+patch_20250801_174857_3339594475be939ea7b916b83492ff39ea0ae129.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit 3339594475be939ea7b916b83492ff39ea0ae129
+
+=====DIFFSUMMARY=====
+commit 3339594475be939ea7b916b83492ff39ea0ae129
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:48:57 2025 -0600
+
+    Add repo audit script
+
+ scripts/CPG_repo_audit.py | 88 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 88 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T17:48:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3339594475be939ea7b916b83492ff39ea0ae129
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history

--- a/docs/patch_logs/patch_20250801_175155_b51afff42c00747260c364aca23ed8f83e6a5695.log
+++ b/docs/patch_logs/patch_20250801_175155_b51afff42c00747260c364aca23ed8f83e6a5695.log
@@ -1,0 +1,61 @@
+patch_20250801_175155_b51afff42c00747260c364aca23ed8f83e6a5695.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Record missing patch log from history
+
+=====CONSTRAINTS=====
+- Placeholder for legacy snapshot and agent metadata
+
+=====SCOPE=====
+LEGACY commit b51afff42c00747260c364aca23ed8f83e6a5695
+
+=====DIFFSUMMARY=====
+commit b51afff42c00747260c364aca23ed8f83e6a5695
+Merge: 074bb2a 3339594
+Author: buymeagoat <53793097+buymeagoat@users.noreply.github.com>
+Date:   Fri Aug 1 11:51:55 2025 -0600
+
+    Merge pull request #543 from buymeagoat/codex/implement-cpg_repo_audit.py-functionality
+    
+    Add baseline repo audit script
+
+ scripts/CPG_repo_audit.py | 88 +++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 88 insertions(+)
+
+=====TIMESTAMP=====
+2025-08-01T17:51:55Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 191117
+
+=====PROMPTID=====
+legacy-backfill-batch-001
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b51afff42c00747260c364aca23ed8f83e6a5695
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+legacy-backfill
+
+=====DECISIONS=====
+- Auto-generated from commit history


### PR DESCRIPTION
## Summary
- add missing patch logs for older commit range

## Testing
- `./scripts/check_env.sh` *(fails: OS mismatch)*
- `./scripts/run_tests.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d11908784832599c8ac65511b0758