### PR TITLE
Remove legacy patch uploader message

### DIFF
--- a/frontend/src/components/PatchUploader.js
+++ b/frontend/src/components/PatchUploader.js
@@ -3,9 +3,7 @@ import React from "react";
 export default function PatchUploader() {
   return (
     <div style={{ marginTop: "1rem", color: "#a1a1aa" }}>
-      Patch logs are generated automatically from Copilot prompts and saved
-      under <code>docs/patch_logs/</code>. Manual ZIP uploads are no longer
-      needed.
+      Manual patch uploads are unsupported.
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- drop Codex-specific patch uploader note in UI
- clarify manual patch uploads are unsupported

## Testing
- `npm test -- --globals`


------
https://chatgpt.com/codex/tasks/task_e_68a8c86d10108325bfa973855b9b591a