### PR TITLE
docs: remove Codex workflow references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Build process is more robust for offline and online builds.
+- Removed Codex Analyst GPT workflow references from documentation.
 
 ### Fixed
 - Ensures all cache directories are updated before Docker build starts.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Self-hosted transcription service with a FastAPI backend and a React frontend. It wraps the OpenAI Whisper CLI so you can upload audio, monitor progress and retrieve transcripts.
 
-All Docker builds now use `scripts/whisper_build.sh`. Previous helper scripts were removed.<!-- # Codex: build entrypoint clarified -->
+All Docker builds now use `scripts/whisper_build.sh`. Previous helper scripts were removed.
 
 For a step-by-step setup guide, see [docs/help.md](docs/help.md).
 
@@ -452,10 +452,6 @@ docker compose restart
 
 If startup fails, rerun with `LOG_LEVEL=DEBUG` and `LOG_TO_STDOUT=true` to see
 the container logs in the console.
-
-## Codex Analyst GPT Workflow
-
-Repository introspection and patch creation are handled entirely by **Codex Analyst GPT (CAG)**. When contributors request changes, CAG retrieves file lists and contents through prompt-driven commands and returns the necessary diffs inside the conversation. Approved patches are applied automatically and the full diff is saved under `docs/patch_logs/` for reference. Manual ZIP uploads are no longer required—patch logs accumulate in that directory and serve as the canonical history.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- remove Codex comment in Docker build note
- drop Codex Analyst GPT workflow section
- note documentation update in changelog

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd2689ec8325811339ae6bba1483