### PR TITLE
Add SnapshotScript rule and repo audit MVP

### DIFF
--- a/docs/patch_logs/patch_20250801_195300_snapshot-script-001.log
+++ b/docs/patch_logs/patch_20250801_195300_snapshot-script-001.log
@@ -1,0 +1,65 @@
+patch_20250801_195300_snapshot-script-001.log
+=====TASK=====
+add_snapshot_script_and_rule
+
+=====OBJECTIVE=====
+① Insert SnapshotScript rule after BaselineFreshness in cag_dense.txt
+② Create scripts/CPG_repo_audit.py with MVP features + unit test.
+
+=====CONSTRAINTS=====
+- AtomicPatch: both file updates must succeed or revert.
+- Preserve alias lines and dense formatting.
+- Script requirements (MVP): commit hash, UTC timestamp, directory tree (paths+SHA1, skip .venv/node_modules), pip freeze, npm ls --depth=0 if available, output JSON to snapshots/snapshot_<UTC>.json, print path + SHA256.
+- Unit test asserts JSON keys exist.
+
+=====SCOPE=====
+instructions/cag_dense.txt
+scripts/CPG_repo_audit.py
+scripts/tests/test_cpg_repo_audit.py
+
+=====DIFFSUMMARY=====
+instructions/cag_dense.txt | 2 +
+scripts/CPG_repo_audit.py | 112 +++++++++++++++++------------------
+scripts/tests/__init__.py | 0
+scripts/tests/test_cpg_repo_audit.py | 15 +++++
+4 files changed, 72 insertions(+), 57 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T19:53:00Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 195300
+
+=====PROMPTID=====
+snapshot-script-001
+
+=====AGENTVERSION=====
+Unknown
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+42dfb89f492d9906cff8339c46b6d2b738d93f3c
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+/workspace/whisper-transcriber/snapshots/snapshot_20250801T201835Z.json afcb2a22f270a2976e2672ea676ed73c33886554a1653354f931b00a15e322b5
+
+=====TESTRESULTS=====
+- pytest scripts/tests/test_cpg_repo_audit.py -q -> 1 passed
+- scripts/run_tests.sh --backend -> failed (docker not found)
+
+=====DIAGNOSTICMETA=====
+{"preflight": {"docker": false, "docker-compose": false, "python": "Python 3.12.10", "node": "v20.19.4", "npm": "11.4.2"}}
+
+=====DECISIONS=====
+- Added BaselineFreshness and SnapshotScript rules to dense instructions.
+- Rewrote CPG_repo_audit.py to capture snapshot data and emit JSON.
+- Added unit test validating snapshot keys.
+- Tests limited due to missing docker.

--- a/instructions/cag_dense.txt
+++ b/instructions/cag_dense.txt
@@ -1,1 +1,3 @@
+BaselineFreshness:C:OnEverySessionInitOrStateChange:PromptXForFullCanonicalSnapshotWithTimestampAndCommitHash;NoPatchAuditTestOrAnalysisUntilBaselineValidated;IfPrimarySnapshotCaptureFails:FallbackToGitCommitHash+UTCTimestamp(degraded in diagnostics);RequireExplicitBAcknowledgmentOfDegradedFallback;RejectAnyActionWithoutExplicitFreshnessMetaOrAcknowledgedDowngrade;
+SnapshotScript:C:IfCPG_repo_auditMissing:PromptXCreateScriptStub;Else:Run;
 PatchLogging:C:EachCommittedPatch:XGeneratesLog /docs/patch_logs/ named patch_<YYYYMMDD><HHMMSS UTC>_<short>.log;LogMustInclude(TASK,OBJECTIVE,CONSTRAINTS,SCOPE,DIFF,TS,prompt_id,AV,AH,CH,TESTRES,DIAGMETA,BDT,SPEC_HASHES);RejectWorkflowIfLogMissing;

--- a/scripts/tests/test_cpg_repo_audit.py
+++ b/scripts/tests/test_cpg_repo_audit.py
@@ -1,0 +1,15 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+def test_audit_snapshot(tmp_path):
+    script = Path(__file__).resolve().parents[1] / 'CPG_repo_audit.py'
+    result = subprocess.check_output([script], text=True)
+    path_str = result.strip().split()[0]
+    snap_path = Path(path_str)
+    assert snap_path.exists(), f"snapshot not found: {snap_path}"
+    data = json.loads(snap_path.read_text())
+    for key in ["commit", "timestamp", "tree", "pip_freeze", "npm_ls"]:
+        assert key in data
+    os.remove(snap_path)


### PR DESCRIPTION
## Summary
- expand `cag_dense.txt` with BaselineFreshness and SnapshotScript rules
- rewrite `CPG_repo_audit.py` to capture repo snapshots with pip/npm data
- add unit test to validate snapshot JSON structure
- log the patch update

## Testing
- `pytest scripts/tests/test_cpg_repo_audit.py -q`
- `bash scripts/run_tests.sh --backend` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e11bd5c832583b17d4dbfeb0172