### PR TITLE
feat(build): add pip cache retry limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - `whisper_build.sh` now automatically populates pip and apt caches before npm cache and build steps.
+- `whisper_build.sh` tracks pip cache failures and exits with code 88 after configurable retries.
 
 ### Changed
 - Build process is more robust for offline and online builds.

--- a/scripts/copilot_agentic_loop.sh
+++ b/scripts/copilot_agentic_loop.sh
@@ -5,6 +5,8 @@
 set -e
 LOG_FILE="logs/agentic_build_loop.log"
 BUILD_SCRIPT="scripts/copilot_agentic_build.sh"
+# Exit code indicating persistent pip cache failures from whisper_build.sh
+PIP_RETRY_EXIT_CODE=88
 
 while true; do
     echo "[INFO] Agentic build loop starting new build attempt..." | tee -a "$LOG_FILE"
@@ -13,6 +15,9 @@ while true; do
     if [[ $BUILD_EXIT -eq 0 ]]; then
         echo "[SUCCESS] Build completed successfully. Exiting loop." | tee -a "$LOG_FILE"
         exit 0
+    elif [[ $BUILD_EXIT -eq $PIP_RETRY_EXIT_CODE ]]; then
+        echo "[ERROR] Max pip cache retries exceeded. Stopping loop." | tee -a "$LOG_FILE"
+        exit $PIP_RETRY_EXIT_CODE
     else
         echo "[FAIL] Build failed with exit code $BUILD_EXIT. Copilot will diagnose, patch, commit, and rerun." | tee -a "$LOG_FILE"
         # Copilot: Automated diagnosis, patch, commit, and rerun logic happens here


### PR DESCRIPTION
## Summary
- add retry counter and exit code for pip cache population in whisper_build.sh
- stop copilot agentic loop when pip cache retries exceeded
- document new exit code

## Testing
- `bash scripts/run_tests.sh --backend` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a71e86248325b3a2d694756322a5