### PR TITLE
Add legacy patch logs for early July commits

### DIFF
--- a/docs/patch_logs/patch_20250703_232401_79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea.log
+++ b/docs/patch_logs/patch_20250703_232401_79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea.log
@@ -1,0 +1,54 @@
+patch_20250703_232401_79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea
+
+=====DIFFSUMMARY=====
+79a2a5d fix docker build script paths
+ scripts/docker_build.sh | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-03T23:24:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250703_232444_f25eb0935d1a82416e20db773c835ddbc4c78d39.log
+++ b/docs/patch_logs/patch_20250703_232444_f25eb0935d1a82416e20db773c835ddbc4c78d39.log
@@ -1,0 +1,55 @@
+patch_20250703_232444_f25eb0935d1a82416e20db773c835ddbc4c78d39.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f25eb0935d1a82416e20db773c835ddbc4c78d39
+
+=====DIFFSUMMARY=====
+f25eb09 Merge pull request #244 from buymeagoat/codex/fix-docker_build.sh-path-references
+
+ scripts/docker_build.sh | 30 +++++++++++++++---------------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-03T23:24:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f25eb0935d1a82416e20db773c835ddbc4c78d39
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_014815_2ace52a3513ed80be80e88a464b16a23a435ec08.log
+++ b/docs/patch_logs/patch_20250704_014815_2ace52a3513ed80be80e88a464b16a23a435ec08.log
@@ -1,0 +1,54 @@
+patch_20250704_014815_2ace52a3513ed80be80e88a464b16a23a435ec08.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 2ace52a3513ed80be80e88a464b16a23a435ec08
+
+=====DIFFSUMMARY=====
+2ace52a add migration for config table
+ .../versions/f9f3e87495ad_add_config_table.py      | 28 ++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-04T01:48:15Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2ace52a3513ed80be80e88a464b16a23a435ec08
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_014854_88fbf7338161646b3a961b041938b179852364cc.log
+++ b/docs/patch_logs/patch_20250704_014854_88fbf7338161646b3a961b041938b179852364cc.log
@@ -1,0 +1,55 @@
+patch_20250704_014854_88fbf7338161646b3a961b041938b179852364cc.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 88fbf7338161646b3a961b041938b179852364cc
+
+=====DIFFSUMMARY=====
+88fbf73 Merge pull request #245 from buymeagoat/codex/fix-database-schema-validation-error
+
+ .../versions/f9f3e87495ad_add_config_table.py      | 28 ++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-04T01:48:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+88fbf7338161646b3a961b041938b179852364cc
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_143242_36abd17a6c470133e853dedd3343da5bc1e2f9fb.log
+++ b/docs/patch_logs/patch_20250704_143242_36abd17a6c470133e853dedd3343da5bc1e2f9fb.log
@@ -1,0 +1,54 @@
+patch_20250704_143242_36abd17a6c470133e853dedd3343da5bc1e2f9fb.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 36abd17a6c470133e853dedd3343da5bc1e2f9fb
+
+=====DIFFSUMMARY=====
+36abd17 Store enum values
+ api/models.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-04T14:32:42Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+36abd17a6c470133e853dedd3343da5bc1e2f9fb
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_143251_fe9f8bc4773214f7701a5a95524d707858a5589c.log
+++ b/docs/patch_logs/patch_20250704_143251_fe9f8bc4773214f7701a5a95524d707858a5589c.log
@@ -1,0 +1,55 @@
+patch_20250704_143251_fe9f8bc4773214f7701a5a95524d707858a5589c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit fe9f8bc4773214f7701a5a95524d707858a5589c
+
+=====DIFFSUMMARY=====
+fe9f8bc Merge pull request #246 from buymeagoat/codex/update-jobstatusenum-to-inherit-from-str
+
+ api/models.py | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-04T14:32:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fe9f8bc4773214f7701a5a95524d707858a5589c
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_144539_cf4834f58ae0392e9443a648e3e5c3f8851694f3.log
+++ b/docs/patch_logs/patch_20250704_144539_cf4834f58ae0392e9443a648e3e5c3f8851694f3.log
@@ -1,0 +1,55 @@
+patch_20250704_144539_cf4834f58ae0392e9443a648e3e5c3f8851694f3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit cf4834f58ae0392e9443a648e3e5c3f8851694f3
+
+=====DIFFSUMMARY=====
+cf4834f docs: clarify dev deps for tests
+ AGENTS.md | 1 +
+ README.md | 5 ++++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-04T14:45:39Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cf4834f58ae0392e9443a648e3e5c3f8851694f3
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250704_144612_4ace0e99431cfe833baefd6d4a834ae1602e8fc1.log
+++ b/docs/patch_logs/patch_20250704_144612_4ace0e99431cfe833baefd6d4a834ae1602e8fc1.log
@@ -1,0 +1,56 @@
+patch_20250704_144612_4ace0e99431cfe833baefd6d4a834ae1602e8fc1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 4ace0e99431cfe833baefd6d4a834ae1602e8fc1
+
+=====DIFFSUMMARY=====
+4ace0e9 Merge pull request #247 from buymeagoat/codex/update-documentation-for-test-suite-requirements
+
+ AGENTS.md | 1 +
+ README.md | 5 ++++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-04T14:46:12Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4ace0e99431cfe833baefd6d4a834ae1602e8fc1
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_004529_874c36d2a78abce0536f830b4cf97a809d9987eb.log
+++ b/docs/patch_logs/patch_20250705_004529_874c36d2a78abce0536f830b4cf97a809d9987eb.log
@@ -1,0 +1,55 @@
+patch_20250705_004529_874c36d2a78abce0536f830b4cf97a809d9987eb.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 874c36d2a78abce0536f830b4cf97a809d9987eb
+
+=====DIFFSUMMARY=====
+874c36d doc: note stack restart after compose changes
+ README.md          | 11 +++++++++--
+ docker-compose.yml |  2 ++
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T00:45:29Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+874c36d2a78abce0536f830b4cf97a809d9987eb
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_012136_3f998a8add1fd72a397b566e59d4284c065bb621.log
+++ b/docs/patch_logs/patch_20250705_012136_3f998a8add1fd72a397b566e59d4284c065bb621.log
@@ -1,0 +1,56 @@
+patch_20250705_012136_3f998a8add1fd72a397b566e59d4284c065bb621.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3f998a8add1fd72a397b566e59d4284c065bb621
+
+=====DIFFSUMMARY=====
+3f998a8 Merge pull request #248 from buymeagoat/codex/update-docker-compose.yml-to-expose-db-port
+
+ README.md          | 11 +++++++++--
+ docker-compose.yml |  2 ++
+ 2 files changed, 11 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T01:21:36Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3f998a8add1fd72a397b566e59d4284c065bb621
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_140840_a9bc6ae043af6dae6cfaf7010733c114d298d416.log
+++ b/docs/patch_logs/patch_20250705_140840_a9bc6ae043af6dae6cfaf7010733c114d298d416.log
@@ -1,0 +1,54 @@
+patch_20250705_140840_a9bc6ae043af6dae6cfaf7010733c114d298d416.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a9bc6ae043af6dae6cfaf7010733c114d298d416
+
+=====DIFFSUMMARY=====
+a9bc6ae Display backend error messages on login
+ frontend/src/pages/LoginPage.jsx | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:08:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a9bc6ae043af6dae6cfaf7010733c114d298d416
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_140851_449e2f0faa06e3684bbb3d9f80a8ef592b843dc8.log
+++ b/docs/patch_logs/patch_20250705_140851_449e2f0faa06e3684bbb3d9f80a8ef592b843dc8.log
@@ -1,0 +1,55 @@
+patch_20250705_140851_449e2f0faa06e3684bbb3d9f80a8ef592b843dc8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 449e2f0faa06e3684bbb3d9f80a8ef592b843dc8
+
+=====DIFFSUMMARY=====
+449e2f0 Merge pull request #249 from buymeagoat/codex/update-error-handling-in-loginpage
+
+ frontend/src/pages/LoginPage.jsx | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:08:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+449e2f0faa06e3684bbb3d9f80a8ef592b843dc8
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_141816_f3e3d7ef62e3206f4caffe1bbacf889aa554c49c.log
+++ b/docs/patch_logs/patch_20250705_141816_f3e3d7ef62e3206f4caffe1bbacf889aa554c49c.log
@@ -1,0 +1,64 @@
+patch_20250705_141816_f3e3d7ef62e3206f4caffe1bbacf889aa554c49c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f3e3d7ef62e3206f4caffe1bbacf889aa554c49c
+
+=====DIFFSUMMARY=====
+f3e3d7e Add default admin and password change workflow
+ README.md                                          |  5 +++
+ api/main.py                                        |  2 +
+ ...b8b3752f3e16_add_must_change_password_column.py | 33 ++++++++++++++
+ api/models.py                                      |  5 ++-
+ api/routes/auth.py                                 | 29 +++++++++---
+ api/schemas.py                                     |  8 ++++
+ api/services/users.py                              | 43 +++++++++++++++++-
+ frontend/src/App.jsx                               |  2 +
+ frontend/src/pages/ChangePasswordPage.jsx          | 51 ++++++++++++++++++++++
+ frontend/src/pages/LoginPage.jsx                   | 11 +++--
+ frontend/src/routes.js                             |  1 +
+ 11 files changed, 179 insertions(+), 11 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:18:16Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f3e3d7ef62e3206f4caffe1bbacf889aa554c49c
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_142302_d066b20000bc57a82f519885ab090c1c724d9353.log
+++ b/docs/patch_logs/patch_20250705_142302_d066b20000bc57a82f519885ab090c1c724d9353.log
@@ -1,0 +1,52 @@
+patch_20250705_142302_d066b20000bc57a82f519885ab090c1c724d9353.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d066b20000bc57a82f519885ab090c1c724d9353
+
+=====DIFFSUMMARY=====
+d066b20 Merge branch 'main' into codex/update-error-handling-in-loginpage
+
+=====TIMESTAMP=====
+2025-07-05T14:23:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d066b20000bc57a82f519885ab090c1c724d9353
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_142310_8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80.log
+++ b/docs/patch_logs/patch_20250705_142310_8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80.log
@@ -1,0 +1,65 @@
+patch_20250705_142310_8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80
+
+=====DIFFSUMMARY=====
+8d7f2bb Merge pull request #250 from buymeagoat/codex/update-error-handling-in-loginpage
+
+ README.md                                          |  5 +++
+ api/main.py                                        |  2 +
+ ...b8b3752f3e16_add_must_change_password_column.py | 33 ++++++++++++++
+ api/models.py                                      |  5 ++-
+ api/routes/auth.py                                 | 29 +++++++++---
+ api/schemas.py                                     |  8 ++++
+ api/services/users.py                              | 43 +++++++++++++++++-
+ frontend/src/App.jsx                               |  2 +
+ frontend/src/pages/ChangePasswordPage.jsx          | 51 ++++++++++++++++++++++
+ frontend/src/pages/LoginPage.jsx                   |  7 ++-
+ frontend/src/routes.js                             |  1 +
+ 11 files changed, 177 insertions(+), 9 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:23:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_143159_0f3040d56babd2315f32c7dd6e212bdf60781781.log
+++ b/docs/patch_logs/patch_20250705_143159_0f3040d56babd2315f32c7dd6e212bdf60781781.log
@@ -1,0 +1,55 @@
+patch_20250705_143159_0f3040d56babd2315f32c7dd6e212bdf60781781.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0f3040d56babd2315f32c7dd6e212bdf60781781
+
+=====DIFFSUMMARY=====
+0f3040d Add header with app name
+ frontend/src/components/Layout.jsx | 24 +++++++++++++++---------
+ frontend/src/index.css             |  7 +++++++
+ 2 files changed, 22 insertions(+), 9 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:31:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0f3040d56babd2315f32c7dd6e212bdf60781781
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_143210_b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801.log
+++ b/docs/patch_logs/patch_20250705_143210_b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801.log
@@ -1,0 +1,56 @@
+patch_20250705_143210_b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801
+
+=====DIFFSUMMARY=====
+b217b48 Merge pull request #251 from buymeagoat/codex/investigate-amqp-connection-errors
+
+ frontend/src/components/Layout.jsx | 24 +++++++++++++++---------
+ frontend/src/index.css             |  7 +++++++
+ 2 files changed, 22 insertions(+), 9 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T14:32:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_174641_9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5.log
+++ b/docs/patch_logs/patch_20250705_174641_9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5.log
@@ -1,0 +1,55 @@
+patch_20250705_174641_9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5
+
+=====DIFFSUMMARY=====
+9ff36b0 Pin bcrypt and document
+ README.md        | 3 +++
+ requirements.txt | 1 +
+ 2 files changed, 4 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T17:46:41Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_174652_2f7e1ac0525a12490d696ba372e1264bf6382258.log
+++ b/docs/patch_logs/patch_20250705_174652_2f7e1ac0525a12490d696ba372e1264bf6382258.log
@@ -1,0 +1,56 @@
+patch_20250705_174652_2f7e1ac0525a12490d696ba372e1264bf6382258.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 2f7e1ac0525a12490d696ba372e1264bf6382258
+
+=====DIFFSUMMARY=====
+2f7e1ac Merge pull request #252 from buymeagoat/codex/update-requirements.txt-and-run-tests
+
+ README.md        | 3 +++
+ requirements.txt | 1 +
+ 2 files changed, 4 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T17:46:52Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+2f7e1ac0525a12490d696ba372e1264bf6382258
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_175915_ac66504ac354dc7b87b45c683d25218778e6095d.log
+++ b/docs/patch_logs/patch_20250705_175915_ac66504ac354dc7b87b45c683d25218778e6095d.log
@@ -1,0 +1,55 @@
+patch_20250705_175915_ac66504ac354dc7b87b45c683d25218778e6095d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ac66504ac354dc7b87b45c683d25218778e6095d
+
+=====DIFFSUMMARY=====
+ac66504 Add size check to CloudStorage
+ api/services/storage.py   |  3 +++
+ tests/test_upload_size.py | 21 ++++++++++++++++++++-
+ 2 files changed, 23 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-05T17:59:15Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ac66504ac354dc7b87b45c683d25218778e6095d
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_175931_7d5ff0cde65083fbce88df20f03bc9e627e9fb2a.log
+++ b/docs/patch_logs/patch_20250705_175931_7d5ff0cde65083fbce88df20f03bc9e627e9fb2a.log
@@ -1,0 +1,56 @@
+patch_20250705_175931_7d5ff0cde65083fbce88df20f03bc9e627e9fb2a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 7d5ff0cde65083fbce88df20f03bc9e627e9fb2a
+
+=====DIFFSUMMARY=====
+7d5ff0c Merge pull request #253 from buymeagoat/codex/update-cloudstorage-size-check
+
+ api/services/storage.py   |  3 +++
+ tests/test_upload_size.py | 21 ++++++++++++++++++++-
+ 2 files changed, 23 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-05T17:59:31Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7d5ff0cde65083fbce88df20f03bc9e627e9fb2a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_180253_ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71.log
+++ b/docs/patch_logs/patch_20250705_180253_ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71.log
@@ -1,0 +1,55 @@
+patch_20250705_180253_ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71
+
+=====DIFFSUMMARY=====
+ec297c5 Add lock for progress connections
+ api/routes/progress.py | 36 +++++++++++++++++++++++-------------
+ tests/test_progress.py | 37 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 60 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:02:53Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_180302_9eab2e4490d15789a3bcd86695da9be5ca979051.log
+++ b/docs/patch_logs/patch_20250705_180302_9eab2e4490d15789a3bcd86695da9be5ca979051.log
@@ -1,0 +1,56 @@
+patch_20250705_180302_9eab2e4490d15789a3bcd86695da9be5ca979051.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9eab2e4490d15789a3bcd86695da9be5ca979051
+
+=====DIFFSUMMARY=====
+9eab2e4 Merge pull request #254 from buymeagoat/codex/add-threading.lock-to-progress.py
+
+ api/routes/progress.py | 36 +++++++++++++++++++++++-------------
+ tests/test_progress.py | 37 +++++++++++++++++++++++++++++++++++++
+ 2 files changed, 60 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:03:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9eab2e4490d15789a3bcd86695da9be5ca979051
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_180601_21ac0c09ae74d89b569c43fcc59ed65589dc223f.log
+++ b/docs/patch_logs/patch_20250705_180601_21ac0c09ae74d89b569c43fcc59ed65589dc223f.log
@@ -1,0 +1,55 @@
+patch_20250705_180601_21ac0c09ae74d89b569c43fcc59ed65589dc223f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 21ac0c09ae74d89b569c43fcc59ed65589dc223f
+
+=====DIFFSUMMARY=====
+21ac0c0 Handle missing Alembic
+ api/orm_bootstrap.py        |  5 +++++
+ tests/test_orm_bootstrap.py | 13 +++++++++++++
+ 2 files changed, 18 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T18:06:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+21ac0c09ae74d89b569c43fcc59ed65589dc223f
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_180620_c95e3ccf7aa43c052904a95f95a35ce3bd258c0e.log
+++ b/docs/patch_logs/patch_20250705_180620_c95e3ccf7aa43c052904a95f95a35ce3bd258c0e.log
@@ -1,0 +1,56 @@
+patch_20250705_180620_c95e3ccf7aa43c052904a95f95a35ce3bd258c0e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit c95e3ccf7aa43c052904a95f95a35ce3bd258c0e
+
+=====DIFFSUMMARY=====
+c95e3cc Merge pull request #255 from buymeagoat/codex/modify-validate_or_initialize_database-to-catch-filenotfound
+
+ api/orm_bootstrap.py        |  5 +++++
+ tests/test_orm_bootstrap.py | 13 +++++++++++++
+ 2 files changed, 18 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T18:06:20Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c95e3ccf7aa43c052904a95f95a35ce3bd258c0e
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_181117_d72d7d8f8d5aa55663e45fd0a67b12817517a029.log
+++ b/docs/patch_logs/patch_20250705_181117_d72d7d8f8d5aa55663e45fd0a67b12817517a029.log
@@ -1,0 +1,59 @@
+patch_20250705_181117_d72d7d8f8d5aa55663e45fd0a67b12817517a029.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d72d7d8f8d5aa55663e45fd0a67b12817517a029
+
+=====DIFFSUMMARY=====
+d72d7d8 Handle specific errors
+ api/routes/audio.py    | 27 ++++++++++++++++++---------
+ api/routes/jobs.py     |  8 ++++++--
+ api/routes/logs.py     |  4 ++--
+ tests/test_audio.py    | 17 +++++++++++++++++
+ tests/test_jobs_api.py | 18 ++++++++++++++++++
+ tests/test_logs_api.py | 12 ++++++++++++
+ 6 files changed, 73 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:11:17Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d72d7d8f8d5aa55663e45fd0a67b12817517a029
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_181132_d2d70fc4cae0559b55145bde6e7fd57829176285.log
+++ b/docs/patch_logs/patch_20250705_181132_d2d70fc4cae0559b55145bde6e7fd57829176285.log
@@ -1,0 +1,60 @@
+patch_20250705_181132_d2d70fc4cae0559b55145bde6e7fd57829176285.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d2d70fc4cae0559b55145bde6e7fd57829176285
+
+=====DIFFSUMMARY=====
+d2d70fc Merge pull request #256 from buymeagoat/codex/refactor-except-blocks-and-update-tests
+
+ api/routes/audio.py    | 27 ++++++++++++++++++---------
+ api/routes/jobs.py     |  8 ++++++--
+ api/routes/logs.py     |  4 ++--
+ tests/test_audio.py    | 17 +++++++++++++++++
+ tests/test_jobs_api.py | 18 ++++++++++++++++++
+ tests/test_logs_api.py | 12 ++++++++++++
+ 6 files changed, 73 insertions(+), 13 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:11:32Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d2d70fc4cae0559b55145bde6e7fd57829176285
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_181647_5c16801ba9f9d204088ecd712300fd4d52675961.log
+++ b/docs/patch_logs/patch_20250705_181647_5c16801ba9f9d204088ecd712300fd4d52675961.log
@@ -1,0 +1,56 @@
+patch_20250705_181647_5c16801ba9f9d204088ecd712300fd4d52675961.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5c16801ba9f9d204088ecd712300fd4d52675961
+
+=====DIFFSUMMARY=====
+5c16801 Add S3 error handling and tests
+ api/errors.py                        |  3 ++
+ api/services/storage.py              | 36 +++++++++++++++---
+ tests/test_cloud_storage_failures.py | 72 ++++++++++++++++++++++++++++++++++++
+ 3 files changed, 105 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:16:47Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5c16801ba9f9d204088ecd712300fd4d52675961
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_181659_33fedd7812a8b608f60a61667c3681a942acb0b7.log
+++ b/docs/patch_logs/patch_20250705_181659_33fedd7812a8b608f60a61667c3681a942acb0b7.log
@@ -1,0 +1,57 @@
+patch_20250705_181659_33fedd7812a8b608f60a61667c3681a942acb0b7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 33fedd7812a8b608f60a61667c3681a942acb0b7
+
+=====DIFFSUMMARY=====
+33fedd7 Merge pull request #257 from buymeagoat/codex/add-error-handling-for-boto3-calls
+
+ api/errors.py                        |  3 ++
+ api/services/storage.py              | 36 +++++++++++++++---
+ tests/test_cloud_storage_failures.py | 72 ++++++++++++++++++++++++++++++++++++
+ 3 files changed, 105 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:16:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+33fedd7812a8b608f60a61667c3681a942acb0b7
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_182145_0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7.log
+++ b/docs/patch_logs/patch_20250705_182145_0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7.log
@@ -1,0 +1,55 @@
+patch_20250705_182145_0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7
+
+=====DIFFSUMMARY=====
+0ca25f2 Handle TTS engine failures
+ api/routes/tts.py     | 16 ++++++++++---
+ tests/test_tts_api.py | 64 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 77 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:21:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_182229_cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2.log
+++ b/docs/patch_logs/patch_20250705_182229_cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2.log
@@ -1,0 +1,56 @@
+patch_20250705_182229_cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2
+
+=====DIFFSUMMARY=====
+cbc5c79 Merge pull request #258 from buymeagoat/codex/modify-generate_tts-to-handle-exceptions
+
+ api/routes/tts.py     | 16 ++++++++++---
+ tests/test_tts_api.py | 64 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 77 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:22:29Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_182602_eeb781628b87223d8f1c522d2fd9f30a5c55a4be.log
+++ b/docs/patch_logs/patch_20250705_182602_eeb781628b87223d8f1c522d2fd9f30a5c55a4be.log
@@ -1,0 +1,55 @@
+patch_20250705_182602_eeb781628b87223d8f1c522d2fd9f30a5c55a4be.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit eeb781628b87223d8f1c522d2fd9f30a5c55a4be
+
+=====DIFFSUMMARY=====
+eeb7816 Handle access log write errors
+ api/middlewares/access_log.py | 17 ++++++++++-------
+ tests/test_access_log.py      | 35 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+), 7 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:26:02Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+eeb781628b87223d8f1c522d2fd9f30a5c55a4be
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_182614_3f2fe453fbc72a794219dab91605dac37b69eac1.log
+++ b/docs/patch_logs/patch_20250705_182614_3f2fe453fbc72a794219dab91605dac37b69eac1.log
@@ -1,0 +1,56 @@
+patch_20250705_182614_3f2fe453fbc72a794219dab91605dac37b69eac1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3f2fe453fbc72a794219dab91605dac37b69eac1
+
+=====DIFFSUMMARY=====
+3f2fe45 Merge pull request #259 from buymeagoat/codex/update-access_logger-with-error-handling
+
+ api/middlewares/access_log.py | 17 ++++++++++-------
+ tests/test_access_log.py      | 35 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 45 insertions(+), 7 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:26:14Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3f2fe453fbc72a794219dab91605dac37b69eac1
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183026_a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a.log
+++ b/docs/patch_logs/patch_20250705_183026_a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a.log
@@ -1,0 +1,55 @@
+patch_20250705_183026_a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a
+
+=====DIFFSUMMARY=====
+a57a744 Ensure job queue shuts down on app exit
+ api/main.py                           |  4 ++++
+ tests/test_lifespan_queue_shutdown.py | 37 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T18:30:26Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183038_5bcc1bf221996868cbc679a3308680761b244de6.log
+++ b/docs/patch_logs/patch_20250705_183038_5bcc1bf221996868cbc679a3308680761b244de6.log
@@ -1,0 +1,56 @@
+patch_20250705_183038_5bcc1bf221996868cbc679a3308680761b244de6.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5bcc1bf221996868cbc679a3308680761b244de6
+
+=====DIFFSUMMARY=====
+5bcc1bf Merge pull request #260 from buymeagoat/codex/update-lifespan-context-to-shutdown-job-queue
+
+ api/main.py                           |  4 ++++
+ tests/test_lifespan_queue_shutdown.py | 37 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T18:30:38Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5bcc1bf221996868cbc679a3308680761b244de6
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183358_b26b1aaccb576411b24b7dc3f74608c41f3e41da.log
+++ b/docs/patch_logs/patch_20250705_183358_b26b1aaccb576411b24b7dc3f74608c41f3e41da.log
@@ -1,0 +1,56 @@
+patch_20250705_183358_b26b1aaccb576411b24b7dc3f74608c41f3e41da.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b26b1aaccb576411b24b7dc3f74608c41f3e41da
+
+=====DIFFSUMMARY=====
+b26b1aa Add cleanup thread stop control
+ api/app_state.py             | 21 +++++++++++++++++----
+ api/main.py                  |  3 +++
+ tests/test_cleanup_thread.py | 22 ++++++++++++++++++++++
+ 3 files changed, 42 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:33:58Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b26b1aaccb576411b24b7dc3f74608c41f3e41da
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183411_893f66d9386eb15279d5f5b2851c1e3da407da73.log
+++ b/docs/patch_logs/patch_20250705_183411_893f66d9386eb15279d5f5b2851c1e3da407da73.log
@@ -1,0 +1,57 @@
+patch_20250705_183411_893f66d9386eb15279d5f5b2851c1e3da407da73.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 893f66d9386eb15279d5f5b2851c1e3da407da73
+
+=====DIFFSUMMARY=====
+893f66d Merge pull request #261 from buymeagoat/codex/implement-cleanup-thread-with-stop-event
+
+ api/app_state.py             | 21 +++++++++++++++++----
+ api/main.py                  |  3 +++
+ tests/test_cleanup_thread.py | 22 ++++++++++++++++++++++
+ 3 files changed, 42 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:34:11Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+893f66d9386eb15279d5f5b2851c1e3da407da73
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183727_c8e49aee3a2865b6b448d677ed44636cf5e471f0.log
+++ b/docs/patch_logs/patch_20250705_183727_c8e49aee3a2865b6b448d677ed44636cf5e471f0.log
@@ -1,0 +1,54 @@
+patch_20250705_183727_c8e49aee3a2865b6b448d677ed44636cf5e471f0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit c8e49aee3a2865b6b448d677ed44636cf5e471f0
+
+=====DIFFSUMMARY=====
+c8e49ae Improve local analysis with sentence ranking
+ api/services/analysis.py | 50 +++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 47 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:37:27Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c8e49aee3a2865b6b448d677ed44636cf5e471f0
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_183740_e5563e9d9f4db7f0b67588e99f56401418d31cc0.log
+++ b/docs/patch_logs/patch_20250705_183740_e5563e9d9f4db7f0b67588e99f56401418d31cc0.log
@@ -1,0 +1,55 @@
+patch_20250705_183740_e5563e9d9f4db7f0b67588e99f56401418d31cc0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e5563e9d9f4db7f0b67588e99f56401418d31cc0
+
+=====DIFFSUMMARY=====
+e5563e9 Merge pull request #262 from buymeagoat/codex/enhance-_local_analyze-with-better-algorithm
+
+ api/services/analysis.py | 50 +++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 47 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T18:37:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e5563e9d9f4db7f0b67588e99f56401418d31cc0
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_225210_4ef7d891facc558563e6a1634da2159545ed5e74.log
+++ b/docs/patch_logs/patch_20250705_225210_4ef7d891facc558563e6a1634da2159545ed5e74.log
@@ -1,0 +1,58 @@
+patch_20250705_225210_4ef7d891facc558563e6a1634da2159545ed5e74.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 4ef7d891facc558563e6a1634da2159545ed5e74
+
+=====DIFFSUMMARY=====
+4ef7d89 Use BuildKit secret for SECRET_KEY
+ Dockerfile              | 4 ++--
+ README.md               | 2 +-
+ docs/design_scope.md    | 4 ++--
+ docs/future_updates.md  | 6 +++---
+ scripts/docker_build.sh | 4 ++--
+ 5 files changed, 10 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T22:52:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+4ef7d891facc558563e6a1634da2159545ed5e74
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_225252_9a1a06e6eb11b2dc58f1911f35e4f77af6630c09.log
+++ b/docs/patch_logs/patch_20250705_225252_9a1a06e6eb11b2dc58f1911f35e4f77af6630c09.log
@@ -1,0 +1,59 @@
+patch_20250705_225252_9a1a06e6eb11b2dc58f1911f35e4f77af6630c09.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9a1a06e6eb11b2dc58f1911f35e4f77af6630c09
+
+=====DIFFSUMMARY=====
+9a1a06e Merge pull request #263 from buymeagoat/codex/replace-secret_key-with-buildkit-secret
+
+ Dockerfile              | 4 ++--
+ README.md               | 2 +-
+ docs/design_scope.md    | 4 ++--
+ docs/future_updates.md  | 6 +++---
+ scripts/docker_build.sh | 4 ++--
+ 5 files changed, 10 insertions(+), 10 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-05T22:52:52Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9a1a06e6eb11b2dc58f1911f35e4f77af6630c09
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_225637_149303364b2b7ea83622ee7d18bd6df99e81c5ca.log
+++ b/docs/patch_logs/patch_20250705_225637_149303364b2b7ea83622ee7d18bd6df99e81c5ca.log
@@ -1,0 +1,54 @@
+patch_20250705_225637_149303364b2b7ea83622ee7d18bd6df99e81c5ca.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 149303364b2b7ea83622ee7d18bd6df99e81c5ca
+
+=====DIFFSUMMARY=====
+1493033 worker: wait for broker before starting
+ scripts/docker-entrypoint.sh | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T22:56:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+149303364b2b7ea83622ee7d18bd6df99e81c5ca
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_225649_a5e25bf229c88f2b3cee8ad44956e4ea49b530d2.log
+++ b/docs/patch_logs/patch_20250705_225649_a5e25bf229c88f2b3cee8ad44956e4ea49b530d2.log
@@ -1,0 +1,55 @@
+patch_20250705_225649_a5e25bf229c88f2b3cee8ad44956e4ea49b530d2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a5e25bf229c88f2b3cee8ad44956e4ea49b530d2
+
+=====DIFFSUMMARY=====
+a5e25bf Merge pull request #264 from buymeagoat/codex/add-logic-to-wait-for-broker-port
+
+ scripts/docker-entrypoint.sh | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T22:56:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a5e25bf229c88f2b3cee8ad44956e4ea49b530d2
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_230137_a7cd894b057e615545ecc5049fd1d6313182c61b.log
+++ b/docs/patch_logs/patch_20250705_230137_a7cd894b057e615545ecc5049fd1d6313182c61b.log
@@ -1,0 +1,57 @@
+patch_20250705_230137_a7cd894b057e615545ecc5049fd1d6313182c61b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a7cd894b057e615545ecc5049fd1d6313182c61b
+
+=====DIFFSUMMARY=====
+a7cd894 Add script for incremental Docker image rebuild
+ README.md                |  2 ++
+ docs/design_scope.md     |  1 +
+ docs/future_updates.md   |  4 ++++
+ scripts/update_images.sh | 12 ++++++++++++
+ 4 files changed, 19 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T23:01:37Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a7cd894b057e615545ecc5049fd1d6313182c61b
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250705_230349_481894970bce6d73ff99b225a70e1edea5955a6a.log
+++ b/docs/patch_logs/patch_20250705_230349_481894970bce6d73ff99b225a70e1edea5955a6a.log
@@ -1,0 +1,58 @@
+patch_20250705_230349_481894970bce6d73ff99b225a70e1edea5955a6a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 481894970bce6d73ff99b225a70e1edea5955a6a
+
+=====DIFFSUMMARY=====
+4818949 Merge pull request #265 from buymeagoat/codex/evaluate-build-logs-and-fix-issues
+
+ README.md                |  2 ++
+ docs/design_scope.md     |  1 +
+ docs/future_updates.md   |  4 ++++
+ scripts/update_images.sh | 12 ++++++++++++
+ 4 files changed, 19 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-05T23:03:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+481894970bce6d73ff99b225a70e1edea5955a6a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_015449_c194a6705db39646b071fed4df8f9551fce5de14.log
+++ b/docs/patch_logs/patch_20250706_015449_c194a6705db39646b071fed4df8f9551fce5de14.log
@@ -1,0 +1,57 @@
+patch_20250706_015449_c194a6705db39646b071fed4df8f9551fce5de14.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit c194a6705db39646b071fed4df8f9551fce5de14
+
+=====DIFFSUMMARY=====
+c194a67 Update worker healthcheck
+ Dockerfile             | 2 +-
+ README.md              | 1 +
+ docker-compose.yml     | 2 +-
+ scripts/healthcheck.sh | 3 ++-
+ 4 files changed, 5 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T01:54:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+c194a6705db39646b071fed4df8f9551fce5de14
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_015506_a012ae104b2bf069d36bd3ab53354f52c38bb327.log
+++ b/docs/patch_logs/patch_20250706_015506_a012ae104b2bf069d36bd3ab53354f52c38bb327.log
@@ -1,0 +1,58 @@
+patch_20250706_015506_a012ae104b2bf069d36bd3ab53354f52c38bb327.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a012ae104b2bf069d36bd3ab53354f52c38bb327
+
+=====DIFFSUMMARY=====
+a012ae1 Merge pull request #266 from buymeagoat/codex/modify-health-check-for-celery-worker
+
+ Dockerfile             | 2 +-
+ README.md              | 1 +
+ docker-compose.yml     | 2 +-
+ scripts/healthcheck.sh | 3 ++-
+ 4 files changed, 5 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T01:55:06Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a012ae104b2bf069d36bd3ab53354f52c38bb327
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_020323_55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f.log
+++ b/docs/patch_logs/patch_20250706_020323_55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f.log
@@ -1,0 +1,65 @@
+patch_20250706_020323_55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f
+
+=====DIFFSUMMARY=====
+55daa70 Configure LAN access
+ Dockerfile                 |  2 +-
+ README.md                  |  6 +++---
+ api/config.py              |  2 +-
+ api/main.py                |  2 +-
+ api/settings.py            |  2 +-
+ docker-compose.yml         |  4 ++--
+ frontend/.env              |  2 +-
+ frontend/.env.example      |  2 +-
+ frontend/public/index.html |  2 +-
+ frontend/src/routes.js     |  2 +-
+ frontend/vite.config.js    | 16 ++++++++--------
+ scripts/healthcheck.sh     |  2 +-
+ 12 files changed, 22 insertions(+), 22 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T02:03:23Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_020336_618076803267534abcf6a07f8d42301aa486c939.log
+++ b/docs/patch_logs/patch_20250706_020336_618076803267534abcf6a07f8d42301aa486c939.log
@@ -1,0 +1,66 @@
+patch_20250706_020336_618076803267534abcf6a07f8d42301aa486c939.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 618076803267534abcf6a07f8d42301aa486c939
+
+=====DIFFSUMMARY=====
+6180768 Merge pull request #267 from buymeagoat/codex/fix-login-failed-with-connection-errors
+
+ Dockerfile                 |  2 +-
+ README.md                  |  6 +++---
+ api/config.py              |  2 +-
+ api/main.py                |  2 +-
+ api/settings.py            |  2 +-
+ docker-compose.yml         |  4 ++--
+ frontend/.env              |  2 +-
+ frontend/.env.example      |  2 +-
+ frontend/public/index.html |  2 +-
+ frontend/src/routes.js     |  2 +-
+ frontend/vite.config.js    | 16 ++++++++--------
+ scripts/healthcheck.sh     |  2 +-
+ 12 files changed, 22 insertions(+), 22 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T02:03:36Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+618076803267534abcf6a07f8d42301aa486c939
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_132147_8ee08b0650856a36959c19bb572c60adaff98159.log
+++ b/docs/patch_logs/patch_20250706_132147_8ee08b0650856a36959c19bb572c60adaff98159.log
@@ -1,0 +1,54 @@
+patch_20250706_132147_8ee08b0650856a36959c19bb572c60adaff98159.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 8ee08b0650856a36959c19bb572c60adaff98159
+
+=====DIFFSUMMARY=====
+8ee08b0 Support token auth for WebSockets
+ api/routes/auth.py | 32 +++++++++++++++++++++++++++++---
+ 1 file changed, 29 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T13:21:47Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8ee08b0650856a36959c19bb572c60adaff98159
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_132201_9367bce7fcef970e9002a4a4609a6f8141018d65.log
+++ b/docs/patch_logs/patch_20250706_132201_9367bce7fcef970e9002a4a4609a6f8141018d65.log
@@ -1,0 +1,55 @@
+patch_20250706_132201_9367bce7fcef970e9002a4a4609a6f8141018d65.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9367bce7fcef970e9002a4a4609a6f8141018d65
+
+=====DIFFSUMMARY=====
+9367bce Merge pull request #268 from buymeagoat/codex/update-authentication-in-auth.py
+
+ api/routes/auth.py | 32 +++++++++++++++++++++++++++++---
+ 1 file changed, 29 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T13:22:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9367bce7fcef970e9002a4a4609a6f8141018d65
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_161647_14d5a81ead54843840d9f7d35be61fd5c907134c.log
+++ b/docs/patch_logs/patch_20250706_161647_14d5a81ead54843840d9f7d35be61fd5c907134c.log
@@ -1,0 +1,54 @@
+patch_20250706_161647_14d5a81ead54843840d9f7d35be61fd5c907134c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 14d5a81ead54843840d9f7d35be61fd5c907134c
+
+=====DIFFSUMMARY=====
+14d5a81 refine failed status filter
+ api/services/jobs.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T16:16:47Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+14d5a81ead54843840d9f7d35be61fd5c907134c
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_161657_7612f242ab0171a0cecb33854958fce9b6d68e72.log
+++ b/docs/patch_logs/patch_20250706_161657_7612f242ab0171a0cecb33854958fce9b6d68e72.log
@@ -1,0 +1,55 @@
+patch_20250706_161657_7612f242ab0171a0cecb33854958fce9b6d68e72.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 7612f242ab0171a0cecb33854958fce9b6d68e72
+
+=====DIFFSUMMARY=====
+7612f24 Merge pull request #269 from buymeagoat/codex/refactor-job-status-filter-in-list_jobs
+
+ api/services/jobs.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T16:16:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+7612f242ab0171a0cecb33854958fce9b6d68e72
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_162040_9ac556a26dc3bd6f27cd38f86384cb94b4244cc3.log
+++ b/docs/patch_logs/patch_20250706_162040_9ac556a26dc3bd6f27cd38f86384cb94b4244cc3.log
@@ -1,0 +1,54 @@
+patch_20250706_162040_9ac556a26dc3bd6f27cd38f86384cb94b4244cc3.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 9ac556a26dc3bd6f27cd38f86384cb94b4244cc3
+
+=====DIFFSUMMARY=====
+9ac556a Use partial for queued whisper jobs
+ api/routes/jobs.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T16:20:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+9ac556a26dc3bd6f27cd38f86384cb94b4244cc3
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_162059_fe80645ce4f2e95b49aa21a3d3bd84f35baaf609.log
+++ b/docs/patch_logs/patch_20250706_162059_fe80645ce4f2e95b49aa21a3d3bd84f35baaf609.log
@@ -1,0 +1,55 @@
+patch_20250706_162059_fe80645ce4f2e95b49aa21a3d3bd84f35baaf609.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit fe80645ce4f2e95b49aa21a3d3bd84f35baaf609
+
+=====DIFFSUMMARY=====
+fe80645 Merge pull request #270 from buymeagoat/codex/refactor-job-functions-to-use-partial
+
+ api/routes/jobs.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-06T16:20:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fe80645ce4f2e95b49aa21a3d3bd84f35baaf609
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_204638_5f4e2464efc4e34b7827dd0525ecc0e6bddecb78.log
+++ b/docs/patch_logs/patch_20250706_204638_5f4e2464efc4e34b7827dd0525ecc0e6bddecb78.log
@@ -1,0 +1,54 @@
+patch_20250706_204638_5f4e2464efc4e34b7827dd0525ecc0e6bddecb78.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 5f4e2464efc4e34b7827dd0525ecc0e6bddecb78
+
+=====DIFFSUMMARY=====
+5f4e246 Use enumerated failed statuses
+ api/services/jobs.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T20:46:38Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+5f4e2464efc4e34b7827dd0525ecc0e6bddecb78
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_205033_571052c487c7825f9af3104be85504096b7d5c2f.log
+++ b/docs/patch_logs/patch_20250706_205033_571052c487c7825f9af3104be85504096b7d5c2f.log
@@ -1,0 +1,55 @@
+patch_20250706_205033_571052c487c7825f9af3104be85504096b7d5c2f.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 571052c487c7825f9af3104be85504096b7d5c2f
+
+=====DIFFSUMMARY=====
+571052c Merge pull request #271 from buymeagoat/codex/update-job-status-check-and-format-file
+
+ api/services/jobs.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T20:50:33Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+571052c487c7825f9af3104be85504096b7d5c2f
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_213334_1ec75ab5aff7d8cbed90f5cb26faee91699a0c19.log
+++ b/docs/patch_logs/patch_20250706_213334_1ec75ab5aff7d8cbed90f5cb26faee91699a0c19.log
@@ -1,0 +1,54 @@
+patch_20250706_213334_1ec75ab5aff7d8cbed90f5cb26faee91699a0c19.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 1ec75ab5aff7d8cbed90f5cb26faee91699a0c19
+
+=====DIFFSUMMARY=====
+1ec75ab Add regression test for failed status filter
+ tests/test_jobs_api.py | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-06T21:33:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+1ec75ab5aff7d8cbed90f5cb26faee91699a0c19
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_213354_f0d9e0fc151dea920f2b737815dc1ddb3125ba34.log
+++ b/docs/patch_logs/patch_20250706_213354_f0d9e0fc151dea920f2b737815dc1ddb3125ba34.log
@@ -1,0 +1,55 @@
+patch_20250706_213354_f0d9e0fc151dea920f2b737815dc1ddb3125ba34.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f0d9e0fc151dea920f2b737815dc1ddb3125ba34
+
+=====DIFFSUMMARY=====
+f0d9e0f Merge pull request #272 from buymeagoat/codex/update-failed-filter-and-add-regression-test
+
+ tests/test_jobs_api.py | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-06T21:33:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f0d9e0fc151dea920f2b737815dc1ddb3125ba34
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_230746_05d9347f2ef8a70898319bcbbfd7bb30b086caf8.log
+++ b/docs/patch_logs/patch_20250706_230746_05d9347f2ef8a70898319bcbbfd7bb30b086caf8.log
@@ -1,0 +1,54 @@
+patch_20250706_230746_05d9347f2ef8a70898319bcbbfd7bb30b086caf8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 05d9347f2ef8a70898319bcbbfd7bb30b086caf8
+
+=====DIFFSUMMARY=====
+05d9347 Avoid uvicorn adding handlers
+ scripts/server_entry.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:07:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+05d9347f2ef8a70898319bcbbfd7bb30b086caf8
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_230801_fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0.log
+++ b/docs/patch_logs/patch_20250706_230801_fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0.log
@@ -1,0 +1,55 @@
+patch_20250706_230801_fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0
+
+=====DIFFSUMMARY=====
+fa016f0 Merge pull request #273 from buymeagoat/codex/modify-uvicorn.run-logging-configuration
+
+ scripts/server_entry.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:08:01Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_231110_a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5.log
+++ b/docs/patch_logs/patch_20250706_231110_a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5.log
@@ -1,0 +1,54 @@
+patch_20250706_231110_a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5
+
+=====DIFFSUMMARY=====
+a3e96a6 Configure Celery logger
+ api/services/celery_app.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-06T23:11:10Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_231123_23bb9ae90d8b7627bd8ee638b70c1924c4c6477d.log
+++ b/docs/patch_logs/patch_20250706_231123_23bb9ae90d8b7627bd8ee638b70c1924c4c6477d.log
@@ -1,0 +1,55 @@
+patch_20250706_231123_23bb9ae90d8b7627bd8ee638b70c1924c4c6477d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 23bb9ae90d8b7627bd8ee638b70c1924c4c6477d
+
+=====DIFFSUMMARY=====
+23bb9ae Merge pull request #274 from buymeagoat/codex/tweak-celery-configuration-for-logging
+
+ api/services/celery_app.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-06T23:11:23Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+23bb9ae90d8b7627bd8ee638b70c1924c4c6477d
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_235344_f1e9413093b2694fca4f2ce15e195a88bccd79fe.log
+++ b/docs/patch_logs/patch_20250706_235344_f1e9413093b2694fca4f2ce15e195a88bccd79fe.log
@@ -1,0 +1,54 @@
+patch_20250706_235344_f1e9413093b2694fca4f2ce15e195a88bccd79fe.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f1e9413093b2694fca4f2ce15e195a88bccd79fe
+
+=====DIFFSUMMARY=====
+f1e9413 Fix uvicorn log level
+ scripts/server_entry.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:53:44Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f1e9413093b2694fca4f2ce15e195a88bccd79fe
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_235424_32961028ac5863f4fe12fde622201e3aae296e29.log
+++ b/docs/patch_logs/patch_20250706_235424_32961028ac5863f4fe12fde622201e3aae296e29.log
@@ -1,0 +1,55 @@
+patch_20250706_235424_32961028ac5863f4fe12fde622201e3aae296e29.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 32961028ac5863f4fe12fde622201e3aae296e29
+
+=====DIFFSUMMARY=====
+3296102 Merge pull request #275 from buymeagoat/codex/edit-uvicorn-to-use-log_level
+
+ scripts/server_entry.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:54:24Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+32961028ac5863f4fe12fde622201e3aae296e29
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_235805_20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7.log
+++ b/docs/patch_logs/patch_20250706_235805_20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7.log
@@ -1,0 +1,55 @@
+patch_20250706_235805_20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7
+
+=====DIFFSUMMARY=====
+20bb6a9 Use VITE_API_HOST in healthcheck
+ README.md              | 1 +
+ scripts/healthcheck.sh | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:58:05Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250706_235940_e941e22d65a40df92408f3fa14a1a6ec250eff9c.log
+++ b/docs/patch_logs/patch_20250706_235940_e941e22d65a40df92408f3fa14a1a6ec250eff9c.log
@@ -1,0 +1,56 @@
+patch_20250706_235940_e941e22d65a40df92408f3fa14a1a6ec250eff9c.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e941e22d65a40df92408f3fa14a1a6ec250eff9c
+
+=====DIFFSUMMARY=====
+e941e22 Merge pull request #276 from buymeagoat/codex/modify-healthcheck.sh-url-construction
+
+ README.md              | 1 +
+ scripts/healthcheck.sh | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-06T23:59:40Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e941e22d65a40df92408f3fa14a1a6ec250eff9c
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_003626_3292be6720066c4a81a9f3a2a2d00fe25be981d2.log
+++ b/docs/patch_logs/patch_20250707_003626_3292be6720066c4a81a9f3a2a2d00fe25be981d2.log
@@ -1,0 +1,54 @@
+patch_20250707_003626_3292be6720066c4a81a9f3a2a2d00fe25be981d2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3292be6720066c4a81a9f3a2a2d00fe25be981d2
+
+=====DIFFSUMMARY=====
+3292be6 Fix import path for get_authorization_scheme_param
+ api/routes/auth.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T00:36:26Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3292be6720066c4a81a9f3a2a2d00fe25be981d2
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_003728_a2a247d57a94ce3ac0047baafcb378a50ddd4b9b.log
+++ b/docs/patch_logs/patch_20250707_003728_a2a247d57a94ce3ac0047baafcb378a50ddd4b9b.log
@@ -1,0 +1,55 @@
+patch_20250707_003728_a2a247d57a94ce3ac0047baafcb378a50ddd4b9b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a2a247d57a94ce3ac0047baafcb378a50ddd4b9b
+
+=====DIFFSUMMARY=====
+a2a247d Merge pull request #277 from buymeagoat/codex/update-import-in-auth.py-and-format
+
+ api/routes/auth.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T00:37:28Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a2a247d57a94ce3ac0047baafcb378a50ddd4b9b
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_013626_482e890d80a6b1a57114fd924e64018cf1e5ec00.log
+++ b/docs/patch_logs/patch_20250707_013626_482e890d80a6b1a57114fd924e64018cf1e5ec00.log
@@ -1,0 +1,54 @@
+patch_20250707_013626_482e890d80a6b1a57114fd924e64018cf1e5ec00.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 482e890d80a6b1a57114fd924e64018cf1e5ec00
+
+=====DIFFSUMMARY=====
+482e890 refactor(auth): simplify get_token signature
+ api/routes/auth.py | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:36:26Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+482e890d80a6b1a57114fd924e64018cf1e5ec00
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_014052_d1aa9eb86464dd2192cb3da32de7425471b7f25d.log
+++ b/docs/patch_logs/patch_20250707_014052_d1aa9eb86464dd2192cb3da32de7425471b7f25d.log
@@ -1,0 +1,55 @@
+patch_20250707_014052_d1aa9eb86464dd2192cb3da32de7425471b7f25d.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d1aa9eb86464dd2192cb3da32de7425471b7f25d
+
+=====DIFFSUMMARY=====
+d1aa9eb Merge pull request #278 from buymeagoat/codex/modify-get_token-to-accept-optional-parameters
+
+ api/routes/auth.py | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:40:52Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d1aa9eb86464dd2192cb3da32de7425471b7f25d
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_014558_0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb.log
+++ b/docs/patch_logs/patch_20250707_014558_0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb.log
@@ -1,0 +1,55 @@
+patch_20250707_014558_0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb
+
+=====DIFFSUMMARY=====
+0aceffc docs: remove celery install step
+ README.md            | 12 ++++++------
+ docs/design_scope.md |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:45:58Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_014658_8439bc035b881930562d76aa32b62218d3657172.log
+++ b/docs/patch_logs/patch_20250707_014658_8439bc035b881930562d76aa32b62218d3657172.log
@@ -1,0 +1,56 @@
+patch_20250707_014658_8439bc035b881930562d76aa32b62218d3657172.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 8439bc035b881930562d76aa32b62218d3657172
+
+=====DIFFSUMMARY=====
+8439bc0 Merge pull request #279 from buymeagoat/codex/update-readme-and-design_scope-for-celery-installation
+
+ README.md            | 12 ++++++------
+ docs/design_scope.md |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:46:58Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8439bc035b881930562d76aa32b62218d3657172
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_014954_83bd8fbb7873b53925e4c915cf76a65dc1945397.log
+++ b/docs/patch_logs/patch_20250707_014954_83bd8fbb7873b53925e4c915cf76a65dc1945397.log
@@ -1,0 +1,54 @@
+patch_20250707_014954_83bd8fbb7873b53925e4c915cf76a65dc1945397.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 83bd8fbb7873b53925e4c915cf76a65dc1945397
+
+=====DIFFSUMMARY=====
+83bd8fb Update frontend README with build instructions
+ frontend/README.md | 34 +++++++++++++++++++++++++++-------
+ 1 file changed, 27 insertions(+), 7 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:49:54Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+83bd8fbb7873b53925e4c915cf76a65dc1945397
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_015049_a644061123807400dfc6b64367bb164935fdf957.log
+++ b/docs/patch_logs/patch_20250707_015049_a644061123807400dfc6b64367bb164935fdf957.log
@@ -1,0 +1,55 @@
+patch_20250707_015049_a644061123807400dfc6b64367bb164935fdf957.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a644061123807400dfc6b64367bb164935fdf957
+
+=====DIFFSUMMARY=====
+a644061 Merge pull request #280 from buymeagoat/codex/rewrite-frontend/readme.md-with-project-instructions
+
+ frontend/README.md | 34 +++++++++++++++++++++++++++-------
+ 1 file changed, 27 insertions(+), 7 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T01:50:49Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a644061123807400dfc6b64367bb164935fdf957
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_024335_0b64177c8952266b0e166fc27a5fe67e0d78525b.log
+++ b/docs/patch_logs/patch_20250707_024335_0b64177c8952266b0e166fc27a5fe67e0d78525b.log
@@ -1,0 +1,54 @@
+patch_20250707_024335_0b64177c8952266b0e166fc27a5fe67e0d78525b.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 0b64177c8952266b0e166fc27a5fe67e0d78525b
+
+=====DIFFSUMMARY=====
+0b64177 docs(auth): clarify get_token behavior
+ api/routes/auth.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-07T02:43:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+0b64177c8952266b0e166fc27a5fe67e0d78525b
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_024355_d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe.log
+++ b/docs/patch_logs/patch_20250707_024355_d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe.log
@@ -1,0 +1,55 @@
+patch_20250707_024355_d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe
+
+=====DIFFSUMMARY=====
+d9d8a0b Merge pull request #281 from buymeagoat/codex/refactor-get_token-to-accept-optional-parameters
+
+ api/routes/auth.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+=====TIMESTAMP=====
+2025-07-07T02:43:55Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_053034_31495d503a98ff1637c5704e86aae81d5fa28834.log
+++ b/docs/patch_logs/patch_20250707_053034_31495d503a98ff1637c5704e86aae81d5fa28834.log
@@ -1,0 +1,56 @@
+patch_20250707_053034_31495d503a98ff1637c5704e86aae81d5fa28834.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 31495d503a98ff1637c5704e86aae81d5fa28834
+
+=====DIFFSUMMARY=====
+31495d5 Add RabbitMQ config and mount in compose
+ README.md          | 10 ++++++++++
+ docker-compose.yml |  1 +
+ rabbitmq.conf      |  3 +++
+ 3 files changed, 14 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T05:30:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+31495d503a98ff1637c5704e86aae81d5fa28834
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_053046_6e82ce4ea410cc2a5d550b57654589685856fc3a.log
+++ b/docs/patch_logs/patch_20250707_053046_6e82ce4ea410cc2a5d550b57654589685856fc3a.log
@@ -1,0 +1,57 @@
+patch_20250707_053046_6e82ce4ea410cc2a5d550b57654589685856fc3a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 6e82ce4ea410cc2a5d550b57654589685856fc3a
+
+=====DIFFSUMMARY=====
+6e82ce4 Merge pull request #282 from buymeagoat/codex/create-rabbitmq.conf-and-update-docker-compose.yml
+
+ README.md          | 10 ++++++++++
+ docker-compose.yml |  1 +
+ rabbitmq.conf      |  3 +++
+ 3 files changed, 14 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T05:30:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+6e82ce4ea410cc2a5d550b57654589685856fc3a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_133125_f39df4bf9c5e80976fce7b3a5629ee62d0029042.log
+++ b/docs/patch_logs/patch_20250707_133125_f39df4bf9c5e80976fce7b3a5629ee62d0029042.log
@@ -1,0 +1,54 @@
+patch_20250707_133125_f39df4bf9c5e80976fce7b3a5629ee62d0029042.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f39df4bf9c5e80976fce7b3a5629ee62d0029042
+
+=====DIFFSUMMARY=====
+f39df4b Improve RabbitMQ readiness check
+ scripts/docker-entrypoint.sh | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T13:31:25Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f39df4bf9c5e80976fce7b3a5629ee62d0029042
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_133145_71a70ca571d86b11e586922684f1f67a914ac2c8.log
+++ b/docs/patch_logs/patch_20250707_133145_71a70ca571d86b11e586922684f1f67a914ac2c8.log
@@ -1,0 +1,55 @@
+patch_20250707_133145_71a70ca571d86b11e586922684f1f67a914ac2c8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 71a70ca571d86b11e586922684f1f67a914ac2c8
+
+=====DIFFSUMMARY=====
+71a70ca Merge pull request #283 from buymeagoat/codex/update-docker-entrypoint.sh-for-rabbitmq-check
+
+ scripts/docker-entrypoint.sh | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T13:31:45Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+71a70ca571d86b11e586922684f1f67a914ac2c8
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_142332_ed06be727d0993982bd516a36647a03b5186b4a8.log
+++ b/docs/patch_logs/patch_20250707_142332_ed06be727d0993982bd516a36647a03b5186b4a8.log
@@ -1,0 +1,56 @@
+patch_20250707_142332_ed06be727d0993982bd516a36647a03b5186b4a8.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit ed06be727d0993982bd516a36647a03b5186b4a8
+
+=====DIFFSUMMARY=====
+ed06be7 require auth for log retrieval
+ README.md            | 2 ++
+ api/routes/logs.py   | 6 +++---
+ docs/design_scope.md | 2 +-
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T14:23:32Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+ed06be727d0993982bd516a36647a03b5186b4a8
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_142413_96c699962d31fcb1a581fe466ba17ad9f3014d63.log
+++ b/docs/patch_logs/patch_20250707_142413_96c699962d31fcb1a581fe466ba17ad9f3014d63.log
@@ -1,0 +1,57 @@
+patch_20250707_142413_96c699962d31fcb1a581fe466ba17ad9f3014d63.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 96c699962d31fcb1a581fe466ba17ad9f3014d63
+
+=====DIFFSUMMARY=====
+96c6999 Merge pull request #284 from buymeagoat/codex/add-authentication-requirement-to-log-endpoints
+
+ README.md            | 2 ++
+ api/routes/logs.py   | 6 +++---
+ docs/design_scope.md | 2 +-
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T14:24:13Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+96c699962d31fcb1a581fe466ba17ad9f3014d63
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_142834_e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e.log
+++ b/docs/patch_logs/patch_20250707_142834_e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e.log
@@ -1,0 +1,55 @@
+patch_20250707_142834_e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e
+
+=====DIFFSUMMARY=====
+e111abe Secure log file path and add test
+ api/routes/logs.py     | 12 ++++++++++--
+ tests/test_logs_api.py |  5 +++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T14:28:34Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_143204_da631a4e85683bd762066195d29616d97c577354.log
+++ b/docs/patch_logs/patch_20250707_143204_da631a4e85683bd762066195d29616d97c577354.log
@@ -1,0 +1,56 @@
+patch_20250707_143204_da631a4e85683bd762066195d29616d97c577354.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit da631a4e85683bd762066195d29616d97c577354
+
+=====DIFFSUMMARY=====
+da631a4 Merge pull request #285 from buymeagoat/codex/modify-get_log_file-and-add-unit-test
+
+ api/routes/logs.py     | 12 ++++++++++--
+ tests/test_logs_api.py |  5 +++++
+ 2 files changed, 15 insertions(+), 2 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T14:32:04Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+da631a4e85683bd762066195d29616d97c577354
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153130_f04134083ba6f84f99c0cc4df9136b8475bec5d1.log
+++ b/docs/patch_logs/patch_20250707_153130_f04134083ba6f84f99c0cc4df9136b8475bec5d1.log
@@ -1,0 +1,56 @@
+patch_20250707_153130_f04134083ba6f84f99c0cc4df9136b8475bec5d1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f04134083ba6f84f99c0cc4df9136b8475bec5d1
+
+=====DIFFSUMMARY=====
+f041340 Remove obsolete config module
+ README.md            |  2 --
+ api/config.py        | 51 ---------------------------------------------------
+ docs/design_scope.md |  4 +---
+ 3 files changed, 1 insertion(+), 56 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:31:30Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f04134083ba6f84f99c0cc4df9136b8475bec5d1
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153150_3d59b726c3c3493dffff0a2dfdbaceded19a00c2.log
+++ b/docs/patch_logs/patch_20250707_153150_3d59b726c3c3493dffff0a2dfdbaceded19a00c2.log
@@ -1,0 +1,54 @@
+patch_20250707_153150_3d59b726c3c3493dffff0a2dfdbaceded19a00c2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 3d59b726c3c3493dffff0a2dfdbaceded19a00c2
+
+=====DIFFSUMMARY=====
+3d59b72 Add auth checks for log endpoints
+ tests/test_logs_api.py | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T15:31:50Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+3d59b726c3c3493dffff0a2dfdbaceded19a00c2
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153219_e58e6f51ad98258b55aea135278768d934ee9ff0.log
+++ b/docs/patch_logs/patch_20250707_153219_e58e6f51ad98258b55aea135278768d934ee9ff0.log
@@ -1,0 +1,55 @@
+patch_20250707_153219_e58e6f51ad98258b55aea135278768d934ee9ff0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e58e6f51ad98258b55aea135278768d934ee9ff0
+
+=====DIFFSUMMARY=====
+e58e6f5 Merge pull request #287 from buymeagoat/codex/extend-tests-for-log-api-and-format
+
+ tests/test_logs_api.py | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T15:32:19Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e58e6f51ad98258b55aea135278768d934ee9ff0
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153300_62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0.log
+++ b/docs/patch_logs/patch_20250707_153300_62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0.log
@@ -1,0 +1,57 @@
+patch_20250707_153300_62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0
+
+=====DIFFSUMMARY=====
+62b8fb0 Merge pull request #286 from buymeagoat/codex/remove-config.py-and-update-documentation
+
+ README.md            |  2 --
+ api/config.py        | 51 ---------------------------------------------------
+ docs/design_scope.md |  4 +---
+ 3 files changed, 1 insertion(+), 56 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:33:00Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153535_b81484a3f7c7663fa80db5d2058e72f1ce33f49a.log
+++ b/docs/patch_logs/patch_20250707_153535_b81484a3f7c7663fa80db5d2058e72f1ce33f49a.log
@@ -1,0 +1,54 @@
+patch_20250707_153535_b81484a3f7c7663fa80db5d2058e72f1ce33f49a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit b81484a3f7c7663fa80db5d2058e72f1ce33f49a
+
+=====DIFFSUMMARY=====
+b81484a docs: remove obsolete audit_environment reference
+ docs/design_scope.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:35:35Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+b81484a3f7c7663fa80db5d2058e72f1ce33f49a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153551_f856038bd29323319d3387c7dac79603bbe30266.log
+++ b/docs/patch_logs/patch_20250707_153551_f856038bd29323319d3387c7dac79603bbe30266.log
@@ -1,0 +1,55 @@
+patch_20250707_153551_f856038bd29323319d3387c7dac79603bbe30266.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f856038bd29323319d3387c7dac79603bbe30266
+
+=====DIFFSUMMARY=====
+f856038 Merge pull request #288 from buymeagoat/codex/remove-references-to-audit_environment.py
+
+ docs/design_scope.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:35:51Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f856038bd29323319d3387c7dac79603bbe30266
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153846_e60dedcc4875d5059740a2bd127572231aa7782e.log
+++ b/docs/patch_logs/patch_20250707_153846_e60dedcc4875d5059740a2bd127572231aa7782e.log
@@ -1,0 +1,54 @@
+patch_20250707_153846_e60dedcc4875d5059740a2bd127572231aa7782e.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e60dedcc4875d5059740a2bd127572231aa7782e
+
+=====DIFFSUMMARY=====
+e60dedc Add worker dependency and faster health check
+ docker-compose.yml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:38:46Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e60dedcc4875d5059740a2bd127572231aa7782e
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_153907_f81e90e810844a08534ce3d45cce3b743808c884.log
+++ b/docs/patch_logs/patch_20250707_153907_f81e90e810844a08534ce3d45cce3b743808c884.log
@@ -1,0 +1,55 @@
+patch_20250707_153907_f81e90e810844a08534ce3d45cce3b743808c884.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit f81e90e810844a08534ce3d45cce3b743808c884
+
+=====DIFFSUMMARY=====
+f81e90e Merge pull request #289 from buymeagoat/codex/update-docker-compose.yml-with-worker-dependency
+
+ docker-compose.yml | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:39:07Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+f81e90e810844a08534ce3d45cce3b743808c884
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_154157_e4cb303343df2ac3e519c48628be59c44094d466.log
+++ b/docs/patch_logs/patch_20250707_154157_e4cb303343df2ac3e519c48628be59c44094d466.log
@@ -1,0 +1,55 @@
+patch_20250707_154157_e4cb303343df2ac3e519c48628be59c44094d466.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit e4cb303343df2ac3e519c48628be59c44094d466
+
+=====DIFFSUMMARY=====
+e4cb303 Add restart policy for compose services
+ README.md          | 3 +++
+ docker-compose.yml | 2 ++
+ 2 files changed, 5 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T15:41:57Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+e4cb303343df2ac3e519c48628be59c44094d466
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_154219_520ebe3f5a58de0c21f247afa6400c8e1b37b553.log
+++ b/docs/patch_logs/patch_20250707_154219_520ebe3f5a58de0c21f247afa6400c8e1b37b553.log
@@ -1,0 +1,56 @@
+patch_20250707_154219_520ebe3f5a58de0c21f247afa6400c8e1b37b553.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 520ebe3f5a58de0c21f247afa6400c8e1b37b553
+
+=====DIFFSUMMARY=====
+520ebe3 Merge pull request #290 from buymeagoat/codex/add-restart-policy-to-docker-services
+
+ README.md          | 3 +++
+ docker-compose.yml | 2 ++
+ 2 files changed, 5 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T15:42:19Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+520ebe3f5a58de0c21f247afa6400c8e1b37b553
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_154559_a966db91f016c261cede601deea7ebbf253c61d2.log
+++ b/docs/patch_logs/patch_20250707_154559_a966db91f016c261cede601deea7ebbf253c61d2.log
@@ -1,0 +1,55 @@
+patch_20250707_154559_a966db91f016c261cede601deea7ebbf253c61d2.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit a966db91f016c261cede601deea7ebbf253c61d2
+
+=====DIFFSUMMARY=====
+a966db9 Make celery connection check loop until success
+ api/app_state.py             | 14 ++++++++------
+ tests/test_celery_startup.py | 29 +++++++++++++++++++++++++++++
+ 2 files changed, 37 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:45:59Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+a966db91f016c261cede601deea7ebbf253c61d2
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_154719_8c595a21f7bff847f083e3e66fd2d1424f42d41a.log
+++ b/docs/patch_logs/patch_20250707_154719_8c595a21f7bff847f083e3e66fd2d1424f42d41a.log
@@ -1,0 +1,56 @@
+patch_20250707_154719_8c595a21f7bff847f083e3e66fd2d1424f42d41a.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 8c595a21f7bff847f083e3e66fd2d1424f42d41a
+
+=====DIFFSUMMARY=====
+8c595a2 Merge pull request #291 from buymeagoat/codex/update-celery-connection-handling
+
+ api/app_state.py             | 14 ++++++++------
+ tests/test_celery_startup.py | 29 +++++++++++++++++++++++++++++
+ 2 files changed, 37 insertions(+), 6 deletions(-)
+
+=====TIMESTAMP=====
+2025-07-07T15:47:19Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+8c595a21f7bff847f083e3e66fd2d1424f42d41a
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_155827_26df4a0bd9b739076606a0df38868201427531c7.log
+++ b/docs/patch_logs/patch_20250707_155827_26df4a0bd9b739076606a0df38868201427531c7.log
@@ -1,0 +1,54 @@
+patch_20250707_155827_26df4a0bd9b739076606a0df38868201427531c7.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit 26df4a0bd9b739076606a0df38868201427531c7
+
+=====DIFFSUMMARY=====
+26df4a0 Add test script to rebuild images and run tests
+ scripts/run_tests.sh | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T15:58:27Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+26df4a0bd9b739076606a0df38868201427531c7
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250707_165230_db9b76ccce1242fa62fa304019c4f1c9801ccff1.log
+++ b/docs/patch_logs/patch_20250707_165230_db9b76ccce1242fa62fa304019c4f1c9801ccff1.log
@@ -1,0 +1,55 @@
+patch_20250707_165230_db9b76ccce1242fa62fa304019c4f1c9801ccff1.log
+=====TASK=====
+Backfill legacy patch log
+
+=====OBJECTIVE=====
+Reconstruct patch metadata for auditing.
+
+=====CONSTRAINTS=====
+- No repository changes
+- Use commit history only
+
+=====SCOPE=====
+Commit db9b76ccce1242fa62fa304019c4f1c9801ccff1
+
+=====DIFFSUMMARY=====
+db9b76c Merge pull request #292 from buymeagoat/codex/create-script-to-test-application-after-code-update
+
+ scripts/run_tests.sh | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+=====TIMESTAMP=====
+2025-07-07T16:52:30Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+db9b76ccce1242fa62fa304019c4f1c9801ccff1
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true}
+
+=====DECISIONS=====
+- Legacy patch log generated from commit history.

--- a/docs/patch_logs/patch_20250801_223543_847305d.log
+++ b/docs/patch_logs/patch_20250801_223543_847305d.log
@@ -1,0 +1,163 @@
+patch_20250801_223543_847305d.log
+=====TASK=====
+generate_legacy_patch_logs
+
+=====OBJECTIVE=====
+Back-fill missing patch logs using commit history.
+
+=====CONSTRAINTS=====
+- AtomicPatch: create ≤100 new logs in this batch; abort on error.
+- Filename pattern: patch_<UTC YYYYMMDD>_<HHMMSS>_<commit_hash>.log
+- Required fields: TASK, OBJECTIVE, CONSTRAINTS, SCOPE, DIFFSUMMARY (git show --stat),
+                    snapshot_metadata=LEGACY-N/A,
+                    agent_metadata=LEGACY-N/A,
+                    test_results=LEGACY-N/A,
+                    diagnostic block noting legacy status,
+                    SPEC_HASHES (current CAG & agents.md).
+- Skip commits already covered by docs/patch_logs/*.log
+- Preserve existing logs; no edits.
+
+=====SCOPE=====
+commits 95fb51e6c2a2dc26dd609c2b3846d65341448264..db9b76ccce1242fa62fa304019c4f1c9801ccff1
+/docs/patch_logs/
+
+=====DIFFSUMMARY=====
+847305d docs: add legacy patch logs for early July commits
+ ...01_79a2a5da6e4ad58e1238b3ed6a90b74e058e7cea.log | 54 ++++++++++++++++++
+ ...44_f25eb0935d1a82416e20db773c835ddbc4c78d39.log | 55 ++++++++++++++++++
+ ...15_2ace52a3513ed80be80e88a464b16a23a435ec08.log | 54 ++++++++++++++++++
+ ...54_88fbf7338161646b3a961b041938b179852364cc.log | 55 ++++++++++++++++++
+ ...42_36abd17a6c470133e853dedd3343da5bc1e2f9fb.log | 54 ++++++++++++++++++
+ ...51_fe9f8bc4773214f7701a5a95524d707858a5589c.log | 55 ++++++++++++++++++
+ ...39_cf4834f58ae0392e9443a648e3e5c3f8851694f3.log | 55 ++++++++++++++++++
+ ...12_4ace0e99431cfe833baefd6d4a834ae1602e8fc1.log | 56 ++++++++++++++++++
+ ...29_874c36d2a78abce0536f830b4cf97a809d9987eb.log | 55 ++++++++++++++++++
+ ...36_3f998a8add1fd72a397b566e59d4284c065bb621.log | 56 ++++++++++++++++++
+ ...40_a9bc6ae043af6dae6cfaf7010733c114d298d416.log | 54 ++++++++++++++++++
+ ...51_449e2f0faa06e3684bbb3d9f80a8ef592b843dc8.log | 55 ++++++++++++++++++
+ ...16_f3e3d7ef62e3206f4caffe1bbacf889aa554c49c.log | 64 +++++++++++++++++++++
+ ...02_d066b20000bc57a82f519885ab090c1c724d9353.log | 52 +++++++++++++++++
+ ...10_8d7f2bbbe9b09d8b884bebd384f9afd2bfe9fc80.log | 65 +++++++++++++++++++++
+ ...59_0f3040d56babd2315f32c7dd6e212bdf60781781.log | 55 ++++++++++++++++++
+ ...10_b217b48b53b80eeb4c3cfb63c0ad5b727a6fd801.log | 56 ++++++++++++++++++
+ ...41_9ff36b04dc68a2c1e28260b2f3ccae5fa6c136a5.log | 55 ++++++++++++++++++
+ ...52_2f7e1ac0525a12490d696ba372e1264bf6382258.log | 56 ++++++++++++++++++
+ ...15_ac66504ac354dc7b87b45c683d25218778e6095d.log | 55 ++++++++++++++++++
+ ...31_7d5ff0cde65083fbce88df20f03bc9e627e9fb2a.log | 56 ++++++++++++++++++
+ ...53_ec297c519ebe1a9acf2fc3fe27aa4215c9cbae71.log | 55 ++++++++++++++++++
+ ...02_9eab2e4490d15789a3bcd86695da9be5ca979051.log | 56 ++++++++++++++++++
+ ...01_21ac0c09ae74d89b569c43fcc59ed65589dc223f.log | 55 ++++++++++++++++++
+ ...20_c95e3ccf7aa43c052904a95f95a35ce3bd258c0e.log | 56 ++++++++++++++++++
+ ...17_d72d7d8f8d5aa55663e45fd0a67b12817517a029.log | 59 +++++++++++++++++++
+ ...32_d2d70fc4cae0559b55145bde6e7fd57829176285.log | 60 ++++++++++++++++++++
+ ...47_5c16801ba9f9d204088ecd712300fd4d52675961.log | 56 ++++++++++++++++++
+ ...59_33fedd7812a8b608f60a61667c3681a942acb0b7.log | 57 +++++++++++++++++++
+ ...45_0ca25f26e587ae54558d3d2fc3af0ba20b01a0d7.log | 55 ++++++++++++++++++
+ ...29_cbc5c79ba7c42df5407ac37835ec69d06d9c2fe2.log | 56 ++++++++++++++++++
+ ...02_eeb781628b87223d8f1c522d2fd9f30a5c55a4be.log | 55 ++++++++++++++++++
+ ...14_3f2fe453fbc72a794219dab91605dac37b69eac1.log | 56 ++++++++++++++++++
+ ...26_a57a7447e9d77a4d4c3ab40a78c1cfbf33755c7a.log | 55 ++++++++++++++++++
+ ...38_5bcc1bf221996868cbc679a3308680761b244de6.log | 56 ++++++++++++++++++
+ ...58_b26b1aaccb576411b24b7dc3f74608c41f3e41da.log | 56 ++++++++++++++++++
+ ...11_893f66d9386eb15279d5f5b2851c1e3da407da73.log | 57 +++++++++++++++++++
+ ...27_c8e49aee3a2865b6b448d677ed44636cf5e471f0.log | 54 ++++++++++++++++++
+ ...40_e5563e9d9f4db7f0b67588e99f56401418d31cc0.log | 55 ++++++++++++++++++
+ ...10_4ef7d891facc558563e6a1634da2159545ed5e74.log | 58 +++++++++++++++++++
+ ...52_9a1a06e6eb11b2dc58f1911f35e4f77af6630c09.log | 59 +++++++++++++++++++
+ ...37_149303364b2b7ea83622ee7d18bd6df99e81c5ca.log | 54 ++++++++++++++++++
+ ...49_a5e25bf229c88f2b3cee8ad44956e4ea49b530d2.log | 55 ++++++++++++++++++
+ ...37_a7cd894b057e615545ecc5049fd1d6313182c61b.log | 57 +++++++++++++++++++
+ ...49_481894970bce6d73ff99b225a70e1edea5955a6a.log | 58 +++++++++++++++++++
+ ...49_c194a6705db39646b071fed4df8f9551fce5de14.log | 57 +++++++++++++++++++
+ ...06_a012ae104b2bf069d36bd3ab53354f52c38bb327.log | 58 +++++++++++++++++++
+ ...23_55daa70bb2eacbcf361e3f7e7e9f400ce2c3486f.log | 65 +++++++++++++++++++++
+ ...36_618076803267534abcf6a07f8d42301aa486c939.log | 66 ++++++++++++++++++++++
+ ...47_8ee08b0650856a36959c19bb572c60adaff98159.log | 54 ++++++++++++++++++
+ ...01_9367bce7fcef970e9002a4a4609a6f8141018d65.log | 55 ++++++++++++++++++
+ ...47_14d5a81ead54843840d9f7d35be61fd5c907134c.log | 54 ++++++++++++++++++
+ ...57_7612f242ab0171a0cecb33854958fce9b6d68e72.log | 55 ++++++++++++++++++
+ ...40_9ac556a26dc3bd6f27cd38f86384cb94b4244cc3.log | 54 ++++++++++++++++++
+ ...59_fe80645ce4f2e95b49aa21a3d3bd84f35baaf609.log | 55 ++++++++++++++++++
+ ...38_5f4e2464efc4e34b7827dd0525ecc0e6bddecb78.log | 54 ++++++++++++++++++
+ ...33_571052c487c7825f9af3104be85504096b7d5c2f.log | 55 ++++++++++++++++++
+ ...34_1ec75ab5aff7d8cbed90f5cb26faee91699a0c19.log | 54 ++++++++++++++++++
+ ...54_f0d9e0fc151dea920f2b737815dc1ddb3125ba34.log | 55 ++++++++++++++++++
+ ...46_05d9347f2ef8a70898319bcbbfd7bb30b086caf8.log | 54 ++++++++++++++++++
+ ...01_fa016f0fc7c33a4b9f5452b62ef052ec9e7496d0.log | 55 ++++++++++++++++++
+ ...10_a3e96a6129ab2a7c88d5290d8fba5f2553a3c5e5.log | 54 ++++++++++++++++++
+ ...23_23bb9ae90d8b7627bd8ee638b70c1924c4c6477d.log | 55 ++++++++++++++++++
+ ...44_f1e9413093b2694fca4f2ce15e195a88bccd79fe.log | 54 ++++++++++++++++++
+ ...24_32961028ac5863f4fe12fde622201e3aae296e29.log | 55 ++++++++++++++++++
+ ...05_20bb6a949e057d8543b2b2e9b24a5ae7207ec3a7.log | 55 ++++++++++++++++++
+ ...40_e941e22d65a40df92408f3fa14a1a6ec250eff9c.log | 56 ++++++++++++++++++
+ ...26_3292be6720066c4a81a9f3a2a2d00fe25be981d2.log | 54 ++++++++++++++++++
+ ...28_a2a247d57a94ce3ac0047baafcb378a50ddd4b9b.log | 55 ++++++++++++++++++
+ ...26_482e890d80a6b1a57114fd924e64018cf1e5ec00.log | 54 ++++++++++++++++++
+ ...52_d1aa9eb86464dd2192cb3da32de7425471b7f25d.log | 55 ++++++++++++++++++
+ ...58_0aceffcb45ff61d0c57574e5e1ff654f7fb98dfb.log | 55 ++++++++++++++++++
+ ...58_8439bc035b881930562d76aa32b62218d3657172.log | 56 ++++++++++++++++++
+ ...54_83bd8fbb7873b53925e4c915cf76a65dc1945397.log | 54 ++++++++++++++++++
+ ...49_a644061123807400dfc6b64367bb164935fdf957.log | 55 ++++++++++++++++++
+ ...35_0b64177c8952266b0e166fc27a5fe67e0d78525b.log | 54 ++++++++++++++++++
+ ...55_d9d8a0b0b39ab8d0f941834f3bfd150ba9f9b3fe.log | 55 ++++++++++++++++++
+ ...34_31495d503a98ff1637c5704e86aae81d5fa28834.log | 56 ++++++++++++++++++
+ ...46_6e82ce4ea410cc2a5d550b57654589685856fc3a.log | 57 +++++++++++++++++++
+ ...25_f39df4bf9c5e80976fce7b3a5629ee62d0029042.log | 54 ++++++++++++++++++
+ ...45_71a70ca571d86b11e586922684f1f67a914ac2c8.log | 55 ++++++++++++++++++
+ ...32_ed06be727d0993982bd516a36647a03b5186b4a8.log | 56 ++++++++++++++++++
+ ...13_96c699962d31fcb1a581fe466ba17ad9f3014d63.log | 57 +++++++++++++++++++
+ ...34_e111abeaef37daa2a7d8cd3ab3e6073b1f7b950e.log | 55 ++++++++++++++++++
+ ...04_da631a4e85683bd762066195d29616d97c577354.log | 56 ++++++++++++++++++
+ ...30_f04134083ba6f84f99c0cc4df9136b8475bec5d1.log | 56 ++++++++++++++++++
+ ...50_3d59b726c3c3493dffff0a2dfdbaceded19a00c2.log | 54 ++++++++++++++++++
+ ...19_e58e6f51ad98258b55aea135278768d934ee9ff0.log | 55 ++++++++++++++++++
+ ...00_62b8fb09804b474ff1aa3fed8da9bfa144b2f8e0.log | 57 +++++++++++++++++++
+ ...35_b81484a3f7c7663fa80db5d2058e72f1ce33f49a.log | 54 ++++++++++++++++++
+ ...51_f856038bd29323319d3387c7dac79603bbe30266.log | 55 ++++++++++++++++++
+ ...46_e60dedcc4875d5059740a2bd127572231aa7782e.log | 54 ++++++++++++++++++
+ ...07_f81e90e810844a08534ce3d45cce3b743808c884.log | 55 ++++++++++++++++++
+ ...57_e4cb303343df2ac3e519c48628be59c44094d466.log | 55 ++++++++++++++++++
+ ...19_520ebe3f5a58de0c21f247afa6400c8e1b37b553.log | 56 ++++++++++++++++++
+ ...59_a966db91f016c261cede601deea7ebbf253c61d2.log | 55 ++++++++++++++++++
+ ...19_8c595a21f7bff847f083e3e66fd2d1424f42d41a.log | 56 ++++++++++++++++++
+ ...27_26df4a0bd9b739076606a0df38868201427531c7.log | 54 ++++++++++++++++++
+ ...30_db9b76ccce1242fa62fa304019c4f1c9801ccff1.log | 55 ++++++++++++++++++
+ scripts/generate_legacy_logs.py                    |  8 +--
+ 100 files changed, 5519 insertions(+), 4 deletions(-)
+
+=====TIMESTAMP=====
+2025-08-01T22:35:43Z
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250801 200929
+
+=====PROMPTID=====
+legacy-backfill-batch-006
+
+=====AGENTVERSION=====
+LEGACY-N/A
+
+=====AGENTHASH=====
+LEGACY-N/A
+
+=====PROMPTHASH=====
+LEGACY-N/A
+
+=====COMMITHASH=====
+847305d
+
+=====SPEC_HASHES=====
+10ba62ac16c28028ead0d8892258ab67b59de208559b0027d4835794228c3167
+
+=====SNAPSHOT=====
+LEGACY-N/A
+
+=====TESTRESULTS=====
+LEGACY-N/A
+
+=====DIAGNOSTICMETA=====
+{"legacy_backfill": true, "prompt_type": "Code"}
+
+=====DECISIONS=====
+- Added 99 historical patch logs generated via script.
+- Recorded commit hash and spec hash for traceability.

--- a/scripts/generate_legacy_logs.py
+++ b/scripts/generate_legacy_logs.py
@@ -1,6 +1,6 @@
 import subprocess, datetime, pathlib, json
-start='6a46418e06efd889fcddf47885258f0402620dba'
-end='ca9481f1db68fb1aef3316ab8d9a687309b40c40'
+start='95fb51e6c2a2dc26dd609c2b3846d65341448264'
+end='db9b76ccce1242fa62fa304019c4f1c9801ccff1'
 logdir=pathlib.Path('docs/patch_logs')
 spec_hash=subprocess.check_output(['scripts/hash_utils.sh','cag_agents_hash','AGENTS.md']).decode().strip()
 commits=subprocess.check_output(['git','rev-list','--reverse',f'{start}..{end}']).decode().split()
@@ -34,10 +34,10 @@ Commit {h}
 {dt.strftime('%Y-%m-%dT%H:%M:%SZ')}
 
 =====BUILDER_DATE_TIME (UTC)=====
-20250801 194741
+20250801 200929
 
 =====PROMPTID=====
-legacy-backfill-batch-002
+legacy-backfill-batch-006
 
 =====AGENTVERSION=====
 LEGACY-N/A


### PR DESCRIPTION
## Summary
- generate legacy patch logs for commit range 95fb51e6..db9b76cc
- log batch generation details for the backfill
- fix diffsummary insertion in latest batch log

## Testing
- `python3 scripts/CPG_repo_audit.py`
- `bash scripts/run_tests.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688d3e6a6fd0832586ce594145c2cfdf