### PR TITLE
fix: assign frontend-only build mode

### DIFF
--- a/scripts/whisper_build.sh
+++ b/scripts/whisper_build.sh
@@ -260,12 +260,7 @@ while [[ $# -gt 0 ]]; do
                 echo "Conflicting switches detected. Only one build mode can be used at a time." >&2
                 exit 1
             fi
-                echo "[INFO] Ensuring pytest is installed from PyPI..."
-                pip install pytest --index-url https://pypi.org/simple
-                if ! pip install --no-index --find-links "$pip_cache" -r "$ROOT_DIR/requirements.txt"; then
-                    echo "[WARNING] Cached pip install failed. Retrying with online PyPI for missing packages..."
-                    pip install -r "$ROOT_DIR/requirements.txt"
-                fi
+            MODE="frontend_only"
             MODE_SET=true
             ;;
         --validate-only)


### PR DESCRIPTION
## Summary
- properly set frontend-only build mode
- drop stray pip install snippet referencing undefined variables

## Testing
- `bash -n scripts/whisper_build.sh`
- `shellcheck scripts/whisper_build.sh` *(warnings: SC1091, SC2181, SC2034, SC2046, SC2155, SC2086)*
- `scripts/run_tests.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89a2b8cac8325ac1646187a933cee