### PR TITLE
docs: update patch uploader message for current workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 - Build process is more robust for offline and online builds.
-- Removed Codex Analyst GPT workflow references from documentation.
+- Removed outdated workflow references from documentation and UI.
 
 ### Fixed
 - Ensures all cache directories are updated before Docker build starts.

--- a/docs/patch_logs/patch_20250822_192953_patch_uploader_message.txt
+++ b/docs/patch_logs/patch_20250822_192953_patch_uploader_message.txt
@@ -1,0 +1,54 @@
+patch_20250822_192953_patch_uploader_message.log
+=====TASK=====
+Remove legacy references from patch uploader and documentation.
+
+=====OBJECTIVE=====
+Clarify patch log process and ensure messaging matches current workflow.
+
+=====CONSTRAINTS=====
+- Keep instructions accurate for the current Copilot-based workflow.
+
+=====SCOPE=====
+- frontend/src/components/PatchUploader.js
+- CHANGELOG.md
+
+=====DIFFSUMMARY=====
+- Reword patch uploader message to reference Copilot prompts.
+- Update changelog to note removal of outdated workflow references.
+
+=====TIMESTAMP=====
+20250822_192953 UTC
+
+=====BUILDER_DATE_TIME (UTC)=====
+20250822 192953
+
+=====PROMPTID=====
+N/A
+
+=====AGENTVERSION=====
+N/A
+
+=====AGENTHASH=====
+N/A
+
+=====PROMPTHASH=====
+N/A
+
+=====COMMITHASH=====
+5e5db3475c64ed3842a67f2089f0588d6f1901cd
+
+=====SPEC_HASHES=====
+N/A
+
+=====SNAPSHOT=====
+N/A
+
+=====TESTRESULTS=====
+frontend npm test: ReferenceError: expect is not defined
+pytest: ModuleNotFoundError: No module named 'api'
+
+=====DIAGNOSTICMETA=====
+{}
+
+=====DECISIONS=====
+- Removed obsolete workflow reference to keep documentation current.

--- a/frontend/src/components/PatchUploader.js
+++ b/frontend/src/components/PatchUploader.js
@@ -3,9 +3,9 @@ import React from "react";
 export default function PatchUploader() {
   return (
     <div style={{ marginTop: "1rem", color: "#a1a1aa" }}>
-      Patch logs are generated automatically from Codex Analyst GPT prompts and
-      saved under <code>docs/patch_logs/</code>. Manual ZIP uploads are no
-      longer needed.
+      Patch logs are generated automatically from Copilot prompts and saved
+      under <code>docs/patch_logs/</code>. Manual ZIP uploads are no longer
+      needed.
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- clarify patch uploader text to highlight automatic Copilot-generated logs
- drop outdated workflow references from the changelog
- record change in a new patch log entry

## Testing
- `npm test` *(fails: ReferenceError: expect is not defined)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4b5f72483258a8dcec1d212c403