### PR TITLE
Require explicit admin credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ LOG_FORMAT=plain
 # Authentication
 # SECRET_KEY is used to sign JWTs. Must be 64 hex chars.
 SECRET_KEY=your_secret_value
+AUTH_USERNAME=your_admin_username
+AUTH_PASSWORD=your_admin_password
 ALLOW_REGISTRATION=true
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 CORS_ORIGINS=*

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ invoking `npm run build`.
   RabbitMQ to respond before exiting (defaults to `60`).
 - `API_HEALTH_TIMEOUT` – how many seconds to wait for the API container to
   become healthy (defaults to `300`).
-- `AUTH_USERNAME` and `AUTH_PASSWORD` – *(deprecated)* previous static credentials.
+- `AUTH_USERNAME` and `AUTH_PASSWORD` – credentials for the initial admin
+  account. Both variables must be set; the application creates this user on
+  startup if it does not already exist.
 - `ALLOW_REGISTRATION` – enable the `/register` endpoint (defaults to `true`).
  - `SECRET_KEY` – **required** secret used to sign JWT tokens. The application
    exits on startup when this variable is missing.
@@ -166,10 +168,11 @@ creates regular users. Set `ALLOW_REGISTRATION=false` in production to disable
 this endpoint. Obtain a token from `/token` using the same credentials. JWT
 payloads now include the user role so clients can inspect their privileges.
 
-The application ships with a built-in `admin` account using the password
-`admin`. Logging in with these credentials returns a token with
-`must_change_password=true`. Call `/change-password` with the new password and
-the token to update it before continuing.
+On first startup, the application creates an admin account using the
+`AUTH_USERNAME` and `AUTH_PASSWORD` environment variables. Logging in with
+these credentials returns a token with `must_change_password=true`. Call
+`/change-password` with the new password and the token to update it before
+continuing.
 
 ### User Management
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -21,8 +21,8 @@ class Settings(BaseSettings):
     db_connect_attempts: int = Field(10, env="DB_CONNECT_ATTEMPTS")
     broker_connect_attempts: int = Field(20, env="BROKER_CONNECT_ATTEMPTS")
     allow_registration: bool = Field(True, env="ALLOW_REGISTRATION")
-    auth_username: str = Field("admin", env="AUTH_USERNAME")
-    auth_password: str = Field("admin", env="AUTH_PASSWORD")
+    auth_username: str = Field(..., env="AUTH_USERNAME")
+    auth_password: str = Field(..., env="AUTH_PASSWORD")
     secret_key: str = Field(..., env="SECRET_KEY")
     access_token_expire_minutes: int = Field(60, env="ACCESS_TOKEN_EXPIRE_MINUTES")
     max_concurrent_jobs: int = Field(2, env="MAX_CONCURRENT_JOBS")
@@ -57,9 +57,7 @@ class Settings(BaseSettings):
     # Not configurable via environment
     algorithm: str = "HS256"
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 import logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import wave
 
 # Ensure required settings exist before importing the application
 os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("AUTH_USERNAME", "admin")
+os.environ.setdefault("AUTH_PASSWORD", "admin")
 
 import pytest
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- require AUTH_USERNAME and AUTH_PASSWORD environment variables for initial admin login
- replace Settings Config class with model_config
- document new admin credential setup and add placeholders in .env.example

## Testing
- `PYTHONPATH=. pytest -q` *(fails: Could not found /usr/lib/postgresql/16/bin/pg_ctl)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d38bc2408325913cf838fb25cd42