### PR TITLE
docs: update operating blueprint and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,9 @@ Thumbs.db
 uploads/
 transcripts/
 logs/
+/docs/patch_logs/
+/docs/audit/
+/docs/telemetry/
 
 # frontend
 frontend/node_modules/

--- a/docs/patch_logs/patch_20250819_165759_c0af2c4.log
+++ b/docs/patch_logs/patch_20250819_165759_c0af2c4.log
@@ -1,0 +1,29 @@
+TASK: Apply governance updates to blueprint and dockerignore
+OBJECTIVE: Rename blueprint doc, clarify roles, retention, session policy, and adjust container exclusions.
+CONSTRAINTS: Preserve Blueprint-Version v1.3; no branch changes; run tests.
+SCOPE: {edit: ["docs/OPERATING_BLUEPRINT.md", ".dockerignore"]}
+DIFFSUMMARY: renamed blueprint file, added governance rules, updated dockerignore exclusions.
+TS: 20250819_165759Z
+prompt_id: apply_blueprint_updates_operating_blueprint_YYYYMMDD_HHMMSS
+AV: unknown
+AH: unknown
+CH: c0af2c4e533667c89c1f67afc3d9e770a1690d52
+BDT: 20250819 165759
+snapshot_metadata: snapshots/snapshot_20250819T165305Z.json f32df94691d157833bb7a391001a5c91ce8a3bac58684498a1a0df67a5530cb1
+agent_metadata: session_id=unknown
+test_results: failed - docker: command not found
+DIAGMETA: {attempted_action_summary: update blueprint and dockerignore, instruction_interpretation: apply governance updates, successes: docs updated, failures: tests failed (no docker), skipped_steps: none, missing_inputs: docker, ambiguities_detected: none, resource_or_environment_gaps: docker missing, suggestions_to_builder: install docker}
+SPEC_HASHES: {blueprint: 0fabc5e751d244e975572905017d1f330aca3a4cf0d91fc4ba3505cd6d7a2ff5, cag: 3b90b3b7e9868ded569220b3bf8e1b39583aa52471a8e359ed27b0348cac37a2, codex: 2445111f1cec15aa23525acaca8b80ccc57fa2809cf6deaa9f6ac51cb23ddd44}
+decisions/deviations: tests skipped due to missing docker
+```json
+{
+  "loc_delta": {"added": 66, "deleted": 8},
+  "files_changed": {"code": 0, "tests": 0, "docs": 1, "other": 1},
+  "coverage_delta": "unknown",
+  "risk_level": "low",
+  "lane": "fast",
+  "drift_detected": false,
+  "halt_events": 0,
+  "decision_path": ["code"]
+}
+```


### PR DESCRIPTION
## Summary
- rename and augment blueprint governance as OPERATING_BLUEPRINT
- clarify role boundaries, session handshake, and retention policies
- exclude docs logs from Docker builds

## Testing
- `scripts/run_tests.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4839c588325b87c64551082d1c0