### PR TITLE
chore: remove codex references

### DIFF
--- a/docs/scripts_reference.md
+++ b/docs/scripts_reference.md
@@ -45,5 +45,5 @@ Most build scripts rely on a common cache directory. By default `CACHE_DIR`
 is `/tmp/docker_cache`. When the host is WSL, the scripts automatically
 override this path to `/mnt/wsl/shared/docker_cache` and print a warning.
 Setting `CACHE_DIR` manually is ignored under WSL so the cache always resides
-in the shared location.<!-- # Codex-verified: CACHE_DIR documentation matches set_cache_dir -->
+in the shared location.
 

--- a/scripts/shared_checks.sh
+++ b/scripts/shared_checks.sh
@@ -4,12 +4,10 @@
 # Expect ROOT_DIR to be defined by the caller
 
 # Set CACHE_DIR appropriately depending on the host environment
-# Codex-verified: automatic override to shared path when running under WSL
 set_cache_dir() {
     CACHE_OVERRIDE_WARNING=0
     if grep -qi microsoft /proc/version; then
         if [ "${CACHE_DIR:-}" != "/mnt/wsl/shared/docker_cache" ]; then
-            echo "[WARNING] Detected WSL; overriding CACHE_DIR to /mnt/wsl/shared/docker_cache" >&2 # Codex:
             CACHE_DIR="/mnt/wsl/shared/docker_cache"
             CACHE_OVERRIDE_WARNING=1
         fi
@@ -26,9 +24,9 @@ set_cache_dir() {
 # CACHE_DIR is not set. In WSL this function returns the WSL path.
 default_cache_dir() {
     if grep -qi microsoft /proc/version; then
-        echo "${CACHE_DIR:-/mnt/wsl/shared/docker_cache}" # Codex:
+        echo "${CACHE_DIR:-/mnt/wsl/shared/docker_cache}"
     else
-        echo "${CACHE_DIR:-/tmp/docker_cache}" # Codex:
+        echo "${CACHE_DIR:-/tmp/docker_cache}"
     fi
 }
 


### PR DESCRIPTION
## Summary
- strip Codex-specific comments and logging from build scripts
- clean up docs referencing Codex cache note

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*
- `npm test` *(fails: Cannot find dependency 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a8bfded2248325866b60e1866b6598