### PR TITLE
Backfill patch logs for early history

### DIFF
--- a/docs/patch_logs/patch_20250727_031450_9ca83783c9e38c79ec9f8ae010fe0859132f8aec.log
+++ b/docs/patch_logs/patch_20250727_031450_9ca83783c9e38c79ec9f8ae010fe0859132f8aec.log
@@ -1,0 +1,55 @@
+patch_20250727_031450_9ca83783c9e38c79ec9f8ae010fe0859132f8aec.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9ca83783c9e38c79ec9f8ae010fe0859132f8aec
+
+=====DIFFSUMMARY=====
+9ca8378 Merge pull request #455 from buymeagoat/codex/add-wheel-package-to-pip-download
+
+ scripts/prestage_dependencies.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T03:14:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9ca83783c9e38c79ec9f8ae010fe0859132f8aec
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_132444_f892f23e1abd0ed826cf9eab793a9a4168d54ae2.log
+++ b/docs/patch_logs/patch_20250727_132444_f892f23e1abd0ed826cf9eab793a9a4168d54ae2.log
@@ -1,0 +1,55 @@
+patch_20250727_132444_f892f23e1abd0ed826cf9eab793a9a4168d54ae2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f892f23e1abd0ed826cf9eab793a9a4168d54ae2
+
+=====DIFFSUMMARY=====
+f892f23 use rm -rf in cleanup
+ scripts/docker_build.sh     | 18 +++++++++---------
+ scripts/start_containers.sh |  8 ++++----
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T13:24:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f892f23e1abd0ed826cf9eab793a9a4168d54ae2
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_132457_19464053ebb305e2278d24e1ce9e5d085395a5d4.log
+++ b/docs/patch_logs/patch_20250727_132457_19464053ebb305e2278d24e1ce9e5d085395a5d4.log
@@ -1,0 +1,56 @@
+patch_20250727_132457_19464053ebb305e2278d24e1ce9e5d085395a5d4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 19464053ebb305e2278d24e1ce9e5d085395a5d4
+
+=====DIFFSUMMARY=====
+1946405 Merge pull request #456 from buymeagoat/codex/update-cleanup-functions-for-file-removal
+
+ scripts/docker_build.sh     | 18 +++++++++---------
+ scripts/start_containers.sh |  8 ++++----
+ 2 files changed, 13 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T13:24:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+19464053ebb305e2278d24e1ce9e5d085395a5d4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_151344_63afa1a9a7aa2dcb59c789baf16460fd9d456d53.log
+++ b/docs/patch_logs/patch_20250727_151344_63afa1a9a7aa2dcb59c789baf16460fd9d456d53.log
@@ -1,0 +1,54 @@
+patch_20250727_151344_63afa1a9a7aa2dcb59c789baf16460fd9d456d53.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 63afa1a9a7aa2dcb59c789baf16460fd9d456d53
+
+=====DIFFSUMMARY=====
+63afa1a docs: update dependency installation notes
+ docs/future_updates.md | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:13:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+63afa1a9a7aa2dcb59c789baf16460fd9d456d53
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_151410_d8d0e68106d160184ba0f329dbe5b4fd3a204274.log
+++ b/docs/patch_logs/patch_20250727_151410_d8d0e68106d160184ba0f329dbe5b4fd3a204274.log
@@ -1,0 +1,55 @@
+patch_20250727_151410_d8d0e68106d160184ba0f329dbe5b4fd3a204274.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d8d0e68106d160184ba0f329dbe5b4fd3a204274
+
+=====DIFFSUMMARY=====
+d8d0e68 Merge pull request #457 from buymeagoat/codex/review-and-update-pip-install-options
+
+ docs/future_updates.md | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:14:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d8d0e68106d160184ba0f329dbe5b4fd3a204274
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_154722_969a2ae37e17265c81406b3dafe6a1c1b266bc7c.log
+++ b/docs/patch_logs/patch_20250727_154722_969a2ae37e17265c81406b3dafe6a1c1b266bc7c.log
@@ -1,0 +1,54 @@
+patch_20250727_154722_969a2ae37e17265c81406b3dafe6a1c1b266bc7c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 969a2ae37e17265c81406b3dafe6a1c1b266bc7c
+
+=====DIFFSUMMARY=====
+969a2ae Improve requirement parsing in offline check
+ scripts/shared_checks.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:47:22Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+969a2ae37e17265c81406b3dafe6a1c1b266bc7c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_154735_d15099e4e29144c2fa242a5cfcc57e6ce56240c5.log
+++ b/docs/patch_logs/patch_20250727_154735_d15099e4e29144c2fa242a5cfcc57e6ce56240c5.log
@@ -1,0 +1,55 @@
+patch_20250727_154735_d15099e4e29144c2fa242a5cfcc57e6ce56240c5.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d15099e4e29144c2fa242a5cfcc57e6ce56240c5
+
+=====DIFFSUMMARY=====
+d15099e Merge pull request #458 from buymeagoat/codex/modify-verify_offline_assets-in-shared_checks.sh
+
+ scripts/shared_checks.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:47:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d15099e4e29144c2fa242a5cfcc57e6ce56240c5
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_155746_5216d3a7f6708e3bc8a802acaa1ce4320564c920.log
+++ b/docs/patch_logs/patch_20250727_155746_5216d3a7f6708e3bc8a802acaa1ce4320564c920.log
@@ -1,0 +1,54 @@
+patch_20250727_155746_5216d3a7f6708e3bc8a802acaa1ce4320564c920.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5216d3a7f6708e3bc8a802acaa1ce4320564c920
+
+=====DIFFSUMMARY=====
+5216d3a Ensure apt packages re-download
+ scripts/prestage_dependencies.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:57:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5216d3a7f6708e3bc8a802acaa1ce4320564c920
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_155819_d7b31f9a744c70c2899ab1466ffa329873662775.log
+++ b/docs/patch_logs/patch_20250727_155819_d7b31f9a744c70c2899ab1466ffa329873662775.log
@@ -1,0 +1,55 @@
+patch_20250727_155819_d7b31f9a744c70c2899ab1466ffa329873662775.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d7b31f9a744c70c2899ab1466ffa329873662775
+
+=====DIFFSUMMARY=====
+d7b31f9 Merge pull request #459 from buymeagoat/codex/update-prestage_dependencies.sh-for-apt-install
+
+ scripts/prestage_dependencies.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T15:58:19Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d7b31f9a744c70c2899ab1466ffa329873662775
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_162556_10edbef12da4452f164430e7a51a602675b1a23d.log
+++ b/docs/patch_logs/patch_20250727_162556_10edbef12da4452f164430e7a51a602675b1a23d.log
@@ -1,0 +1,54 @@
+patch_20250727_162556_10edbef12da4452f164430e7a51a602675b1a23d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 10edbef12da4452f164430e7a51a602675b1a23d
+
+=====DIFFSUMMARY=====
+10edbef fix offline asset check for underscore wheels
+ scripts/shared_checks.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:25:56Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+10edbef12da4452f164430e7a51a602675b1a23d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_162606_0ee358cff9f8e718ece081e6ba275880e2543f01.log
+++ b/docs/patch_logs/patch_20250727_162606_0ee358cff9f8e718ece081e6ba275880e2543f01.log
@@ -1,0 +1,55 @@
+patch_20250727_162606_0ee358cff9f8e718ece081e6ba275880e2543f01.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0ee358cff9f8e718ece081e6ba275880e2543f01
+
+=====DIFFSUMMARY=====
+0ee358c Merge pull request #460 from buymeagoat/codex/update-verify_offline_assets-to-use-underscores
+
+ scripts/shared_checks.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:26:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0ee358cff9f8e718ece081e6ba275880e2543f01
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_163025_81ba56a0e8b499812b1015325b8703d3fc8b57db.log
+++ b/docs/patch_logs/patch_20250727_163025_81ba56a0e8b499812b1015325b8703d3fc8b57db.log
@@ -1,0 +1,54 @@
+patch_20250727_163025_81ba56a0e8b499812b1015325b8703d3fc8b57db.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 81ba56a0e8b499812b1015325b8703d3fc8b57db
+
+=====DIFFSUMMARY=====
+81ba56a chore: ensure node version for tests
+ scripts/run_tests.sh | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T16:30:25Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+81ba56a0e8b499812b1015325b8703d3fc8b57db
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_163105_7ba21efdadc6b8107f57800f21c6cb23e3940430.log
+++ b/docs/patch_logs/patch_20250727_163105_7ba21efdadc6b8107f57800f21c6cb23e3940430.log
@@ -1,0 +1,55 @@
+patch_20250727_163105_7ba21efdadc6b8107f57800f21c6cb23e3940430.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 7ba21efdadc6b8107f57800f21c6cb23e3940430
+
+=====DIFFSUMMARY=====
+7ba21ef Merge pull request #461 from buymeagoat/codex/update-run_tests.sh-for-node.js-checks
+
+ scripts/run_tests.sh | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T16:31:05Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7ba21efdadc6b8107f57800f21c6cb23e3940430
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_163243_5a379760cd2b25e07ed8d3e8fd2f2c3a2147dd1a.log
+++ b/docs/patch_logs/patch_20250727_163243_5a379760cd2b25e07ed8d3e8fd2f2c3a2147dd1a.log
@@ -1,0 +1,54 @@
+patch_20250727_163243_5a379760cd2b25e07ed8d3e8fd2f2c3a2147dd1a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5a379760cd2b25e07ed8d3e8fd2f2c3a2147dd1a
+
+=====DIFFSUMMARY=====
+5a37976 docs: clarify required model files
+ docs/help.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-27T16:32:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5a379760cd2b25e07ed8d3e8fd2f2c3a2147dd1a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_163254_3d3f7c6bae6e8a6d6fd65617d1169a52eede23a1.log
+++ b/docs/patch_logs/patch_20250727_163254_3d3f7c6bae6e8a6d6fd65617d1169a52eede23a1.log
@@ -1,0 +1,55 @@
+patch_20250727_163254_3d3f7c6bae6e8a6d6fd65617d1169a52eede23a1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3d3f7c6bae6e8a6d6fd65617d1169a52eede23a1
+
+=====DIFFSUMMARY=====
+3d3f7c6 Merge pull request #462 from buymeagoat/codex/update-prerequisites-in-help.md
+
+ docs/help.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-27T16:32:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3d3f7c6bae6e8a6d6fd65617d1169a52eede23a1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_164013_9219e0104dd23f8ef6fd8cb44727f42c2a96d707.log
+++ b/docs/patch_logs/patch_20250727_164013_9219e0104dd23f8ef6fd8cb44727f42c2a96d707.log
@@ -1,0 +1,54 @@
+patch_20250727_164013_9219e0104dd23f8ef6fd8cb44727f42c2a96d707.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9219e0104dd23f8ef6fd8cb44727f42c2a96d707
+
+=====DIFFSUMMARY=====
+9219e01 Fix pip wheel generation
+ scripts/prestage_dependencies.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:40:13Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9219e0104dd23f8ef6fd8cb44727f42c2a96d707
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_164039_f5543a770adda70ad0c5cacca505521cb1e25a31.log
+++ b/docs/patch_logs/patch_20250727_164039_f5543a770adda70ad0c5cacca505521cb1e25a31.log
@@ -1,0 +1,55 @@
+patch_20250727_164039_f5543a770adda70ad0c5cacca505521cb1e25a31.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f5543a770adda70ad0c5cacca505521cb1e25a31
+
+=====DIFFSUMMARY=====
+f5543a7 Merge pull request #463 from buymeagoat/codex/fix-missing-wheel-for-openai-whisper
+
+ scripts/prestage_dependencies.sh | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:40:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f5543a770adda70ad0c5cacca505521cb1e25a31
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_164533_49dc0609a7fe2e0d1503c46ce872cb29c23b0cc7.log
+++ b/docs/patch_logs/patch_20250727_164533_49dc0609a7fe2e0d1503c46ce872cb29c23b0cc7.log
@@ -1,0 +1,54 @@
+patch_20250727_164533_49dc0609a7fe2e0d1503c46ce872cb29c23b0cc7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 49dc0609a7fe2e0d1503c46ce872cb29c23b0cc7
+
+=====DIFFSUMMARY=====
+49dc060 Fix duplicate pip wheel invocation in prestage script
+ scripts/prestage_dependencies.sh | 1 -
+ 1 file changed, 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:45:33Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+49dc0609a7fe2e0d1503c46ce872cb29c23b0cc7
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_164545_2fa34f4333a0ac764afba1a311d5b0c42795b5d1.log
+++ b/docs/patch_logs/patch_20250727_164545_2fa34f4333a0ac764afba1a311d5b0c42795b5d1.log
@@ -1,0 +1,55 @@
+patch_20250727_164545_2fa34f4333a0ac764afba1a311d5b0c42795b5d1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 2fa34f4333a0ac764afba1a311d5b0c42795b5d1
+
+=====DIFFSUMMARY=====
+2fa34f4 Merge pull request #464 from buymeagoat/codex/update-script-for-pip-wheel-invocation
+
+ scripts/prestage_dependencies.sh | 1 -
+ 1 file changed, 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:45:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2fa34f4333a0ac764afba1a311d5b0c42795b5d1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_165539_0e50a41e508fe1430a60315a1f76ccb206736376.log
+++ b/docs/patch_logs/patch_20250727_165539_0e50a41e508fe1430a60315a1f76ccb206736376.log
@@ -1,0 +1,54 @@
+patch_20250727_165539_0e50a41e508fe1430a60315a1f76ccb206736376.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0e50a41e508fe1430a60315a1f76ccb206736376
+
+=====DIFFSUMMARY=====
+0e50a41 Pin openai-whisper version
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:55:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0e50a41e508fe1430a60315a1f76ccb206736376
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_165548_3d4a8ec130f26e86b8d66eb875b12a2ddab0cd38.log
+++ b/docs/patch_logs/patch_20250727_165548_3d4a8ec130f26e86b8d66eb875b12a2ddab0cd38.log
@@ -1,0 +1,55 @@
+patch_20250727_165548_3d4a8ec130f26e86b8d66eb875b12a2ddab0cd38.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3d4a8ec130f26e86b8d66eb875b12a2ddab0cd38
+
+=====DIFFSUMMARY=====
+3d4a8ec Merge pull request #465 from buymeagoat/codex/update-requirements.txt-with-fixed-release
+
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T16:55:48Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3d4a8ec130f26e86b8d66eb875b12a2ddab0cd38
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_165949_15790ae0649b7afd26ee056afb23a57a368de76c.log
+++ b/docs/patch_logs/patch_20250727_165949_15790ae0649b7afd26ee056afb23a57a368de76c.log
@@ -1,0 +1,54 @@
+patch_20250727_165949_15790ae0649b7afd26ee056afb23a57a368de76c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 15790ae0649b7afd26ee056afb23a57a368de76c
+
+=====DIFFSUMMARY=====
+15790ae Check for Whisper wheel after build
+ scripts/prestage_dependencies.sh | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T16:59:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+15790ae0649b7afd26ee056afb23a57a368de76c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_170000_7a5a12bca5eceae4e10deba344c4d964ebe1c083.log
+++ b/docs/patch_logs/patch_20250727_170000_7a5a12bca5eceae4e10deba344c4d964ebe1c083.log
@@ -1,0 +1,55 @@
+patch_20250727_170000_7a5a12bca5eceae4e10deba344c4d964ebe1c083.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 7a5a12bca5eceae4e10deba344c4d964ebe1c083
+
+=====DIFFSUMMARY=====
+7a5a12b Merge pull request #466 from buymeagoat/codex/add-check-for-openai_whisper-wheel
+
+ scripts/prestage_dependencies.sh | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T17:00:00Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7a5a12bca5eceae4e10deba344c4d964ebe1c083
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_170342_4bef9b840bca9910bcaf6180020768184e1cea9d.log
+++ b/docs/patch_logs/patch_20250727_170342_4bef9b840bca9910bcaf6180020768184e1cea9d.log
@@ -1,0 +1,54 @@
+patch_20250727_170342_4bef9b840bca9910bcaf6180020768184e1cea9d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 4bef9b840bca9910bcaf6180020768184e1cea9d
+
+=====DIFFSUMMARY=====
+4bef9b8 docs: clarify model requirement
+ README.md | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T17:03:42Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4bef9b840bca9910bcaf6180020768184e1cea9d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_170353_464526d9875a76ad02eaf4fc09eb8882c9c7cd0e.log
+++ b/docs/patch_logs/patch_20250727_170353_464526d9875a76ad02eaf4fc09eb8882c9c7cd0e.log
@@ -1,0 +1,55 @@
+patch_20250727_170353_464526d9875a76ad02eaf4fc09eb8882c9c7cd0e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 464526d9875a76ad02eaf4fc09eb8882c9c7cd0e
+
+=====DIFFSUMMARY=====
+464526d Merge pull request #467 from buymeagoat/codex/update-readme.md-with-model-file-requirements
+
+ README.md | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T17:03:53Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+464526d9875a76ad02eaf4fc09eb8882c9c7cd0e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_173511_d242602ccf49b3b33c9f83941f9c6d63af3fe3d8.log
+++ b/docs/patch_logs/patch_20250727_173511_d242602ccf49b3b33c9f83941f9c6d63af3fe3d8.log
@@ -1,0 +1,54 @@
+patch_20250727_173511_d242602ccf49b3b33c9f83941f9c6d63af3fe3d8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d242602ccf49b3b33c9f83941f9c6d63af3fe3d8
+
+=====DIFFSUMMARY=====
+d242602 Update openai-whisper version
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T17:35:11Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d242602ccf49b3b33c9f83941f9c6d63af3fe3d8
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_173726_c4d77a9194619ea8693aedba015bc7e0d92d7901.log
+++ b/docs/patch_logs/patch_20250727_173726_c4d77a9194619ea8693aedba015bc7e0d92d7901.log
@@ -1,0 +1,55 @@
+patch_20250727_173726_c4d77a9194619ea8693aedba015bc7e0d92d7901.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit c4d77a9194619ea8693aedba015bc7e0d92d7901
+
+=====DIFFSUMMARY=====
+c4d77a9 Merge pull request #468 from buymeagoat/codex/update-openai-whisper-version-in-requirements
+
+ requirements.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T17:37:26Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c4d77a9194619ea8693aedba015bc7e0d92d7901
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_182012_5c5c944a92be4cc9f4160eead0ccadb7fc0f6005.log
+++ b/docs/patch_logs/patch_20250727_182012_5c5c944a92be4cc9f4160eead0ccadb7fc0f6005.log
@@ -1,0 +1,55 @@
+patch_20250727_182012_5c5c944a92be4cc9f4160eead0ccadb7fc0f6005.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5c5c944a92be4cc9f4160eead0ccadb7fc0f6005
+
+=====DIFFSUMMARY=====
+5c5c944 Sync apt cache into Docker build context
+ .gitignore              | 1 +
+ scripts/docker_build.sh | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T18:20:12Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5c5c944a92be4cc9f4160eead0ccadb7fc0f6005
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_182040_94092787c7c285d015d85c464de42624710f97ae.log
+++ b/docs/patch_logs/patch_20250727_182040_94092787c7c285d015d85c464de42624710f97ae.log
@@ -1,0 +1,56 @@
+patch_20250727_182040_94092787c7c285d015d85c464de42624710f97ae.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 94092787c7c285d015d85c464de42624710f97ae
+
+=====DIFFSUMMARY=====
+9409278 Merge pull request #469 from buymeagoat/codex/copy-.deb-files-into-docker-build-context
+
+ .gitignore              | 1 +
+ scripts/docker_build.sh | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T18:20:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+94092787c7c285d015d85c464de42624710f97ae
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_182942_d02ea7339954b9a10e947b4eaf549e5e41a1f5a8.log
+++ b/docs/patch_logs/patch_20250727_182942_d02ea7339954b9a10e947b4eaf549e5e41a1f5a8.log
@@ -1,0 +1,54 @@
+patch_20250727_182942_d02ea7339954b9a10e947b4eaf549e5e41a1f5a8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d02ea7339954b9a10e947b4eaf549e5e41a1f5a8
+
+=====DIFFSUMMARY=====
+d02ea73 chore: validate apt cache before docker build
+ scripts/docker_build.sh | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T18:29:42Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d02ea7339954b9a10e947b4eaf549e5e41a1f5a8
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_183043_afc6b9bd2b097e7fe513d71f42fafefda600ea65.log
+++ b/docs/patch_logs/patch_20250727_183043_afc6b9bd2b097e7fe513d71f42fafefda600ea65.log
@@ -1,0 +1,55 @@
+patch_20250727_183043_afc6b9bd2b097e7fe513d71f42fafefda600ea65.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit afc6b9bd2b097e7fe513d71f42fafefda600ea65
+
+=====DIFFSUMMARY=====
+afc6b9b Merge pull request #470 from buymeagoat/codex/enhance-docker-build-script-robustness
+
+ scripts/docker_build.sh | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T18:30:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+afc6b9bd2b097e7fe513d71f42fafefda600ea65
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_185649_3a0918174a85a6f658781850840d9458b43ddd1d.log
+++ b/docs/patch_logs/patch_20250727_185649_3a0918174a85a6f658781850840d9458b43ddd1d.log
@@ -1,0 +1,54 @@
+patch_20250727_185649_3a0918174a85a6f658781850840d9458b43ddd1d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3a0918174a85a6f658781850840d9458b43ddd1d
+
+=====DIFFSUMMARY=====
+3a09181 Use apt-get install for debs
+ Dockerfile | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T18:56:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3a0918174a85a6f658781850840d9458b43ddd1d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_185659_0f8ccf02fd86ac86a56eb1d243ed5e7d5dc8b41f.log
+++ b/docs/patch_logs/patch_20250727_185659_0f8ccf02fd86ac86a56eb1d243ed5e7d5dc8b41f.log
@@ -1,0 +1,55 @@
+patch_20250727_185659_0f8ccf02fd86ac86a56eb1d243ed5e7d5dc8b41f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0f8ccf02fd86ac86a56eb1d243ed5e7d5dc8b41f
+
+=====DIFFSUMMARY=====
+0f8ccf0 Merge pull request #471 from buymeagoat/codex/replace-dpkg-with-apt-install-in-dockerfile
+
+ Dockerfile | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T18:56:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0f8ccf02fd86ac86a56eb1d243ed5e7d5dc8b41f
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_191841_b613dd2047187fc98c33f6067e84623196177d27.log
+++ b/docs/patch_logs/patch_20250727_191841_b613dd2047187fc98c33f6067e84623196177d27.log
@@ -1,0 +1,54 @@
+patch_20250727_191841_b613dd2047187fc98c33f6067e84623196177d27.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b613dd2047187fc98c33f6067e84623196177d27
+
+=====DIFFSUMMARY=====
+b613dd2 Update Docker base image and apt-get update
+ Dockerfile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T19:18:41Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b613dd2047187fc98c33f6067e84623196177d27
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_191906_ff50af27df2846dd2229e0cc12735ba09336a8af.log
+++ b/docs/patch_logs/patch_20250727_191906_ff50af27df2846dd2229e0cc12735ba09336a8af.log
@@ -1,0 +1,55 @@
+patch_20250727_191906_ff50af27df2846dd2229e0cc12735ba09336a8af.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ff50af27df2846dd2229e0cc12735ba09336a8af
+
+=====DIFFSUMMARY=====
+ff50af2 Merge pull request #472 from buymeagoat/codex/update-dockerfile-base-image-and-apt-command
+
+ Dockerfile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T19:19:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ff50af27df2846dd2229e0cc12735ba09336a8af
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_194807_bd3d5654b5240db7c14d98d64af50b230b8a1164.log
+++ b/docs/patch_logs/patch_20250727_194807_bd3d5654b5240db7c14d98d64af50b230b8a1164.log
@@ -1,0 +1,54 @@
+patch_20250727_194807_bd3d5654b5240db7c14d98d64af50b230b8a1164.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit bd3d5654b5240db7c14d98d64af50b230b8a1164
+
+=====DIFFSUMMARY=====
+bd3d565 Add environment verification script
+ scripts/check_env.sh | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T19:48:07Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bd3d5654b5240db7c14d98d64af50b230b8a1164
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_195131_0fcaa19c8f4d50bbc9bff7e0961e63a74381edd6.log
+++ b/docs/patch_logs/patch_20250727_195131_0fcaa19c8f4d50bbc9bff7e0961e63a74381edd6.log
@@ -1,0 +1,55 @@
+patch_20250727_195131_0fcaa19c8f4d50bbc9bff7e0961e63a74381edd6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0fcaa19c8f4d50bbc9bff7e0961e63a74381edd6
+
+=====DIFFSUMMARY=====
+0fcaa19 Merge pull request #474 from buymeagoat/codex/create-script-to-check-environment
+
+ scripts/check_env.sh | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T19:51:31Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0fcaa19c8f4d50bbc9bff7e0961e63a74381edd6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_195713_bb0c4f008da30aa0ca078e27ef74648b3c794e6e.log
+++ b/docs/patch_logs/patch_20250727_195713_bb0c4f008da30aa0ca078e27ef74648b3c794e6e.log
@@ -1,0 +1,54 @@
+patch_20250727_195713_bb0c4f008da30aa0ca078e27ef74648b3c794e6e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit bb0c4f008da30aa0ca078e27ef74648b3c794e6e
+
+=====DIFFSUMMARY=====
+bb0c4f0 Run environment check in docker build
+ scripts/docker_build.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-27T19:57:13Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bb0c4f008da30aa0ca078e27ef74648b3c794e6e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_195721_ca3db11b01984002b16fa4a839ebe0721c1b9f1f.log
+++ b/docs/patch_logs/patch_20250727_195721_ca3db11b01984002b16fa4a839ebe0721c1b9f1f.log
@@ -1,0 +1,55 @@
+patch_20250727_195721_ca3db11b01984002b16fa4a839ebe0721c1b9f1f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ca3db11b01984002b16fa4a839ebe0721c1b9f1f
+
+=====DIFFSUMMARY=====
+ca3db11 Merge pull request #475 from buymeagoat/codex/update-docker_build.sh-to-check-environment
+
+ scripts/docker_build.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-27T19:57:21Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ca3db11b01984002b16fa4a839ebe0721c1b9f1f
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_200224_e3ad3de74adfd222295276c757ea7ffc1d70e021.log
+++ b/docs/patch_logs/patch_20250727_200224_e3ad3de74adfd222295276c757ea7ffc1d70e021.log
@@ -1,0 +1,54 @@
+patch_20250727_200224_e3ad3de74adfd222295276c757ea7ffc1d70e021.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e3ad3de74adfd222295276c757ea7ffc1d70e021
+
+=====DIFFSUMMARY=====
+e3ad3de scripts: verify environment during staging
+ scripts/start_containers.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T20:02:24Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e3ad3de74adfd222295276c757ea7ffc1d70e021
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_200234_b410708258092b0c21363902b71e779ba8cedaaa.log
+++ b/docs/patch_logs/patch_20250727_200234_b410708258092b0c21363902b71e779ba8cedaaa.log
@@ -1,0 +1,55 @@
+patch_20250727_200234_b410708258092b0c21363902b71e779ba8cedaaa.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b410708258092b0c21363902b71e779ba8cedaaa
+
+=====DIFFSUMMARY=====
+b410708 Merge pull request #476 from buymeagoat/codex/edit-start_containers.sh-for-staging-check
+
+ scripts/start_containers.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T20:02:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b410708258092b0c21363902b71e779ba8cedaaa
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_201243_ef1ab5ff91c5a760cbbeedd77cc7f28968916eb9.log
+++ b/docs/patch_logs/patch_20250727_201243_ef1ab5ff91c5a760cbbeedd77cc7f28968916eb9.log
@@ -1,0 +1,56 @@
+patch_20250727_201243_ef1ab5ff91c5a760cbbeedd77cc7f28968916eb9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ef1ab5ff91c5a760cbbeedd77cc7f28968916eb9
+
+=====DIFFSUMMARY=====
+ef1ab5f docs: mention check_env script and WSL DNS
+ README.md            | 1 +
+ docs/design_scope.md | 3 +++
+ docs/help.md         | 1 +
+ 3 files changed, 5 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T20:12:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ef1ab5ff91c5a760cbbeedd77cc7f28968916eb9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_201254_b8a1870d304d50a87c27a2125b9107080a3beb2f.log
+++ b/docs/patch_logs/patch_20250727_201254_b8a1870d304d50a87c27a2125b9107080a3beb2f.log
@@ -1,0 +1,57 @@
+patch_20250727_201254_b8a1870d304d50a87c27a2125b9107080a3beb2f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b8a1870d304d50a87c27a2125b9107080a3beb2f
+
+=====DIFFSUMMARY=====
+b8a1870 Merge pull request #477 from buymeagoat/codex/document-setup/build-script-and-dns-options
+
+ README.md            | 1 +
+ docs/design_scope.md | 3 +++
+ docs/help.md         | 1 +
+ 3 files changed, 5 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-27T20:12:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b8a1870d304d50a87c27a2125b9107080a3beb2f
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_203639_fd1395e0993d0f11e64ed7bf1df74d4ebf958675.log
+++ b/docs/patch_logs/patch_20250727_203639_fd1395e0993d0f11e64ed7bf1df74d4ebf958675.log
@@ -1,0 +1,56 @@
+patch_20250727_203639_fd1395e0993d0f11e64ed7bf1df74d4ebf958675.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit fd1395e0993d0f11e64ed7bf1df74d4ebf958675
+
+=====DIFFSUMMARY=====
+fd1395e prestage: check codename
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ scripts/prestage_dependencies.sh | 15 ++++++++++++++-
+ 3 files changed, 16 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T20:36:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fd1395e0993d0f11e64ed7bf1df74d4ebf958675
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_203738_92216ec227f6326af6c5efb2795858fdae361b61.log
+++ b/docs/patch_logs/patch_20250727_203738_92216ec227f6326af6c5efb2795858fdae361b61.log
@@ -1,0 +1,57 @@
+patch_20250727_203738_92216ec227f6326af6c5efb2795858fdae361b61.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 92216ec227f6326af6c5efb2795858fdae361b61
+
+=====DIFFSUMMARY=====
+92216ec Merge pull request #478 from buymeagoat/codex/add-codename-validation-in-prestage_dependencies.sh
+
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ scripts/prestage_dependencies.sh | 15 ++++++++++++++-
+ 3 files changed, 16 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T20:37:38Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+92216ec227f6326af6c5efb2795858fdae361b61
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_205759_b6e2224ddd23fe11b022536999948650c4103cee.log
+++ b/docs/patch_logs/patch_20250727_205759_b6e2224ddd23fe11b022536999948650c4103cee.log
@@ -1,0 +1,54 @@
+patch_20250727_205759_b6e2224ddd23fe11b022536999948650c4103cee.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b6e2224ddd23fe11b022536999948650c4103cee
+
+=====DIFFSUMMARY=====
+b6e2224 feat: add internet check and dry-run option
+ scripts/prestage_dependencies.sh | 66 +++++++++++++++++++++++++++++++---------
+ 1 file changed, 51 insertions(+), 15 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T20:57:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b6e2224ddd23fe11b022536999948650c4103cee
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_205810_a7a2d5d4cdd178fd85fc55f6d6a552f852163b75.log
+++ b/docs/patch_logs/patch_20250727_205810_a7a2d5d4cdd178fd85fc55f6d6a552f852163b75.log
@@ -1,0 +1,55 @@
+patch_20250727_205810_a7a2d5d4cdd178fd85fc55f6d6a552f852163b75.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a7a2d5d4cdd178fd85fc55f6d6a552f852163b75
+
+=====DIFFSUMMARY=====
+a7a2d5d Merge pull request #479 from buymeagoat/codex/add-network-checks-before-downloads
+
+ scripts/prestage_dependencies.sh | 66 +++++++++++++++++++++++++++++++---------
+ 1 file changed, 51 insertions(+), 15 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T20:58:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a7a2d5d4cdd178fd85fc55f6d6a552f852163b75
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_210144_d5caa15630b1f2111fb87ae7b9e9abfe3118b3a4.log
+++ b/docs/patch_logs/patch_20250727_210144_d5caa15630b1f2111fb87ae7b9e9abfe3118b3a4.log
@@ -1,0 +1,54 @@
+patch_20250727_210144_d5caa15630b1f2111fb87ae7b9e9abfe3118b3a4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d5caa15630b1f2111fb87ae7b9e9abfe3118b3a4
+
+=====DIFFSUMMARY=====
+d5caa15 Validate apt packages codename
+ scripts/prestage_dependencies.sh | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:01:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d5caa15630b1f2111fb87ae7b9e9abfe3118b3a4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_210205_bdd31112dee90d7443463f2a691a6b26c762dd2a.log
+++ b/docs/patch_logs/patch_20250727_210205_bdd31112dee90d7443463f2a691a6b26c762dd2a.log
@@ -1,0 +1,55 @@
+patch_20250727_210205_bdd31112dee90d7443463f2a691a6b26c762dd2a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit bdd31112dee90d7443463f2a691a6b26c762dd2a
+
+=====DIFFSUMMARY=====
+bdd3111 Merge pull request #480 from buymeagoat/codex/validate-downloaded-packages-for-jammy
+
+ scripts/prestage_dependencies.sh | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:02:05Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+bdd31112dee90d7443463f2a691a6b26c762dd2a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_212557_59e5504d60ffc1cbc2ce097c55525dda20f4593e.log
+++ b/docs/patch_logs/patch_20250727_212557_59e5504d60ffc1cbc2ce097c55525dda20f4593e.log
@@ -1,0 +1,55 @@
+patch_20250727_212557_59e5504d60ffc1cbc2ce097c55525dda20f4593e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 59e5504d60ffc1cbc2ce097c55525dda20f4593e
+
+=====DIFFSUMMARY=====
+59e5504 Record package versions after caching
+ README.md                        |  1 +
+ scripts/prestage_dependencies.sh | 10 +++++++++-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:25:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+59e5504d60ffc1cbc2ce097c55525dda20f4593e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_212609_b4c9d6cd479dd7b238c02bf3a133ba8a6afb0783.log
+++ b/docs/patch_logs/patch_20250727_212609_b4c9d6cd479dd7b238c02bf3a133ba8a6afb0783.log
@@ -1,0 +1,56 @@
+patch_20250727_212609_b4c9d6cd479dd7b238c02bf3a133ba8a6afb0783.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b4c9d6cd479dd7b238c02bf3a133ba8a6afb0783
+
+=====DIFFSUMMARY=====
+b4c9d6c Merge pull request #481 from buymeagoat/codex/log-pip-and-npm-package-versions
+
+ README.md                        |  1 +
+ scripts/prestage_dependencies.sh | 10 +++++++++-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:26:09Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b4c9d6cd479dd7b238c02bf3a133ba8a6afb0783
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_213552_d1394510a0a4e5e092d84be72029d85c38cbb17f.log
+++ b/docs/patch_logs/patch_20250727_213552_d1394510a0a4e5e092d84be72029d85c38cbb17f.log
@@ -1,0 +1,57 @@
+patch_20250727_213552_d1394510a0a4e5e092d84be72029d85c38cbb17f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d1394510a0a4e5e092d84be72029d85c38cbb17f
+
+=====DIFFSUMMARY=====
+d139451 Add checksum option to prestage script
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  4 ++++
+ scripts/prestage_dependencies.sh | 13 ++++++++++++-
+ 4 files changed, 18 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:35:52Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d1394510a0a4e5e092d84be72029d85c38cbb17f
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_213621_d5ccc0f9d25f63b04fda170c1299e63608b27e43.log
+++ b/docs/patch_logs/patch_20250727_213621_d5ccc0f9d25f63b04fda170c1299e63608b27e43.log
@@ -1,0 +1,58 @@
+patch_20250727_213621_d5ccc0f9d25f63b04fda170c1299e63608b27e43.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d5ccc0f9d25f63b04fda170c1299e63608b27e43
+
+=====DIFFSUMMARY=====
+d5ccc0f Merge pull request #482 from buymeagoat/codex/add-checksum-flag-to-prestage_dependencies.sh
+
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  4 ++++
+ scripts/prestage_dependencies.sh | 13 ++++++++++++-
+ 4 files changed, 18 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:36:21Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d5ccc0f9d25f63b04fda170c1299e63608b27e43
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_214641_15258b8773e0ed65313627cfd13eb1a32fd9d8cc.log
+++ b/docs/patch_logs/patch_20250727_214641_15258b8773e0ed65313627cfd13eb1a32fd9d8cc.log
@@ -1,0 +1,58 @@
+patch_20250727_214641_15258b8773e0ed65313627cfd13eb1a32fd9d8cc.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 15258b8773e0ed65313627cfd13eb1a32fd9d8cc
+
+=====DIFFSUMMARY=====
+15258b8 cache python image digest
+ README.md                        |  2 +-
+ docs/design_scope.md             |  5 +++--
+ docs/help.md                     |  2 +-
+ scripts/check_env.sh             | 15 +++++++++++++++
+ scripts/prestage_dependencies.sh |  7 ++++++-
+ 5 files changed, 26 insertions(+), 5 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:46:41Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+15258b8773e0ed65313627cfd13eb1a32fd9d8cc
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_214651_2ec191b221c82d25feccaed13e3c779b75190b6b.log
+++ b/docs/patch_logs/patch_20250727_214651_2ec191b221c82d25feccaed13e3c779b75190b6b.log
@@ -1,0 +1,59 @@
+patch_20250727_214651_2ec191b221c82d25feccaed13e3c779b75190b6b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 2ec191b221c82d25feccaed13e3c779b75190b6b
+
+=====DIFFSUMMARY=====
+2ec191b Merge pull request #483 from buymeagoat/codex/store-and-verify-python-digest
+
+ README.md                        |  2 +-
+ docs/design_scope.md             |  5 +++--
+ docs/help.md                     |  2 +-
+ scripts/check_env.sh             | 15 +++++++++++++++
+ scripts/prestage_dependencies.sh |  7 ++++++-
+ 5 files changed, 26 insertions(+), 5 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T21:46:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2ec191b221c82d25feccaed13e3c779b75190b6b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_220437_004b8d4b71b9bb2a81b6cff82d7dcc0c4bbaad51.log
+++ b/docs/patch_logs/patch_20250727_220437_004b8d4b71b9bb2a81b6cff82d7dcc0c4bbaad51.log
@@ -1,0 +1,57 @@
+patch_20250727_220437_004b8d4b71b9bb2a81b6cff82d7dcc0c4bbaad51.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 004b8d4b71b9bb2a81b6cff82d7dcc0c4bbaad51
+
+=====DIFFSUMMARY=====
+004b8d4 enhance prestage checksum
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  2 +-
+ scripts/prestage_dependencies.sh | 22 +++++++++++++++++++---
+ 4 files changed, 22 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T22:04:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+004b8d4b71b9bb2a81b6cff82d7dcc0c4bbaad51
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_220448_a0553d29f4107f592e1bff85c50582ea2dd76b4e.log
+++ b/docs/patch_logs/patch_20250727_220448_a0553d29f4107f592e1bff85c50582ea2dd76b4e.log
@@ -1,0 +1,58 @@
+patch_20250727_220448_a0553d29f4107f592e1bff85c50582ea2dd76b4e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a0553d29f4107f592e1bff85c50582ea2dd76b4e
+
+=====DIFFSUMMARY=====
+a0553d2 Merge pull request #484 from buymeagoat/codex/update-checksum-generation-and-manifest-creation
+
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  2 +-
+ scripts/prestage_dependencies.sh | 22 +++++++++++++++++++---
+ 4 files changed, 22 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T22:04:48Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a0553d29f4107f592e1bff85c50582ea2dd76b4e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_234035_a1df49cc52325a9b6f41490b457bd761c51bba55.log
+++ b/docs/patch_logs/patch_20250727_234035_a1df49cc52325a9b6f41490b457bd761c51bba55.log
@@ -1,0 +1,54 @@
+patch_20250727_234035_a1df49cc52325a9b6f41490b457bd761c51bba55.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a1df49cc52325a9b6f41490b457bd761c51bba55
+
+=====DIFFSUMMARY=====
+a1df49c feat: add verify-only option to prestage script
+ scripts/prestage_dependencies.sh | 35 +++++++++++++++++++++++------------
+ 1 file changed, 23 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T23:40:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a1df49cc52325a9b6f41490b457bd761c51bba55
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250727_234247_9c1c192a8e803cf0fa299862d0245501cb2ea629.log
+++ b/docs/patch_logs/patch_20250727_234247_9c1c192a8e803cf0fa299862d0245501cb2ea629.log
@@ -1,0 +1,55 @@
+patch_20250727_234247_9c1c192a8e803cf0fa299862d0245501cb2ea629.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9c1c192a8e803cf0fa299862d0245501cb2ea629
+
+=====DIFFSUMMARY=====
+9c1c192 Merge pull request #485 from buymeagoat/codex/add-verify-only-flag-to-prestage-script
+
+ scripts/prestage_dependencies.sh | 35 +++++++++++++++++++++++------------
+ 1 file changed, 23 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-27T23:42:47Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9c1c192a8e803cf0fa299862d0245501cb2ea629
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_001710_0ab0ecb09ba09dbbbb2ad573f5bf18a1f20d6948.log
+++ b/docs/patch_logs/patch_20250728_001710_0ab0ecb09ba09dbbbb2ad573f5bf18a1f20d6948.log
@@ -1,0 +1,56 @@
+patch_20250728_001710_0ab0ecb09ba09dbbbb2ad573f5bf18a1f20d6948.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0ab0ecb09ba09dbbbb2ad573f5bf18a1f20d6948
+
+=====DIFFSUMMARY=====
+0ab0ecb Add apt source connectivity check
+ README.md                        |  2 +-
+ scripts/prestage_dependencies.sh |  1 +
+ scripts/shared_checks.sh         | 14 ++++++++++++++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:17:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0ab0ecb09ba09dbbbb2ad573f5bf18a1f20d6948
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_001735_c3f995c9d8626be65ab417b8aee47387daf2ecb0.log
+++ b/docs/patch_logs/patch_20250728_001735_c3f995c9d8626be65ab417b8aee47387daf2ecb0.log
@@ -1,0 +1,57 @@
+patch_20250728_001735_c3f995c9d8626be65ab417b8aee47387daf2ecb0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit c3f995c9d8626be65ab417b8aee47387daf2ecb0
+
+=====DIFFSUMMARY=====
+c3f995c Merge pull request #486 from buymeagoat/codex/add-check_apt_sources-function
+
+ README.md                        |  2 +-
+ scripts/prestage_dependencies.sh |  1 +
+ scripts/shared_checks.sh         | 14 ++++++++++++++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:17:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c3f995c9d8626be65ab417b8aee47387daf2ecb0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_003239_235f97bd1451bd87ca462e9875b296bd8adbf083.log
+++ b/docs/patch_logs/patch_20250728_003239_235f97bd1451bd87ca462e9875b296bd8adbf083.log
@@ -1,0 +1,57 @@
+patch_20250728_003239_235f97bd1451bd87ca462e9875b296bd8adbf083.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 235f97bd1451bd87ca462e9875b296bd8adbf083
+
+=====DIFFSUMMARY=====
+235f97b generalize codename checks
+ README.md                        |  4 ++--
+ docs/design_scope.md             |  8 ++++----
+ scripts/check_env.sh             | 11 ++++++-----
+ scripts/prestage_dependencies.sh | 15 +++++++--------
+ 4 files changed, 19 insertions(+), 19 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:32:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+235f97bd1451bd87ca462e9875b296bd8adbf083
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_003302_d0caed8a16c5b332ea7b0be6fab02819a0111325.log
+++ b/docs/patch_logs/patch_20250728_003302_d0caed8a16c5b332ea7b0be6fab02819a0111325.log
@@ -1,0 +1,58 @@
+patch_20250728_003302_d0caed8a16c5b332ea7b0be6fab02819a0111325.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d0caed8a16c5b332ea7b0be6fab02819a0111325
+
+=====DIFFSUMMARY=====
+d0caed8 Merge pull request #488 from buymeagoat/codex/remove-jammy-specific-logic-from-prestage_dependencies.sh
+
+ README.md                        |  4 ++--
+ docs/design_scope.md             |  8 ++++----
+ scripts/check_env.sh             | 11 ++++++-----
+ scripts/prestage_dependencies.sh | 15 +++++++--------
+ 4 files changed, 19 insertions(+), 19 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:33:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d0caed8a16c5b332ea7b0be6fab02819a0111325
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_003735_99cc869707e93d427d0f99873feb8193514b6f21.log
+++ b/docs/patch_logs/patch_20250728_003735_99cc869707e93d427d0f99873feb8193514b6f21.log
@@ -1,0 +1,56 @@
+patch_20250728_003735_99cc869707e93d427d0f99873feb8193514b6f21.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 99cc869707e93d427d0f99873feb8193514b6f21
+
+=====DIFFSUMMARY=====
+99cc869 Document new lockfiles
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ scripts/prestage_dependencies.sh | 12 ++++++++++++
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:37:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+99cc869707e93d427d0f99873feb8193514b6f21
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_003744_96642d63a53acbf20e36e4f8e90d4277a7cf0cf4.log
+++ b/docs/patch_logs/patch_20250728_003744_96642d63a53acbf20e36e4f8e90d4277a7cf0cf4.log
@@ -1,0 +1,57 @@
+patch_20250728_003744_96642d63a53acbf20e36e4f8e90d4277a7cf0cf4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 96642d63a53acbf20e36e4f8e90d4277a7cf0cf4
+
+=====DIFFSUMMARY=====
+96642d6 Merge pull request #489 from buymeagoat/codex/update-dependency-staging-script
+
+ README.md                        |  2 +-
+ docs/design_scope.md             |  2 +-
+ scripts/prestage_dependencies.sh | 12 ++++++++++++
+ 3 files changed, 14 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T00:37:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+96642d63a53acbf20e36e4f8e90d4277a7cf0cf4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_015131_e10b6aa31bad9f20249915529788a0c770fb6bc6.log
+++ b/docs/patch_logs/patch_20250728_015131_e10b6aa31bad9f20249915529788a0c770fb6bc6.log
@@ -1,0 +1,57 @@
+patch_20250728_015131_e10b6aa31bad9f20249915529788a0c770fb6bc6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e10b6aa31bad9f20249915529788a0c770fb6bc6
+
+=====DIFFSUMMARY=====
+e10b6aa Record base image digest
+ README.md                        |  4 ++--
+ docs/design_scope.md             |  7 ++++---
+ scripts/check_env.sh             | 24 ++++++++++++++++--------
+ scripts/prestage_dependencies.sh |  5 +++++
+ 4 files changed, 27 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T01:51:31Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e10b6aa31bad9f20249915529788a0c770fb6bc6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_015150_72878cbea44b74b585f3bb1413e014bd6462fa69.log
+++ b/docs/patch_logs/patch_20250728_015150_72878cbea44b74b585f3bb1413e014bd6462fa69.log
@@ -1,0 +1,58 @@
+patch_20250728_015150_72878cbea44b74b585f3bb1413e014bd6462fa69.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 72878cbea44b74b585f3bb1413e014bd6462fa69
+
+=====DIFFSUMMARY=====
+72878cb Merge pull request #490 from buymeagoat/codex/store-base-image-digest-in-variable
+
+ README.md                        |  4 ++--
+ docs/design_scope.md             |  7 ++++---
+ scripts/check_env.sh             | 24 ++++++++++++++++--------
+ scripts/prestage_dependencies.sh |  5 +++++
+ 4 files changed, 27 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T01:51:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+72878cbea44b74b585f3bb1413e014bd6462fa69
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_142112_a060cc4849855573ba28cc482e17c189bf7bb85e.log
+++ b/docs/patch_logs/patch_20250728_142112_a060cc4849855573ba28cc482e17c189bf7bb85e.log
@@ -1,0 +1,56 @@
+patch_20250728_142112_a060cc4849855573ba28cc482e17c189bf7bb85e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a060cc4849855573ba28cc482e17c189bf7bb85e
+
+=====DIFFSUMMARY=====
+a060cc4 Add architecture checks for staged packages
+ README.md                        | 4 ++--
+ scripts/check_env.sh             | 9 ++++++++-
+ scripts/prestage_dependencies.sh | 8 +++++++-
+ 3 files changed, 17 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:21:12Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a060cc4849855573ba28cc482e17c189bf7bb85e
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_142131_6d7850700f8cd2b63b00aeae977b8ee913defd66.log
+++ b/docs/patch_logs/patch_20250728_142131_6d7850700f8cd2b63b00aeae977b8ee913defd66.log
@@ -1,0 +1,57 @@
+patch_20250728_142131_6d7850700f8cd2b63b00aeae977b8ee913defd66.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 6d7850700f8cd2b63b00aeae977b8ee913defd66
+
+=====DIFFSUMMARY=====
+6d78507 Merge pull request #491 from buymeagoat/codex/add-architecture-validation-to-scripts
+
+ README.md                        | 4 ++--
+ scripts/check_env.sh             | 9 ++++++++-
+ scripts/prestage_dependencies.sh | 8 +++++++-
+ 3 files changed, 17 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:21:31Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6d7850700f8cd2b63b00aeae977b8ee913defd66
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_143543_54eabd2c870c75961c46ca91a32487a9085de12b.log
+++ b/docs/patch_logs/patch_20250728_143543_54eabd2c870c75961c46ca91a32487a9085de12b.log
@@ -1,0 +1,57 @@
+patch_20250728_143543_54eabd2c870c75961c46ca91a32487a9085de12b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 54eabd2c870c75961c46ca91a32487a9085de12b
+
+=====DIFFSUMMARY=====
+54eabd2 Add rsync option and cache docs
+ README.md                        | 13 +++++++++++++
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  6 ++++++
+ scripts/prestage_dependencies.sh | 17 ++++++++++++++++-
+ 4 files changed, 36 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:35:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+54eabd2c870c75961c46ca91a32487a9085de12b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_143556_e87783165bf8a20e1ac3e65aed785e2368ec169d.log
+++ b/docs/patch_logs/patch_20250728_143556_e87783165bf8a20e1ac3e65aed785e2368ec169d.log
@@ -1,0 +1,58 @@
+patch_20250728_143556_e87783165bf8a20e1ac3e65aed785e2368ec169d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e87783165bf8a20e1ac3e65aed785e2368ec169d
+
+=====DIFFSUMMARY=====
+e877831 Merge pull request #492 from buymeagoat/codex/add-rsync-argument-to-prestage_dependencies.sh
+
+ README.md                        | 13 +++++++++++++
+ docs/design_scope.md             |  2 +-
+ docs/future_updates.md           |  6 ++++++
+ scripts/prestage_dependencies.sh | 17 ++++++++++++++++-
+ 4 files changed, 36 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:35:56Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e87783165bf8a20e1ac3e65aed785e2368ec169d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_144743_90c0c2c1f5ebe065f0f9a6d6b7775c46d61e43f1.log
+++ b/docs/patch_logs/patch_20250728_144743_90c0c2c1f5ebe065f0f9a6d6b7775c46d61e43f1.log
@@ -1,0 +1,55 @@
+patch_20250728_144743_90c0c2c1f5ebe065f0f9a6d6b7775c46d61e43f1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 90c0c2c1f5ebe065f0f9a6d6b7775c46d61e43f1
+
+=====DIFFSUMMARY=====
+90c0c2c Enforce digest mismatch check
+ docs/help.md         | 2 +-
+ scripts/check_env.sh | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:47:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+90c0c2c1f5ebe065f0f9a6d6b7775c46d61e43f1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_144753_a3af21b42fc7b0f29b720259d104182c93f12a76.log
+++ b/docs/patch_logs/patch_20250728_144753_a3af21b42fc7b0f29b720259d104182c93f12a76.log
@@ -1,0 +1,56 @@
+patch_20250728_144753_a3af21b42fc7b0f29b720259d104182c93f12a76.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a3af21b42fc7b0f29b720259d104182c93f12a76
+
+=====DIFFSUMMARY=====
+a3af21b Merge pull request #493 from buymeagoat/codex/update-check_env.sh-error-handling
+
+ docs/help.md         | 2 +-
+ scripts/check_env.sh | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T14:47:53Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a3af21b42fc7b0f29b720259d104182c93f12a76
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_145659_568ef9d78d599efe0144b57bcb7a62ff7cea89d3.log
+++ b/docs/patch_logs/patch_20250728_145659_568ef9d78d599efe0144b57bcb7a62ff7cea89d3.log
@@ -1,0 +1,55 @@
+patch_20250728_145659_568ef9d78d599efe0144b57bcb7a62ff7cea89d3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 568ef9d78d599efe0144b57bcb7a62ff7cea89d3
+
+=====DIFFSUMMARY=====
+568ef9d Add timestamp and manifest improvements
+ README.md                        | 22 ++++++++++++++++++++++
+ scripts/prestage_dependencies.sh | 12 ++++++++++++
+ 2 files changed, 34 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T14:56:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+568ef9d78d599efe0144b57bcb7a62ff7cea89d3
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_150045_fb47c22e6297deb68ea5b8ab548e2e9ef979cfc9.log
+++ b/docs/patch_logs/patch_20250728_150045_fb47c22e6297deb68ea5b8ab548e2e9ef979cfc9.log
@@ -1,0 +1,56 @@
+patch_20250728_150045_fb47c22e6297deb68ea5b8ab548e2e9ef979cfc9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit fb47c22e6297deb68ea5b8ab548e2e9ef979cfc9
+
+=====DIFFSUMMARY=====
+fb47c22 Merge pull request #494 from buymeagoat/codex/update-prestage_dependencies.sh-for-timestamp
+
+ README.md                        | 22 ++++++++++++++++++++++
+ scripts/prestage_dependencies.sh | 12 ++++++++++++
+ 2 files changed, 34 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T15:00:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fb47c22e6297deb68ea5b8ab548e2e9ef979cfc9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_160555_9b7cfba06860903b17b7b581dbed3c50ed963409.log
+++ b/docs/patch_logs/patch_20250728_160555_9b7cfba06860903b17b7b581dbed3c50ed963409.log
@@ -1,0 +1,56 @@
+patch_20250728_160555_9b7cfba06860903b17b7b581dbed3c50ed963409.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9b7cfba06860903b17b7b581dbed3c50ed963409
+
+=====DIFFSUMMARY=====
+9b7cfba harden env checks and add manifest validator
+ scripts/check_env.sh         | 63 +++++++++++++++-------------
+ scripts/shared_checks.sh     | 46 +++++++++++++++++++++
+ scripts/validate_manifest.sh | 98 ++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 178 insertions(+), 29 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T16:05:55Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9b7cfba06860903b17b7b581dbed3c50ed963409
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_160606_3685197801d53fa4cd85f8ea91cd169db412aea0.log
+++ b/docs/patch_logs/patch_20250728_160606_3685197801d53fa4cd85f8ea91cd169db412aea0.log
@@ -1,0 +1,57 @@
+patch_20250728_160606_3685197801d53fa4cd85f8ea91cd169db412aea0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3685197801d53fa4cd85f8ea91cd169db412aea0
+
+=====DIFFSUMMARY=====
+3685197 Merge pull request #495 from buymeagoat/codex/extend-responsibilities-of-scripts
+
+ scripts/check_env.sh         | 63 +++++++++++++++-------------
+ scripts/shared_checks.sh     | 46 +++++++++++++++++++++
+ scripts/validate_manifest.sh | 98 ++++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 178 insertions(+), 29 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T16:06:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3685197801d53fa4cd85f8ea91cd169db412aea0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_163637_f3ff5380a504d36a85f4a53237a2ffc3acb914fd.log
+++ b/docs/patch_logs/patch_20250728_163637_f3ff5380a504d36a85f4a53237a2ffc3acb914fd.log
@@ -1,0 +1,54 @@
+patch_20250728_163637_f3ff5380a504d36a85f4a53237a2ffc3acb914fd.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f3ff5380a504d36a85f4a53237a2ffc3acb914fd
+
+=====DIFFSUMMARY=====
+f3ff538 Update help.md with Docker quickstart and troubleshooting
+ docs/help.md | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T16:36:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f3ff5380a504d36a85f4a53237a2ffc3acb914fd
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_163646_ae75314c5d459c6e491a8d98a16371d604e80c47.log
+++ b/docs/patch_logs/patch_20250728_163646_ae75314c5d459c6e491a8d98a16371d604e80c47.log
@@ -1,0 +1,55 @@
+patch_20250728_163646_ae75314c5d459c6e491a8d98a16371d604e80c47.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ae75314c5d459c6e491a8d98a16371d604e80c47
+
+=====DIFFSUMMARY=====
+ae75314 Merge pull request #496 from buymeagoat/codex/update-help.md-for-real-world-usage
+
+ docs/help.md | 17 +++++++++++------
+ 1 file changed, 11 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T16:36:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ae75314c5d459c6e491a8d98a16371d604e80c47
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_190054_8d4cf6c17be56e7b9d3f51fc28df45fc4735800b.log
+++ b/docs/patch_logs/patch_20250728_190054_8d4cf6c17be56e7b9d3f51fc28df45fc4735800b.log
@@ -1,0 +1,54 @@
+patch_20250728_190054_8d4cf6c17be56e7b9d3f51fc28df45fc4735800b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 8d4cf6c17be56e7b9d3f51fc28df45fc4735800b
+
+=====DIFFSUMMARY=====
+8d4cf6c Refactor README for external users
+ README.md | 167 +++++++++++++-------------------------------------------------
+ 1 file changed, 35 insertions(+), 132 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:00:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8d4cf6c17be56e7b9d3f51fc28df45fc4735800b
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_190131_ccc282e7db8d7221dbbc93a8ad3cf3dd25e1bc7c.log
+++ b/docs/patch_logs/patch_20250728_190131_ccc282e7db8d7221dbbc93a8ad3cf3dd25e1bc7c.log
@@ -1,0 +1,55 @@
+patch_20250728_190131_ccc282e7db8d7221dbbc93a8ad3cf3dd25e1bc7c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ccc282e7db8d7221dbbc93a8ad3cf3dd25e1bc7c
+
+=====DIFFSUMMARY=====
+ccc282e Merge pull request #497 from buymeagoat/codex/refactor-readme.md-for-external-audience
+
+ README.md | 167 +++++++++++++-------------------------------------------------
+ 1 file changed, 35 insertions(+), 132 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:01:31Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ccc282e7db8d7221dbbc93a8ad3cf3dd25e1bc7c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_190703_6a31dd5dbddfeb9e05f7bf56801e4dca76f7c1d1.log
+++ b/docs/patch_logs/patch_20250728_190703_6a31dd5dbddfeb9e05f7bf56801e4dca76f7c1d1.log
@@ -1,0 +1,54 @@
+patch_20250728_190703_6a31dd5dbddfeb9e05f7bf56801e4dca76f7c1d1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 6a31dd5dbddfeb9e05f7bf56801e4dca76f7c1d1
+
+=====DIFFSUMMARY=====
+6a31dd5 docs: focus design_scope for dev reference
+ docs/design_scope.md | 45 +++++++++++++--------------------------------
+ 1 file changed, 13 insertions(+), 32 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:07:03Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6a31dd5dbddfeb9e05f7bf56801e4dca76f7c1d1
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_190714_6d16ab8ca6590cbb635d8b77413aca39e11bcb0c.log
+++ b/docs/patch_logs/patch_20250728_190714_6d16ab8ca6590cbb635d8b77413aca39e11bcb0c.log
@@ -1,0 +1,55 @@
+patch_20250728_190714_6d16ab8ca6590cbb635d8b77413aca39e11bcb0c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 6d16ab8ca6590cbb635d8b77413aca39e11bcb0c
+
+=====DIFFSUMMARY=====
+6d16ab8 Merge pull request #498 from buymeagoat/codex/refactor-design_scope.md-for-developer-reference
+
+ docs/design_scope.md | 45 +++++++++++++--------------------------------
+ 1 file changed, 13 insertions(+), 32 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:07:14Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6d16ab8ca6590cbb635d8b77413aca39e11bcb0c
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_191016_183db32fe0688e0a90c6e5a3a9e4722aba86c9b6.log
+++ b/docs/patch_logs/patch_20250728_191016_183db32fe0688e0a90c6e5a3a9e4722aba86c9b6.log
@@ -1,0 +1,54 @@
+patch_20250728_191016_183db32fe0688e0a90c6e5a3a9e4722aba86c9b6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 183db32fe0688e0a90c6e5a3a9e4722aba86c9b6
+
+=====DIFFSUMMARY=====
+183db32 docs: streamline quick start
+ docs/help.md | 75 ++++++++++++++++++------------------------------------------
+ 1 file changed, 22 insertions(+), 53 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:10:16Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+183db32fe0688e0a90c6e5a3a9e4722aba86c9b6
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_191027_79c7e22374654ef34e03733f3950e6e0ad039ae4.log
+++ b/docs/patch_logs/patch_20250728_191027_79c7e22374654ef34e03733f3950e6e0ad039ae4.log
@@ -1,0 +1,55 @@
+patch_20250728_191027_79c7e22374654ef34e03733f3950e6e0ad039ae4.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 79c7e22374654ef34e03733f3950e6e0ad039ae4
+
+=====DIFFSUMMARY=====
+79c7e22 Merge pull request #499 from buymeagoat/codex/simplify-help.md-for-initial-setup
+
+ docs/help.md | 75 ++++++++++++++++++------------------------------------------
+ 1 file changed, 22 insertions(+), 53 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T19:10:27Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+79c7e22374654ef34e03733f3950e6e0ad039ae4
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_191844_749131bc5c2fce6890b24e13bd9013cbbedb6dfa.log
+++ b/docs/patch_logs/patch_20250728_191844_749131bc5c2fce6890b24e13bd9013cbbedb6dfa.log
@@ -1,0 +1,54 @@
+patch_20250728_191844_749131bc5c2fce6890b24e13bd9013cbbedb6dfa.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 749131bc5c2fce6890b24e13bd9013cbbedb6dfa
+
+=====DIFFSUMMARY=====
+749131b docs: add Completed status definition
+ docs/future_updates.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:18:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+749131bc5c2fce6890b24e13bd9013cbbedb6dfa
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_191921_a4e0bedf43293d4c9508c831645f6a62ad6eecb7.log
+++ b/docs/patch_logs/patch_20250728_191921_a4e0bedf43293d4c9508c831645f6a62ad6eecb7.log
@@ -1,0 +1,55 @@
+patch_20250728_191921_a4e0bedf43293d4c9508c831645f6a62ad6eecb7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a4e0bedf43293d4c9508c831645f6a62ad6eecb7
+
+=====DIFFSUMMARY=====
+a4e0bed Merge pull request #500 from buymeagoat/codex/review-future_updates.md-for-actionable-plans
+
+ docs/future_updates.md | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:19:21Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a4e0bedf43293d4c9508c831645f6a62ad6eecb7
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_193853_0f917091a97ac829cfc780685d04b516a6e9dd0d.log
+++ b/docs/patch_logs/patch_20250728_193853_0f917091a97ac829cfc780685d04b516a6e9dd0d.log
@@ -1,0 +1,55 @@
+patch_20250728_193853_0f917091a97ac829cfc780685d04b516a6e9dd0d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0f917091a97ac829cfc780685d04b516a6e9dd0d
+
+=====DIFFSUMMARY=====
+0f91709 docs: add changelog and security guide
+ docs/CHANGELOG.md | 87 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ docs/SECURITY.md  | 38 ++++++++++++++++++++++++
+ 2 files changed, 125 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:38:53Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0f917091a97ac829cfc780685d04b516a6e9dd0d
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_193925_61616a82f5ec536afbc9642d12d12bf6b3d980c2.log
+++ b/docs/patch_logs/patch_20250728_193925_61616a82f5ec536afbc9642d12d12bf6b3d980c2.log
@@ -1,0 +1,56 @@
+patch_20250728_193925_61616a82f5ec536afbc9642d12d12bf6b3d980c2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 61616a82f5ec536afbc9642d12d12bf6b3d980c2
+
+=====DIFFSUMMARY=====
+61616a8 Merge pull request #501 from buymeagoat/codex/create-changelog.md-and-security.md-files
+
+ docs/CHANGELOG.md | 87 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ docs/SECURITY.md  | 38 ++++++++++++++++++++++++
+ 2 files changed, 125 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:39:25Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+61616a82f5ec536afbc9642d12d12bf6b3d980c2
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_194539_cad3ab79c8626f02a3ce13f126965742454d7429.log
+++ b/docs/patch_logs/patch_20250728_194539_cad3ab79c8626f02a3ce13f126965742454d7429.log
@@ -1,0 +1,55 @@
+patch_20250728_194539_cad3ab79c8626f02a3ce13f126965742454d7429.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit cad3ab79c8626f02a3ce13f126965742454d7429
+
+=====DIFFSUMMARY=====
+cad3ab7 docs: add contributing and troubleshooting guides
+ docs/CONTRIBUTING.md    | 47 +++++++++++++++++++++++++++++++++++++++++
+ docs/TROUBLESHOOTING.md | 56 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 103 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:45:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cad3ab79c8626f02a3ce13f126965742454d7429
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_194552_f237c5842a2833ca1d5740aa1339f926db037e56.log
+++ b/docs/patch_logs/patch_20250728_194552_f237c5842a2833ca1d5740aa1339f926db037e56.log
@@ -1,0 +1,56 @@
+patch_20250728_194552_f237c5842a2833ca1d5740aa1339f926db037e56.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f237c5842a2833ca1d5740aa1339f926db037e56
+
+=====DIFFSUMMARY=====
+f237c58 Merge pull request #502 from buymeagoat/codex/add-contributing.md-and-troubleshooting.md
+
+ docs/CONTRIBUTING.md    | 47 +++++++++++++++++++++++++++++++++++++++++
+ docs/TROUBLESHOOTING.md | 56 +++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 103 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:45:52Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f237c5842a2833ca1d5740aa1339f926db037e56
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_195958_0fe18576f59e8d192d31f2a77123cbc7634dff36.log
+++ b/docs/patch_logs/patch_20250728_195958_0fe18576f59e8d192d31f2a77123cbc7634dff36.log
@@ -1,0 +1,56 @@
+patch_20250728_195958_0fe18576f59e8d192d31f2a77123cbc7634dff36.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0fe18576f59e8d192d31f2a77123cbc7634dff36
+
+=====DIFFSUMMARY=====
+0fe1857 docs: add architecture diagram and guidelines
+ docs/architecture_diagram.svg  | 87 ++++++++++++++++++++++++++++++++++++++++++
+ docs/performance_guidelines.md | 56 +++++++++++++++++++++++++++
+ docs/testing_strategy.md       | 47 +++++++++++++++++++++++
+ 3 files changed, 190 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T19:59:58Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0fe18576f59e8d192d31f2a77123cbc7634dff36
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_200702_88fd4a2d5f0eded007755a9d8bc2e29da167e553.log
+++ b/docs/patch_logs/patch_20250728_200702_88fd4a2d5f0eded007755a9d8bc2e29da167e553.log
@@ -1,0 +1,57 @@
+patch_20250728_200702_88fd4a2d5f0eded007755a9d8bc2e29da167e553.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 88fd4a2d5f0eded007755a9d8bc2e29da167e553
+
+=====DIFFSUMMARY=====
+88fd4a2 Merge pull request #503 from buymeagoat/codex/create-architecture,-performance,-and-testing-docs
+
+ docs/architecture_diagram.svg  | 87 ++++++++++++++++++++++++++++++++++++++++++
+ docs/performance_guidelines.md | 56 +++++++++++++++++++++++++++
+ docs/testing_strategy.md       | 47 +++++++++++++++++++++++
+ 3 files changed, 190 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T20:07:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+88fd4a2d5f0eded007755a9d8bc2e29da167e553
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_210322_47c35480161bdcdc02d5172c8df16bc4fbcce8c9.log
+++ b/docs/patch_logs/patch_20250728_210322_47c35480161bdcdc02d5172c8df16bc4fbcce8c9.log
@@ -1,0 +1,55 @@
+patch_20250728_210322_47c35480161bdcdc02d5172c8df16bc4fbcce8c9.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 47c35480161bdcdc02d5172c8df16bc4fbcce8c9
+
+=====DIFFSUMMARY=====
+47c3548 docs: add index and log reference
+ docs/index.md         |  18 ++++++++
+ docs/log_reference.md | 123 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 141 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T21:03:22Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+47c35480161bdcdc02d5172c8df16bc4fbcce8c9
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_210335_d479dc4ffe61315b85978d72a615ec0d2610a928.log
+++ b/docs/patch_logs/patch_20250728_210335_d479dc4ffe61315b85978d72a615ec0d2610a928.log
@@ -1,0 +1,56 @@
+patch_20250728_210335_d479dc4ffe61315b85978d72a615ec0d2610a928.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d479dc4ffe61315b85978d72a615ec0d2610a928
+
+=====DIFFSUMMARY=====
+d479dc4 Merge pull request #504 from buymeagoat/codex/add-documentation-files-index.md-and-log_reference.md
+
+ docs/index.md         |  18 ++++++++
+ docs/log_reference.md | 123 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 141 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-28T21:03:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d479dc4ffe61315b85978d72a615ec0d2610a928
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_212144_b94a511c8ea4619d661788b2f2595703f66cff6f.log
+++ b/docs/patch_logs/patch_20250728_212144_b94a511c8ea4619d661788b2f2595703f66cff6f.log
@@ -1,0 +1,60 @@
+patch_20250728_212144_b94a511c8ea4619d661788b2f2595703f66cff6f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b94a511c8ea4619d661788b2f2595703f66cff6f
+
+=====DIFFSUMMARY=====
+b94a511 docs: add comprehensive documentation index and guides
+ docs/automation_tasks.md    | 21 +++++++++++++++++++++
+ docs/backup_and_recovery.md | 45 ++++++++++++++++++++++++++++++++++++++++++++
+ docs/index.md               | 46 +++++++++++++++++++++++++++++++++------------
+ docs/integrations.md        | 19 +++++++++++++++++++
+ docs/onboarding.md          | 41 ++++++++++++++++++++++++++++++++++++++++
+ docs/scripts_reference.md   | 22 ++++++++++++++++++++++
+ docs/versioning_policy.md   | 24 +++++++++++++++++++++++
+ 7 files changed, 206 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T21:21:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b94a511c8ea4619d661788b2f2595703f66cff6f
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_212154_83c722a33e790abddf012a656e240c638e33b7d0.log
+++ b/docs/patch_logs/patch_20250728_212154_83c722a33e790abddf012a656e240c638e33b7d0.log
@@ -1,0 +1,61 @@
+patch_20250728_212154_83c722a33e790abddf012a656e240c638e33b7d0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 83c722a33e790abddf012a656e240c638e33b7d0
+
+=====DIFFSUMMARY=====
+83c722a Merge pull request #505 from buymeagoat/codex/generate-missing-documentation-files
+
+ docs/automation_tasks.md    | 21 +++++++++++++++++++++
+ docs/backup_and_recovery.md | 45 ++++++++++++++++++++++++++++++++++++++++++++
+ docs/index.md               | 46 +++++++++++++++++++++++++++++++++------------
+ docs/integrations.md        | 19 +++++++++++++++++++
+ docs/onboarding.md          | 41 ++++++++++++++++++++++++++++++++++++++++
+ docs/scripts_reference.md   | 22 ++++++++++++++++++++++
+ docs/versioning_policy.md   | 24 +++++++++++++++++++++++
+ 7 files changed, 206 insertions(+), 12 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T21:21:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+83c722a33e790abddf012a656e240c638e33b7d0
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_214359_088f43c106afbd776eeb3abd46fa7f45f1fb638a.log
+++ b/docs/patch_logs/patch_20250728_214359_088f43c106afbd776eeb3abd46fa7f45f1fb638a.log
@@ -1,0 +1,60 @@
+patch_20250728_214359_088f43c106afbd776eeb3abd46fa7f45f1fb638a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 088f43c106afbd776eeb3abd46fa7f45f1fb638a
+
+=====DIFFSUMMARY=====
+088f43c Add comprehensive documentation
+ .env.example                 | 30 ++++++++++++++++-
+ docs/api_reference.md        | 61 ++++++++++++++++++++++++++++++++++
+ docs/architecture_diagram.md | 16 +++++++++
+ docs/environment.md          | 78 ++++++++++++++++++++++++++++++++++++++++++++
+ docs/index.md                | 45 ++++++++++++++-----------
+ docs/observability.md        | 26 +++++++++++++++
+ docs/upgrade.md              | 30 +++++++++++++++++
+ 7 files changed, 266 insertions(+), 20 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T21:43:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+088f43c106afbd776eeb3abd46fa7f45f1fb638a
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250728_214443_ca9481f1db68fb1aef3316ab8d9a687309b40c40.log
+++ b/docs/patch_logs/patch_20250728_214443_ca9481f1db68fb1aef3316ab8d9a687309b40c40.log
@@ -1,0 +1,61 @@
+patch_20250728_214443_ca9481f1db68fb1aef3316ab8d9a687309b40c40.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ca9481f1db68fb1aef3316ab8d9a687309b40c40
+
+=====DIFFSUMMARY=====
+ca9481f Merge pull request #506 from buymeagoat/codex/create-and-update-documentation-for-whisper-transcriber
+
+ .env.example                 | 30 ++++++++++++++++-
+ docs/api_reference.md        | 61 ++++++++++++++++++++++++++++++++++
+ docs/architecture_diagram.md | 16 +++++++++
+ docs/environment.md          | 78 ++++++++++++++++++++++++++++++++++++++++++++
+ docs/index.md                | 45 ++++++++++++++-----------
+ docs/observability.md        | 26 +++++++++++++++
+ docs/upgrade.md              | 30 +++++++++++++++++
+ 7 files changed, 266 insertions(+), 20 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-28T21:44:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ca9481f1db68fb1aef3316ab8d9a687309b40c40
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250801_195644_e61b493a48684c06e715bb56f371d61754b88cff.log
+++ b/docs/patch_logs/patch_20250801_195644_e61b493a48684c06e715bb56f371d61754b88cff.log
@@ -1,0 +1,59 @@
+patch_20250801_195644_e61b493a48684c06e715bb56f371d61754b88cff.log
+=====TASK=====
+Generate legacy patch logs for historical commits
+
+=====OBJECTIVE=====
+Backfill missing patch logs using commit history.
+
+=====CONSTRAINTS=====
+- AtomicPatch: create ≤100 new logs in this batch; abort on error.
+- Filename pattern: patch_<UTC YYYYMMDD>_<HHMMSS>_<commit_hash>.log
+- Required fields per CAG
+
+=====SCOPE=====
+docs/patch_logs/
+
+=====DIFFSUMMARY=====
+e61b493 Add legacy patch logs for historical commits
+ ...50_9ca83783c9e38c79ec9f8ae010fe0859132f8aec.log | 55 +++++++++++++++++
+ ...44_f892f23e1abd0ed826cf9eab793a9a4168d54ae2.log | 55 +++++++++++++++++
+ ...57_19464053ebb305e2278d24e1ce9e5d085395a5d4.log | 56 +++++++++++++++++
+ ...44_63afa1a9a7aa2dcb59c789baf16460fd9d456d53.log | 54 +++++++++++++++++
+ ...
+
+=====TIMESTAMP=====
+2025-08-01T19:56:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e61b493a48684c06e715bb56f371d61754b88cff
+
+=====SPEC_HASHES=====
+6bfaa5a80ab85a494b5e35d9cc68b1ec039d330a4386e8ac011f130556dbb7a1
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.
+
+=====DIAGNOSTICMETA=====
+{"preflight": {"docker": false, "docker-compose": false, "python": "3.12.10", "node": "v20.19.4", "npm": "11.4.2"}}
+
+=====DECISIONS=====
+- Automated creation of 99 legacy patch logs using a helper script.
+- Tests could not run due to missing docker.

--- a/scripts/generate_legacy_logs.py
+++ b/scripts/generate_legacy_logs.py
@@ -1,0 +1,70 @@
+import subprocess, datetime, pathlib, json
+start='6a46418e06efd889fcddf47885258f0402620dba'
+end='ca9481f1db68fb1aef3316ab8d9a687309b40c40'
+logdir=pathlib.Path('docs/patch_logs')
+spec_hash=subprocess.check_output(['scripts/hash_utils.sh','cag_agents_hash','AGENTS.md']).decode().strip()
+commits=subprocess.check_output(['git','rev-list','--reverse',f'{start}..{end}']).decode().split()
+print('commits',len(commits))
+for h in commits:
+    date_iso=subprocess.check_output(['git','show','-s','--format=%cI',h]).decode().strip()
+    dt=datetime.datetime.fromisoformat(date_iso.replace('Z','+00:00')).astimezone(datetime.timezone.utc)
+    fname=dt.strftime('patch_%Y%m%d_%H%M%S_')+h+'.log'
+    path=logdir/fname
+    if path.exists():
+        continue
+    diff=subprocess.check_output(['git','show','--stat','--oneline',h]).decode().strip()
+    body=f"""{fname}
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit {h}
+
+=====DIFFSUMMARY=====
+{diff}
+
+=====TIMESTAMP=====
+{dt.strftime('%Y-%m-%dT%H:%M:%SZ')}
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 194741
+
+=====PROMPTID=====
+legacy-backfill-batch-002
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+{h}
+
+=====SPEC_HASHES=====
+{spec_hash}
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{{"legacy_backfill": true}}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.
+"""
+    path.write_text(body)
+print('Generated',len(commits),'logs')


### PR DESCRIPTION
## Summary
- add script `generate_legacy_logs.py` to produce patch logs from commit history
- backfill 99 legacy patch logs for commits 6a46418e..ca9481f
- record patch log for this batch

## Testing
- `scripts/run_tests.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d19f6be708325b21fa650dae452bf