### PR TITLE
docs: clarify densified CAG instruction rules

### DIFF
--- a/docs/OPERATING_BLUEPRINT.md
+++ b/docs/OPERATING_BLUEPRINT.md
@@ -42,6 +42,9 @@ Harden the collaboration model between C (CAG) and X (Codex) using GPT-5 Thinkin
 Every major rule or gate MUST include a `> Rationale:` line explaining its intent.
 > Rationale: ensures governance decisions remain transparent and auditable.
 
+- Rationale lines are **not required** in the densified CAG instruction file (`/docs/CAG_spec.md`).
+> Rationale: The densified version is derived from the rationale-backed human-readable form.
+
 # Current Canon
 
 * BuilderContract: ExplicitBuilderIntentForActions; NoCAGActionWithoutB; BRelaysXResponses; NoHiddenStateBetweenSessions; COnlySourcesViaX; BConfirmsIntentBeforeExecutionPrompt.
@@ -101,6 +104,9 @@ To ensure CAG, Codex, and Builder/Architect operate on the same authoritative in
   - `Bundle-UTC`
   - `Blueprint-Version: 2`
 > Rationale: single bundle header replaces per-file hash equality.
+
+- The densified CAG instructions (`/docs/CAG_spec.md`) must embed the bundle header at the **top of the file**, not inline.
+> Rationale: Ensures identity metadata is preserved in CAG's instruction window context.
 
 ## Audit Demand (Recovery Protocol)
 - Trigger: mirror inequality or mismatched `Bundle-ID`/`Bundle-UTC` values.
@@ -558,7 +564,9 @@ Source-of-Truth: OPERATING_BLUEPRINT.md
 **Generated Artifacts**
 - `/docs/CAG_instructions_master.md` — human-readable draft of CAG’s Instructions.
 - `/AGENTS.md` — human-readable Codex-side instructions.
-- Both include the Bundle header from this Blueprint.
+- `/docs/CAG_spec.md` — densified version of CAG instructions (Codex-visible).
+- All include the Bundle header from this Blueprint.
+> Rationale: Aligns file references with actual artifact roles.
 
 **How “green” is determined (Model G2)**
 - Mirrors byte-equal within each pair.
@@ -573,8 +581,12 @@ Source-of-Truth: OPERATING_BLUEPRINT.md
 4) CI validates Model G2 (bundle headers + mirror byte-equality).
 
 **Edits flow only from the Blueprint**
-- Any change to CAG’s instructions or AGENTS.md must originate from a Blueprint change (which increments Bundle-ID).
+- Any change to CAG’s instructions or AGENTS.md must originate from a Blueprint change,
+  or from Architect-led densification of Codex-generated CAG instructions,
+  provided the source text originates from a Blueprint-approved generation prompt.
+> Rationale: Supports compression of system-governed logic into CAG’s instruction window.
 - Direct edits to `/AGENTS.md`, `/docs/CAG_spec.md`, or `/docs/AGENTS_mirror.md` are prohibited; regenerate instead.
+> Rationale: centralizes governance and prevents uncoordinated instruction drift.
 
 **CI additions**
 - Verify `/AGENTS.md` and `/docs/CAG_instructions_master.md` carry the Bundle header.

--- a/docs/patch_logs/patch_20250819_210816_blueprint.log
+++ b/docs/patch_logs/patch_20250819_210816_blueprint.log
@@ -1,0 +1,29 @@
+Task: Update operating blueprint to reflect revised CAG instruction densification behavior.
+Objective: Codify that rationale lines are not required in the densified CAG instructions and require bundle headers at file top; update generation pipeline for Architect-led densification.
+Constraints: Preserve existing behavior and rule structure; do not alter roles, gates, or functional logic.
+Scope: {edit: /docs/OPERATING_BLUEPRINT.md, create_if_missing: false}
+Diff summary: docs/OPERATING_BLUEPRINT.md | 16 ++++++++++++++-- (1 file changed, 14 insertions(+), 2 deletions(-))
+Commit timestamp: 20250819_210816
+Builder UTC timestamp: 20250819_210816
+prompt_id: eff9cc7a-786a-4b07-9576-df83ebe4673a
+agent_version: 1
+agent_hash: 0000000
+prompt_hash: 0000000
+commit_hash: TBD
+spec_hashes: N/A
+snapshot: N/A
+test_results: 5 failed, 15 passed, 43 warnings, 41 errors in 3.65s
+bundle: {Bundle-ID:1, Bundle-UTC:20250819, Blueprint-Version:2}
+lane: Fast-Path
+risk: low
+decisions_or_deviations: tests failed due to missing dependencies.
+DIAGMETA:
+  attempted_action_summary: Updated Blueprint documentation.
+  instruction_interpretation: Clarified densification rules and rationale exceptions.
+  successes: Blueprint sections updated.
+  failures: Test suite errors.
+  skipped_steps: none
+  missing_inputs: api module for tests
+  ambiguities_detected: none
+  resource_or_environment_gaps: testing dependencies absent
+  suggestions_to_builder: provide environment with required modules


### PR DESCRIPTION
## Summary
- Document that densified CAG instructions omit rationale lines and require bundle headers at the top.
- Reference `/docs/CAG_spec.md` as the Codex-visible densified artifact and update generation pipeline rules.
- Allow Blueprint-approved, Architect-led densification as a valid source of CAG instruction changes.

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError and 5 failed, 41 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e5adfe908325b375b630f37f34fb